### PR TITLE
feat(installer): one-command Claude and Codex setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,13 +56,13 @@ Smart notifications for Claude Code with click-to-focus, git branch display, and
 
 ### Prerequisites
 
-- Claude Code
+- Claude Code and/or Codex CLI for the products you select
 - **Windows users:** Git Bash (included with [Git for Windows](https://git-scm.com/download/win))
 - **macOS/Linux users:** No additional software required
 
 ### Quick Install (Recommended)
 
-One command to install everything:
+One command to install or update the notifications plugin for Claude Code, Codex, or both. The interactive menu asks you to choose:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/777genius/claude-notifications-go/main/bin/bootstrap.sh | bash
@@ -70,7 +70,15 @@ curl -fsSL https://raw.githubusercontent.com/777genius/claude-notifications-go/m
 
 > Windows users: open Git Bash from the Start menu and run this command there. Do not run the `curl ... | bash` command from PowerShell or Windows Terminal if `bash` opens WSL, because that targets Linux paths and binaries instead of Windows.
 
-Then restart Claude Code and optionally run `/claude-notifications-go:settings` to configure sounds.
+For automation or terminals without a controlling TTY, choose explicitly:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/777genius/claude-notifications-go/main/bin/bootstrap.sh | bash -s -- --product codex
+```
+
+Use `claude`, `codex`, or `both`. All selected host CLIs must already be on `PATH`. Codex installation requires a published stable release v1.42.0 or newer; source and binaries use the same release tag. It respects `CODEX_HOME` and automatically registers hooks using `setup-codex`. Then start Codex, run `/hooks`, and review and trust the entries yourself. Installation does not grant trust.
+
+For Claude, restart Claude Code and optionally run `/claude-notifications-go:settings` to configure sounds.
 
 The binary is downloaded once and cached locally. You can re-run `/claude-notifications-go:settings` anytime to reconfigure.
 
@@ -145,17 +153,11 @@ The registration command is implemented in Go and does not require `jq`. You nee
 Codex-capable release (v1.42.0 or later) and its plugin bundle; an older binary cannot run
 `setup-codex`. The command is not automatically added to your `PATH` by the Claude plugin.
 
-For a Codex-only installation, download a bundle and its platform binary first. In a
-terminal with Git and Bash (Git Bash on Windows), run:
+Use the [one-command installer](#quick-install-recommended) and choose Codex or both.
+It downloads matching release source and binaries in temporary staging, registers the
+stable runtime copy, and removes staging automatically. Re-run it to update.
 
-```bash
-git clone --depth 1 https://github.com/777genius/claude-notifications-go.git
-cd claude-notifications-go
-CN_PRODUCT=codex bash bin/install.sh
-```
-
-This downloads the notification binary; it does not install Claude Code. Keep this source
-directory for updates. The Codex registration below installs a separate stable runtime copy.
+For manual registration, use a downloaded **matching release** bundle and binary:
 
 From an already downloaded plugin bundle, run the binary by its path:
 
@@ -183,16 +185,15 @@ yourself, `--codex-home` and `--plugin-root` override the paths.
 
 After updating the plugin, run the command again to refresh the installed copy. The registration
 itself does not change, so Codex does not ask you to trust the hooks again.
-For the Git checkout above, update with `git pull --ff-only`, run `CN_PRODUCT=codex bash bin/install.sh --force`,
-then repeat the appropriate `setup-codex` command. Existing Claude plugin users can update
-their source bundle using the usual Claude plugin update process before repeating setup.
+With the bootstrap installer, re-run the same one-liner and select Codex or both to
+install the latest supported stable release and refresh registration automatically.
 
 Claude Code installation and updates continue to use the [existing installation steps](#installation).
 Both products share settings at `~/.claude/claude-notifications-go/config.json`; installing
 Codex does not require installing Claude Code. Keep your existing settings file when updating.
 
 <details>
-<summary>Why a separate step is needed</summary>
+<summary>How registration works</summary>
 
 `setup-codex` registers user hooks explicitly, using a stable runtime directory independent
 of the plugin cache. This is the setup path covered by this project's installer tests.

--- a/bin/bootstrap.sh
+++ b/bin/bootstrap.sh
@@ -33,6 +33,9 @@ MARKETPLACE_PLUGIN_JSON="${MARKETPLACE_DIR}/.claude-plugin/plugin.json"
 
 # State
 PLUGIN_ROOT=""
+_BOOTSTRAP_STAGE=""
+PRODUCT=""
+BOOTSTRAP_TAG=""
 _BOOTSTRAP_TMP=""  # temp file path for trap (set -u safe)
 
 # ──────────────────────────────────────────────
@@ -86,7 +89,7 @@ abort_if_wsl_environment() {
 # ──────────────────────────────────────────────
 
 check_prerequisites() {
-    if ! command -v claude &>/dev/null; then
+    if [ "${PRODUCT:-claude}" != codex ] && ! command -v claude &>/dev/null; then
         echo -e "${RED}✗ claude CLI not found in PATH${NC}" >&2
         echo "" >&2
         echo -e "${YELLOW}Install Claude Code first:${NC}" >&2
@@ -94,7 +97,14 @@ check_prerequisites() {
         echo "" >&2
         exit 1
     fi
-    echo -e "${GREEN}✓${NC} claude CLI found"
+    if [ "${PRODUCT:-claude}" != claude ] && ! command -v codex &>/dev/null; then
+        echo "codex CLI not found in PATH; install Codex first." >&2
+        exit 1
+    fi
+    if [ "${PRODUCT:-claude}" != claude ] && ! command -v tar &>/dev/null; then
+        echo "tar is required for the Codex source bundle." >&2
+        exit 1
+    fi
 
     if ! command -v curl &>/dev/null && ! command -v wget &>/dev/null; then
         echo -e "${RED}✗ curl or wget required${NC}" >&2
@@ -842,7 +852,7 @@ download_binary() {
 
     # Download install.sh to a temp file, verify it's non-empty, then run
     # Set trap BEFORE mktemp to avoid race condition on Ctrl+C
-    trap 'rm -f "$_BOOTSTRAP_TMP" 2>/dev/null' EXIT INT TERM
+    install_cleanup_traps
     # Validate TMPDIR exists; fall back to /tmp if it doesn't
     local tmp_base="${TMPDIR:-/tmp}"
     if [ ! -d "$tmp_base" ]; then
@@ -866,7 +876,7 @@ download_binary() {
 
     # </dev/null prevents stdin conflicts when running via `curl | bash`
     local install_exit=0
-    INSTALL_TARGET_DIR="$target_dir" bash "$tmp_script" </dev/null || install_exit=$?
+    install_runtime claude "$tmp_script" "$target_dir" || install_exit=$?
 
     if [ $install_exit -ne 0 ]; then
         echo -e "${RED}✗ Binary installation failed (exit code: ${install_exit})${NC}" >&2
@@ -952,18 +962,168 @@ print_success() {
 
 # ──────────────────────────────────────────────
 
-main() {
-    print_header
-    abort_if_wsl_environment
-    check_prerequisites
-    detect_platform
+# Product selection must precede any filesystem or host CLI mutation.
+select_product() {
+    while [ "$#" -gt 0 ]; do
+        case "$1" in
+            --product)
+                [ "$#" -ge 2 ] && [ -z "$PRODUCT" ] || { echo "Use --product claude|codex|both once." >&2; return 1; }
+                PRODUCT="$2"; shift 2 ;;
+            --help|-h)
+                echo "Usage: bash bootstrap.sh [--product claude|codex|both]"
+                exit 0 ;;
+            *) echo "Unknown option: $1" >&2; return 1 ;;
+        esac
+    done
+    if [ -z "$PRODUCT" ]; then
+        if ! { exec 3<>/dev/tty; } 2>/dev/null; then
+            echo "No controlling TTY. Specify --product claude|codex|both." >&2
+            return 1
+        fi
+        printf 'Install notifications for: 1) Claude  2) Codex  3) Both\nChoice: ' >&3
+        local choice=""
+        IFS= read -r choice <&3 || true
+        exec 3>&-
+        case "$choice" in
+            1|claude) PRODUCT=claude ;;
+            2|codex) PRODUCT=codex ;;
+            3|both) PRODUCT=both ;;
+            *) echo "Invalid product choice; use claude, codex or both." >&2; return 1 ;;
+        esac
+    fi
+    case "$PRODUCT" in
+        claude|codex|both) ;;
+        *) echo "Invalid product: $PRODUCT; use claude, codex or both." >&2; return 1 ;;
+    esac
+}
+
+bootstrap_cleanup() {
+    [ -z "$_BOOTSTRAP_TMP" ] || rm -f "$_BOOTSTRAP_TMP"
+    [ -z "$_BOOTSTRAP_STAGE" ] || rm -rf "$_BOOTSTRAP_STAGE"
+    return 0
+}
+
+install_cleanup_traps() {
+    trap bootstrap_cleanup EXIT
+    trap 'exit 130' INT
+    trap 'exit 143' TERM
+}
+
+install_runtime() {
+    local product="$1" script="$2" target="$3"
+    CN_PRODUCT="$product" INSTALL_TARGET_DIR="$target" bash "$script" "${@:4}" </dev/null
+}
+
+fetch_bootstrap_file() {
+    if command -v curl >/dev/null 2>&1; then
+        curl -fsSL --connect-timeout 15 --max-time 120 "$1" -o "$2"
+    else
+        wget -q -T 120 "$1" -O "$2"
+    fi
+}
+
+resolve_bootstrap_release() {
+    BOOTSTRAP_TAG="${BOOTSTRAP_RELEASE_TAG:-}"
+    if [ -z "$BOOTSTRAP_TAG" ]; then
+        _BOOTSTRAP_TMP=$(mktemp "${TMPDIR:-/tmp}/bootstrap-release-XXXXXX") || return 1
+        fetch_bootstrap_file "${BOOTSTRAP_LATEST_RELEASE_API_URL:-https://api.github.com/repos/${REPO}/releases/latest}" "$_BOOTSTRAP_TMP" || return 1
+        BOOTSTRAP_TAG=$(grep -oE '"tag_name"[[:space:]]*:[[:space:]]*"[^"]+"' "$_BOOTSTRAP_TMP" | head -1 | sed -E 's/.*"([^"]+)".*/\1/') || return 1
+        rm -f "$_BOOTSTRAP_TMP"
+        _BOOTSTRAP_TMP=""
+    fi
+    # Reject prereleases, malformed tags and releases predating setup-codex.
+    printf '%s\n' "$BOOTSTRAP_TAG" | grep -Eq '^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$' || {
+        echo "Invalid stable release tag: $BOOTSTRAP_TAG" >&2; return 1;
+    }
+    local version="${BOOTSTRAP_TAG#v}" major minor component
+    for component in ${version//./ }; do
+        [ "${#component}" -le 9 ] || { echo "Release version component too large." >&2; return 1; }
+    done
+    major="${version%%.*}"; minor="${version#*.}"; minor="${minor%%.*}"
+    if [ "$major" -lt 1 ] || { [ "$major" -eq 1 ] && [ "$minor" -lt 42 ]; }; then
+        echo "Codex requires published release v1.42.0 or newer; found $BOOTSTRAP_TAG." >&2
+        return 1
+    fi
+}
+
+install_codex() {
+    local tag="$BOOTSTRAP_TAG" version="${BOOTSTRAP_TAG#v}"
+    local source_base="${BOOTSTRAP_SOURCE_BASE_URL:-https://github.com/${REPO}/archive/refs/tags}"
+    local release_base="${BOOTSTRAP_RELEASES_BASE_URL:-https://github.com/${REPO}/releases}"
+    _BOOTSTRAP_STAGE=$(mktemp -d "${TMPDIR:-/tmp}/bootstrap-codex-XXXXXX") || return 1
+    local bundle="$_BOOTSTRAP_STAGE/bundle"
+    mkdir "$bundle" || return 1
+    if [ -n "$PLUGIN_ROOT" ] && [ "$(get_manifest_version "$PLUGIN_ROOT/.claude-plugin/plugin.json")" = "$version" ]; then
+        # Work on a copy so failed Codex updates cannot damage the Claude install.
+        cp -R "$PLUGIN_ROOT/." "$bundle/" || return 1
+    else
+        [ "$PRODUCT" != both ] || echo "Claude bundle differs from $tag; downloading matching Codex source."
+        fetch_bootstrap_file "$source_base/$tag.tar.gz" "$_BOOTSTRAP_STAGE/source.tar.gz" || return 1
+        tar -xzf "$_BOOTSTRAP_STAGE/source.tar.gz" --strip-components=1 -C "$bundle" || return 1
+    fi
+    [ "$(get_manifest_version "$bundle/.claude-plugin/plugin.json")" = "$version" ] || {
+        echo "Source bundle must match Codex-capable release $tag (minimum v1.42.0)." >&2; return 1;
+    }
+    [ -f "$bundle/bin/install.sh" ] || return 1
+    RELEASE_URL="$release_base/download/$tag" \
+    CHECKSUMS_URL="$release_base/download/$tag/checksums.txt" \
+    MODERN_NOTIFIER_URL="$release_base/download/$tag/ClaudeNotifier.app.zip" \
+        install_runtime codex "$bundle/bin/install.sh" "$bundle/bin" --force || return 1
+    local binary="$bundle/bin/claude-notifications" arch
+    case "$(uname -s)" in
+        MINGW*|MSYS*|CYGWIN*)
+            case "$(uname -m)" in
+                x86_64|amd64) arch=amd64 ;;
+                aarch64|arm64) arch=arm64 ;;
+                *) echo "Unsupported Windows architecture" >&2; return 1 ;;
+            esac
+            binary="$bundle/bin/claude-notifications-windows-$arch.exe" ;;
+    esac
+    local actual
+    actual=$(CN_PRODUCT=codex "$binary" --version) || return 1
+    [ "$actual" = "claude-notifications v$version" ] || {
+        echo "Binary must match $tag and support setup-codex." >&2; return 1;
+    }
+    CN_PRODUCT=codex "$binary" setup-codex --plugin-root "$bundle" --dry-run </dev/null || return 1
+    CN_PRODUCT=codex "$binary" setup-codex --plugin-root "$bundle" </dev/null || return 1
+    echo "Codex installed. Start Codex, run /hooks, review and trust the entries."
+}
+
+install_claude() {
     setup_marketplace
     sync_marketplace_checkout
     install_plugin
     find_plugin_root
     download_binary
     setup_iterm2_venv
-    print_success
+    if [ "$PRODUCT" = both ]; then
+        echo "Claude notifications installed; continuing with Codex."
+    else
+        print_success
+    fi
+}
+
+main() {
+    select_product "$@"
+    print_header
+    abort_if_wsl_environment
+    check_prerequisites
+    detect_platform
+    install_cleanup_traps
+    if [ "$PRODUCT" != claude ]; then
+        resolve_bootstrap_release || { echo "Cannot resolve supported Codex release." >&2; return 1; }
+    fi
+    if [ "$PRODUCT" != codex ]; then
+        # Function assignment scopes child environment while preserving PLUGIN_ROOT.
+        CN_PRODUCT=claude install_claude
+    fi
+    if [ "$PRODUCT" != claude ]; then
+        if ! install_codex; then
+            echo "Codex installation/registration failed; no all-products success." >&2
+            [ "$PRODUCT" != both ] || echo "Claude installation completed separately." >&2
+            return 1
+        fi
+    fi
 }
 
 main "$@"

--- a/bin/bootstrap_product_test.sh
+++ b/bin/bootstrap_product_test.sh
@@ -107,6 +107,14 @@ run(['--product', 'codex']); run(['--product', 'codex'])
 run(['--product', 'codex'], extra={'BOOTSTRAP_RELEASE_TAG':'v1.43.0'})
 registration = pathlib.Path(env['CODEX_HOME']) / 'fixture-registration'
 before = registration.read_bytes()
+# Reject mixed binary/source releases before registration and retain live state.
+payload_file = web / 'download/v1.42.0/binary'
+valid_payload = payload_file.read_text()
+payload_file.write_text(valid_payload.replace('v1.42.0', 'v1.41.0'))
+run(['--product', 'codex'], 1)
+assert registration.read_bytes() == before
+payload_file.write_text(valid_payload)
+
 run(['--product', 'codex'], 1, {'FAIL_REGISTER':'1'})
 run(['--product', 'codex'], 1, {'BOOTSTRAP_SOURCE_BASE_URL':base+'/missing'})
 assert registration.read_bytes() == before
@@ -119,10 +127,16 @@ command = 'source '+shlex.quote(str(sandbox/'functions.sh'))+'; PRODUCT=both; PL
 r = subprocess.run([bash,'-c',command],env=env,stdout=subprocess.PIPE,stderr=subprocess.STDOUT,timeout=20)
 assert r.returncode == 0, r.stdout.decode()
 assert (live/'bin/claude-notifications').read_text() == 'stale'
-for choice, success in ([('2',True), ('invalid',False)] if os.name != 'nt' else []):
+# Menu routing for Claude/both uses explicit adapters; Codex below exercises
+# the complete bootstrap HTTP/staging path with fake runtime assets.
+dispatch = (root / 'bin/bootstrap.sh').read_text().replace('main "$@"', '')
+dispatch += '\ncheck_prerequisites() { :; }\nresolve_bootstrap_release() { :; }\ninstall_claude() { echo CLAUDE_ADAPTER; }\ninstall_codex() { echo CODEX_ADAPTER; }\nmain "$@"\n'
+(web / 'dispatch.sh').write_text(dispatch)
+for choice, success in ([('1',True), ('2',True), ('3',True), ('invalid',False)] if os.name != 'nt' else []):
+    entry = '/dispatch.sh' if choice in ['1', '3'] else '/bootstrap.sh'
     pid, fd = pty.fork()
     if pid == 0:
-        os.execve(bash,[bash,'-c', 'curl -fsSL '+base+'/bootstrap.sh | bash'],env)
+        os.execve(bash,[bash,'-c', 'curl -fsSL '+base+entry+' | bash'],env)
     output = b''; sent = False; deadline = time.monotonic()+20
     while time.monotonic() < deadline:
         if select.select([fd],[],[],0.1)[0]:
@@ -136,6 +150,9 @@ for choice, success in ([('2',True), ('invalid',False)] if os.name != 'nt' else 
         os.kill(pid,9); raise AssertionError('PTY timeout')
     _, status = os.waitpid(pid,0); os.close(fd)
     assert sent and (os.waitstatus_to_exitcode(status)==0)==success, output.decode()
+    if choice in ['1','3']: assert b'CLAUDE_ADAPTER' in output
+    if choice == '1': assert b'CODEX_ADAPTER' not in output
+    if choice == '3': assert b'CODEX_ADAPTER' in output
 assert not list(pathlib.Path(env['TMPDIR']).glob('bootstrap-codex-*'))
 assert not list(pathlib.Path(env['TMPDIR']).glob('bootstrap-release-*'))
 server.shutdown(); server.server_close()

--- a/bin/bootstrap_product_test.sh
+++ b/bin/bootstrap_product_test.sh
@@ -129,9 +129,9 @@ assert r.returncode == 0, r.stdout.decode()
 assert (live/'bin/claude-notifications').read_text() == 'stale'
 # Menu routing for Claude/both uses explicit adapters; Codex below exercises
 # the complete bootstrap HTTP/staging path with fake runtime assets.
-dispatch = (root / 'bin/bootstrap.sh').read_text().replace('main "$@"', '')
+dispatch = (root / 'bin/bootstrap.sh').read_text(encoding='utf-8').replace('main "$@"', '')
 dispatch += '\ncheck_prerequisites() { :; }\nresolve_bootstrap_release() { :; }\ninstall_claude() { echo CLAUDE_ADAPTER; }\ninstall_codex() { echo CODEX_ADAPTER; }\nmain "$@"\n'
-(web / 'dispatch.sh').write_text(dispatch)
+(web / 'dispatch.sh').write_text(dispatch, encoding='utf-8')
 for choice, success in ([('1',True), ('2',True), ('3',True), ('invalid',False)] if os.name != 'nt' else []):
     entry = '/dispatch.sh' if choice in ['1', '3'] else '/bootstrap.sh'
     pid, fd = pty.fork()

--- a/bin/bootstrap_product_test.sh
+++ b/bin/bootstrap_product_test.sh
@@ -1,0 +1,143 @@
+#!/bin/bash
+# Isolated unit/adapter fixtures: no public network, real host CLIs or Go builds.
+set -euo pipefail
+ROOT=$(cd "$(dirname "$0")/.." && pwd)
+SANDBOX=$(mktemp -d /tmp/bootstrap-products-XXXXXX)
+trap 'rm -rf "$SANDBOX"' EXIT
+export HOME="$SANDBOX/home space" CODEX_HOME="$SANDBOX/codex space"
+export XDG_CONFIG_HOME="$SANDBOX/config" XDG_CACHE_HOME="$SANDBOX/cache" TMPDIR="$SANDBOX/tmp"
+export CLAUDE_CONFIG_DIR="$SANDBOX/claude config" CLAUDE_HOME="$SANDBOX/claude home"
+export USERPROFILE="$HOME" APPDATA="$SANDBOX/appdata" LOCALAPPDATA="$SANDBOX/localappdata"
+export XDG_DATA_HOME="$SANDBOX/data" XDG_STATE_HOME="$SANDBOX/state" XDG_RUNTIME_DIR="$SANDBOX/run"
+export TMP="$TMPDIR" TEMP="$TMPDIR"
+mkdir -p "$HOME" "$CODEX_HOME" "$XDG_CONFIG_HOME" "$XDG_CACHE_HOME" "$TMPDIR"
+sed '/^main "\$@"$/d' "$ROOT/bin/bootstrap.sh" > "$SANDBOX/functions.sh"
+source "$SANDBOX/functions.sh"
+for product in claude codex both; do
+    PRODUCT=""; select_product --product "$product"; [ "$PRODUCT" = "$product" ]
+done
+for args in '--product invalid' '--product' '--unknown' '--product claude --product codex'; do
+    if ( PRODUCT=""; select_product $args ); then echo "accepted $args"; exit 1; fi
+done
+for tag in v1.42.0 v1.43.2 v2.0.0; do
+    BOOTSTRAP_RELEASE_TAG="$tag" resolve_bootstrap_release
+    [ "$BOOTSTRAP_TAG" = "$tag" ]
+done
+for tag in v1.41.0 v0.99.0 v1.42.0-rc1 v01.42.0 v1.042.0 v1.42.00 v99999999999999999999.0.0 main; do
+    if BOOTSTRAP_RELEASE_TAG="$tag" resolve_bootstrap_release; then exit 1; fi
+done
+# Dispatch tests preserve shared bundle state and isolate CN_PRODUCT.
+print_header() { :; }; abort_if_wsl_environment() { :; }
+check_prerequisites() { :; }; detect_platform() { :; }
+resolve_bootstrap_release() { BOOTSTRAP_TAG=v1.43.2; }
+install_claude() { [ "$CN_PRODUCT" = claude ]; PLUGIN_ROOT='bundle space'; echo claude >> "$SANDBOX/calls"; }
+install_codex() { [ "${CN_PRODUCT:-}" = sentinel ]; echo codex >> "$SANDBOX/calls"; }
+export CN_PRODUCT=sentinel
+for product in claude codex both; do
+    : > "$SANDBOX/calls"
+    PRODUCT=""; main --product "$product"
+    case "$product" in
+        claude) [ "$(cat "$SANDBOX/calls")" = claude ] ;;
+        codex) [ "$(cat "$SANDBOX/calls")" = codex ] ;;
+        both) [ "$(cat "$SANDBOX/calls")" = "$(printf 'claude\ncodex')" ]; [ "$PLUGIN_ROOT" = 'bundle space' ] ;;
+    esac
+done
+install_codex() { return 1; }
+if ( PRODUCT=""; main --product both ); then exit 1; fi
+# main installs its own trap; restore test-owned sandbox cleanup.
+trap 'rm -rf "$SANDBOX"' EXIT
+printf 'bootstrap product unit fixtures passed\n'
+# Local HTTP and controlling-PTY integration. Installer/registration are explicit
+# fake adapters here; the fetched bootstrap, archive extraction and curl are real.
+python3 - "$ROOT" "$SANDBOX" <<'PY'
+import functools, http.server, io, os, pathlib, select, shlex, shutil, subprocess, sys, tarfile, threading, time
+if os.name != "nt":
+    import pty
+root, sandbox = map(pathlib.Path, sys.argv[1:])
+web = sandbox / 'http'; web.mkdir()
+(web / 'bootstrap.sh').write_bytes((root / 'bin/bootstrap.sh').read_bytes())
+(web / 'latest').write_text('{"tag_name":"v1.42.0"}')
+installer = '''#!/bin/bash
+set -eu
+[ "$CN_PRODUCT" = codex ]
+[ "$1" = --force ]
+curl -fsSL "$RELEASE_URL/binary" -o "$INSTALL_TARGET_DIR/claude-notifications"
+chmod +x "$INSTALL_TARGET_DIR/claude-notifications"
+cp "$INSTALL_TARGET_DIR/claude-notifications" "$INSTALL_TARGET_DIR/claude-notifications-windows-amd64.exe"
+'''
+binary = '''#!/bin/bash
+set -eu
+[ "$CN_PRODUCT" = codex ]
+if [ "$1" = --version ]; then echo 'claude-notifications v1.42.0'; exit; fi
+[ "$1" = setup-codex ]
+[ "${FAIL_REGISTER:-0}" = 0 ] || exit 1
+[ "${4:-}" != --dry-run ] || exit 0
+mkdir -p "$CODEX_HOME"
+printf registered > "$CODEX_HOME/fixture-registration"
+'''
+for tag in ['v1.42.0', 'v1.43.0']:
+    with tarfile.open(web / (tag + '.tar.gz'), 'w:gz') as archive:
+        for name, data in {'bin/install.sh': installer, '.claude-plugin/plugin.json': '{"version":"'+tag[1:]+'"}'}.items():
+            data = data.encode(); entry = tarfile.TarInfo('bundle/' + name); entry.size = len(data); entry.mode = 0o755
+            archive.addfile(entry, io.BytesIO(data))
+    dest = web / 'download' / tag; dest.mkdir(parents=True)
+    (dest / 'binary').write_text(binary.replace('v1.42.0', tag))
+class Handler(http.server.SimpleHTTPRequestHandler):
+    def log_message(self, *args): pass
+server = http.server.ThreadingHTTPServer(('127.0.0.1', 0), functools.partial(Handler, directory=str(web)))
+threading.Thread(target=server.serve_forever, daemon=True).start()
+base = 'http://127.0.0.1:' + str(server.server_port)
+env = os.environ.copy()
+env.update(BOOTSTRAP_LATEST_RELEASE_API_URL=base+'/latest', BOOTSTRAP_SOURCE_BASE_URL=base, BOOTSTRAP_RELEASES_BASE_URL=base)
+cli = sandbox / 'clis'; cli.mkdir()
+(cli / 'codex').write_text('#!/bin/sh\nexit 99\n'); (cli / 'codex').chmod(0o755)
+bash = shutil.which('bash'); assert bash
+env['PATH'] = str(cli) + os.pathsep + (os.environ['PATH'] if os.name == 'nt' else '/usr/bin:/bin')
+script = str(root / 'bin/bootstrap.sh')
+def run(args, expected=0, extra=None):
+    result = subprocess.run([bash, script]+args, env=dict(env, **(extra or {})), stdin=subprocess.DEVNULL, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, start_new_session=True, timeout=20)
+    assert (result.returncode == 0) == (expected == 0), result.stdout.decode()
+    return result.stdout.decode()
+assert 'No controlling TTY' in run([], 1)
+assert 'claude CLI not found' in run(['--product', 'both'], 1)
+(cli / 'codex').rename(cli / 'absent')
+assert 'codex CLI not found' in run(['--product', 'codex'], 1)
+(cli / 'absent').rename(cli / 'codex')
+run(['--product', 'codex']); run(['--product', 'codex'])
+run(['--product', 'codex'], extra={'BOOTSTRAP_RELEASE_TAG':'v1.43.0'})
+registration = pathlib.Path(env['CODEX_HOME']) / 'fixture-registration'
+before = registration.read_bytes()
+run(['--product', 'codex'], 1, {'FAIL_REGISTER':'1'})
+run(['--product', 'codex'], 1, {'BOOTSTRAP_SOURCE_BASE_URL':base+'/missing'})
+assert registration.read_bytes() == before
+# Matching Claude manifest with stale runtime must force a fresh staged binary.
+live = sandbox / 'live claude'; (live / 'bin').mkdir(parents=True); (live / '.claude-plugin').mkdir()
+(live / '.claude-plugin/plugin.json').write_text('{"version":"1.42.0"}')
+(live / 'bin/install.sh').write_text(installer)
+(live / 'bin/claude-notifications').write_text('stale')
+command = 'source '+shlex.quote(str(sandbox/'functions.sh'))+'; PRODUCT=both; PLUGIN_ROOT='+shlex.quote(str(live))+'; BOOTSTRAP_TAG=v1.42.0; install_cleanup_traps; install_codex'
+r = subprocess.run([bash,'-c',command],env=env,stdout=subprocess.PIPE,stderr=subprocess.STDOUT,timeout=20)
+assert r.returncode == 0, r.stdout.decode()
+assert (live/'bin/claude-notifications').read_text() == 'stale'
+for choice, success in ([('2',True), ('invalid',False)] if os.name != 'nt' else []):
+    pid, fd = pty.fork()
+    if pid == 0:
+        os.execve(bash,[bash,'-c', 'curl -fsSL '+base+'/bootstrap.sh | bash'],env)
+    output = b''; sent = False; deadline = time.monotonic()+20
+    while time.monotonic() < deadline:
+        if select.select([fd],[],[],0.1)[0]:
+            try: chunk = os.read(fd,65536)
+            except OSError: break
+            if not chunk: break
+            output += chunk
+            if b'Choice:' in output and not sent:
+                os.write(fd,(choice+'\n').encode()); sent=True
+    else:
+        os.kill(pid,9); raise AssertionError('PTY timeout')
+    _, status = os.waitpid(pid,0); os.close(fd)
+    assert sent and (os.waitstatus_to_exitcode(status)==0)==success, output.decode()
+assert not list(pathlib.Path(env['TMPDIR']).glob('bootstrap-codex-*'))
+assert not list(pathlib.Path(env['TMPDIR']).glob('bootstrap-release-*'))
+server.shutdown(); server.server_close()
+print('local HTTP / curl-pipe PTY adapter fixtures passed (fake installer and binary)')
+PY

--- a/bin/install_test.sh
+++ b/bin/install_test.sh
@@ -250,6 +250,12 @@ else
     TESTS_FAILED=$((TESTS_FAILED + 1))
 fi
 
+if bash "$SCRIPT_DIR/bootstrap_product_test.sh"; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+fi
+
 # Summary
 echo "========================================="
 echo " Test Summary"


### PR DESCRIPTION
The existing curl bootstrap now asks whether to install notifications for Claude, Codex, or both. Noninteractive callers select --product claude|codex|both. Codex setup runs automatically; users still review and trust definitions in /hooks.

Bootstrap selects and orchestrates product adapters. Existing install.sh owns binary installation; existing Go setup-codex owns stable runtime copying, foreign-hook preservation and registration. Codex source and assets share one resolved stable release tag; temporary staging protects existing installations. Claude behavior remains in its adapter.

Focused Bash3/macOS and hosted Linux tests pass: selection/dispatch, version validation, local HTTP download, repeat/update, failure preservation and curl-pipe PTY. These use explicit fake installer/binary adapters. A separate real draft-binary curl-pipe canary passed against the final production bootstrap (SHA256 d0f1b8db653f573a794501b250c5e370bd7b8c36a570a1a1a69f1096827f6d81): automatic registration, repeated setup, foreign-hook/config preservation and one local webhook delivery. Independent read-only review found no confirmed P1/P2 defects. This canary invokes the installed hook directly; it does not claim interactive Codex trust or desktop GUI delivery.

The public v1.42.0 prerequisite is not published yet. This PR does not authorize publication or imply the existing draft already contains this new bootstrap. SDK/product draft publication remains separately gated. PTY fixtures cover all three menu choices; the complete staged path uses Codex fixtures and the real draft-binary canary. Windows initially exposed a test-only default text encoding failure, fixed with explicit UTF-8. Final commit 52598cb3d8abca485e87e59a91e5464cba7bd92a passed all six Go 1.22/1.26 jobs across Ubuntu, macOS and Windows, plus lint and Swift tests. Runs: Ubuntu 34325327524, macOS 34325327515, Windows 34325327455.
