### PR TITLE
fix(codex): preserve Windows focus helper and clarify installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 </table>
 </div>
 
-Smart notifications for Claude Code with click-to-focus, git branch display, and webhook integrations.
+Notifications for Claude Code and Codex CLI (beta), with sounds, git branch display, and webhook integrations. See [Codex support and limitations](#codex-cli-support-beta) for differences between products.
 
 > **Boost your productivity** — check out the [advanced task manager for Claude with a convenient UI](https://github.com/777genius/claude_agent_teams_ui), from the creator of this plugin.
 
@@ -29,6 +29,7 @@ Smart notifications for Claude Code with click-to-focus, git branch display, and
     - [Manual Install](#manual-install)
     - [Updating](#updating)
   - [Supported Notification Types](#supported-notification-types)
+  - [Codex CLI Support (beta)](#codex-cli-support-beta)
   - [Platform Support](#platform-support)
     - [Click-to-Focus (macOS & Linux)](#click-to-focus-macos--linux)
   - [Configuration](#configuration)
@@ -44,7 +45,7 @@ Smart notifications for Claude Code with click-to-focus, git branch display, and
 ## Features
 
 - **Cross-platform**: macOS (Intel & Apple Silicon), Linux (x64 & ARM64), Windows 10+ (x64)
-- **6 notification types**: Task Complete, Review Complete, Question, Plan Ready, Session Limit, API Error
+- **Claude notification types**: Task Complete, Review Complete, Question, Plan Ready, Session Limit, API Error
 - **Click-to-focus** (macOS, Linux): click notification to focus the exact project window and tab — Ghostty, VS Code, iTerm2, Warp, kitty, WezTerm, Alacritty, Hyper, Apple Terminal, GNOME Terminal, Konsole, Tilix, Terminator, XFCE4 Terminal, MATE Terminal
 - **Multiplexers**: tmux (including iTerm2 -CC integration mode), zellij, WezTerm, kitty — click switches to the correct session/pane/tab
 - **Git branch in title**: `✅ Completed main [cat]`
@@ -76,13 +77,17 @@ For automation or terminals without a controlling TTY, choose explicitly:
 curl -fsSL https://raw.githubusercontent.com/777genius/claude-notifications-go/main/bin/bootstrap.sh | bash -s -- --product codex
 ```
 
-Use `claude`, `codex`, or `both`. All selected host CLIs must already be on `PATH`. Codex installation requires a published stable release v1.42.0 or newer; source and binaries use the same release tag. It respects `CODEX_HOME` and automatically registers hooks using `setup-codex`. Then start Codex, run `/hooks`, and review and trust the entries yourself. Installation does not grant trust.
+Use `claude`, `codex`, or `both`. This installs the notifications plugin; the selected Claude Code / Codex CLI must already be on `PATH`.
 
-For Claude, restart Claude Code and optionally run `/claude-notifications-go:settings` to configure sounds.
+After installation:
 
-The binary is downloaded once and cached locally. You can re-run `/claude-notifications-go:settings` anytime to reconfigure.
+- **Claude:** restart Claude Code. Optionally run `/claude-notifications-go:settings` to configure sounds.
+- **Codex:** start Codex, run `/hooks`, then review and trust the installed hooks. The installer registers them automatically; no JSON editing or manual registration command is needed. Trust approval remains yours.
+- **Both:** complete both steps above.
 
-> If the bootstrap script doesn't work for your environment, use the [Manual Install](#manual-install) steps below inside Claude Code.
+Codex requires a published stable plugin release v1.42.0 or newer. The installer downloads matching source and binaries, respects `CODEX_HOME`, and keeps a permanent runtime copy there. It reports an error if no supported release is published yet.
+
+> If installation fails, use [manual Claude installation](#manual-install) or [manual Codex registration](#manual-codex-registration), depending on the product.
 
 ### Manual Install
 
@@ -109,16 +114,16 @@ Run these slash commands in the Claude Code chat, not in your system terminal:
 
 ### Updating
 
-Run the same command as for installation — it will update both the plugin and the binary:
+Run the same command and choose the product(s) you want to update:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/777genius/claude-notifications-go/main/bin/bootstrap.sh | bash
 ```
 
-Then restart Claude Code to apply the new version. Your settings in `~/.claude/claude-notifications-go/config.json` are preserved across updates.
+For Claude, restart Claude Code. For Codex, restart Codex and inspect `/hooks`; changed hook definitions may need trust approval again. The installer refreshes the Codex runtime and registration automatically. Existing foreign hooks and shared settings in `~/.claude/claude-notifications-go/config.json` are preserved.
 
 <details>
-<summary>Manual update (if bootstrap didn't work)</summary>
+<summary>Manual Claude update (if bootstrap didn't work)</summary>
 
 Claude Code also periodically checks for plugin updates automatically. Binaries are updated on the next hook invocation when a version mismatch is detected.
 
@@ -132,6 +137,8 @@ If the binary auto-update didn't work (e.g. no internet at the time), run `/clau
 </details>
 
 ## Supported Notification Types
+
+The Claude triggers are listed below. Codex uses a different event mapping, described in [Codex support](#codex-cli-support-beta).
 
 | Status | Icon | Description | Trigger |
 |--------|------|-------------|---------|
@@ -149,17 +156,17 @@ The same binary can notify for OpenAI Codex CLI sessions.
 
 ### Setup
 
-The registration command is implemented in Go and does not require `jq`. You need a
-Codex-capable release (v1.42.0 or later) and its plugin bundle; an older binary cannot run
-`setup-codex`. The command is not automatically added to your `PATH` by the Claude plugin.
-
 Use the [one-command installer](#quick-install-recommended) and choose Codex or both.
-It downloads matching release source and binaries in temporary staging, registers the
-stable runtime copy, and removes staging automatically. Re-run it to update.
+It downloads matching release source and binaries, registers the hooks, and keeps a stable
+runtime copy. Then start Codex and approve the entries in `/hooks`.
 
-For manual registration, use a downloaded **matching release** bundle and binary:
+### Manual Codex registration
 
-From an already downloaded plugin bundle, run the binary by its path:
+Skip this section if you used the one-command installer. For manual setup, download a
+matching release bundle and binary (v1.42.0 or newer). The Go registration command needs
+no `jq` and is not automatically added to your `PATH`.
+
+From the bundle directory:
 
 ```bash
 ./bin/claude-notifications setup-codex --plugin-root .
@@ -178,15 +185,14 @@ It installs a self-contained copy of the plugin at `~/.codex/claude-notification
 the hook entries into `~/.codex/hooks.json`. Existing foreign hook definitions and unknown fields are preserved,
 and every run saves a uniquely named backup of the previous file next to it.
 
-Then start Codex, run `/hooks`, review the entries and trust them — Codex asks once.
+Then start Codex, run `/hooks`, review the entries and trust them.
 
 Useful flags: `--dry-run` shows what would change, `--print` outputs the JSON so you can merge it
 yourself, `--codex-home` and `--plugin-root` override the paths.
 
-After updating the plugin, run the command again to refresh the installed copy. The registration
-itself does not change, so Codex does not ask you to trust the hooks again.
-With the bootstrap installer, re-run the same one-liner and select Codex or both to
-install the latest supported stable release and refresh registration automatically.
+For manual updates, run the registration command again to refresh the installed copy.
+Unchanged hook definitions retain trust; changed definitions require review again.
+The one-command installer handles this registration step automatically.
 
 Claude Code installation and updates continue to use the [existing installation steps](#installation).
 Both products share settings at `~/.claude/claude-notifications-go/config.json`; installing

--- a/internal/codexsetup/codexsetup.go
+++ b/internal/codexsetup/codexsetup.go
@@ -797,6 +797,10 @@ func runtimeBinary(name string) bool {
 		for _, arch := range []string{"amd64", "arm64"} {
 			expected := "claude-notifications-" + platform + "-" + arch
 			if platform == "windows" {
+				// Toast clicks use the GUI helper to avoid opening a console window.
+				if name == expected+"-focus.exe" {
+					return true
+				}
 				expected += ".exe"
 			}
 			if name == expected {

--- a/internal/codexsetup/safety_test.go
+++ b/internal/codexsetup/safety_test.go
@@ -46,10 +46,13 @@ func TestForeignEmptyAndMatcherPreserved(t *testing.T) {
 func TestCopyPreservesUpdaterAssets(t *testing.T) {
 	src, dst := fakeBundle(t), t.TempDir()
 	files := map[string]string{
-		".claude-plugin/plugin.json":  `{"version":"1.42.0"}`,
-		".claude-plugin/private-note": "not a runtime asset",
-		"bin/install.sh":              "#!/bin/sh\nexit 0\n",
-		"bin/bootstrap.sh":            "not used by the Codex launcher",
+		".claude-plugin/plugin.json":                       `{"version":"1.42.0"}`,
+		".claude-plugin/private-note":                      "not a runtime asset",
+		"bin/install.sh":                                   "#!/bin/sh\nexit 0\n",
+		"bin/bootstrap.sh":                                 "not used by the Codex launcher",
+		"bin/claude-notifications-windows-amd64-focus.exe": "amd64 GUI focus helper",
+		"bin/claude-notifications-windows-arm64-focus.exe": "arm64 GUI focus helper",
+		"bin/claude-notifications-linux-amd64-focus.exe":   "not a supported helper",
 	}
 	for name, content := range files {
 		path := filepath.Join(src, filepath.FromSlash(name))
@@ -63,13 +66,13 @@ func TestCopyPreservesUpdaterAssets(t *testing.T) {
 	if err := copyBundle(src, dst); err != nil {
 		t.Fatal(err)
 	}
-	for _, name := range []string{".claude-plugin/plugin.json", "bin/install.sh"} {
+	for _, name := range []string{".claude-plugin/plugin.json", "bin/install.sh", "bin/claude-notifications-windows-amd64-focus.exe", "bin/claude-notifications-windows-arm64-focus.exe"} {
 		got, err := os.ReadFile(filepath.Join(dst, filepath.FromSlash(name)))
 		if err != nil || string(got) != files[name] {
 			t.Fatalf("runtime asset %s missing or altered: %v", name, err)
 		}
 	}
-	for _, name := range []string{".claude-plugin/private-note", "bin/bootstrap.sh"} {
+	for _, name := range []string{".claude-plugin/private-note", "bin/bootstrap.sh", "bin/claude-notifications-linux-amd64-focus.exe"} {
 		if _, err := os.Stat(filepath.Join(dst, filepath.FromSlash(name))); !os.IsNotExist(err) {
 			t.Fatalf("unexpected asset %s: %v", name, err)
 		}

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -13,10 +13,19 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// Each test owns its state directory. Other packages may clean test-session
+// files in the system temp directory while go test runs packages concurrently.
+func newTestManager(t *testing.T) *Manager {
+	t.Helper()
+	mgr := NewManager()
+	mgr.tempDir = t.TempDir()
+	return mgr
+}
+
 // === Load/Save/Delete Tests ===
 
 func TestManager_LoadNonExistent(t *testing.T) {
-	mgr := NewManager()
+	mgr := newTestManager(t)
 
 	state, err := mgr.Load("non-existent-session")
 	require.NoError(t, err)
@@ -24,7 +33,7 @@ func TestManager_LoadNonExistent(t *testing.T) {
 }
 
 func TestManager_SaveAndLoad(t *testing.T) {
-	mgr := NewManager()
+	mgr := newTestManager(t)
 	sessionID := "test-session-save-load"
 
 	// Clean up after test
@@ -54,7 +63,7 @@ func TestManager_SaveAndLoad(t *testing.T) {
 }
 
 func TestManager_Delete(t *testing.T) {
-	mgr := NewManager()
+	mgr := newTestManager(t)
 	sessionID := "test-session-delete"
 
 	// Save state
@@ -78,7 +87,7 @@ func TestManager_Delete(t *testing.T) {
 }
 
 func TestManager_DeleteNonExistent(t *testing.T) {
-	mgr := NewManager()
+	mgr := newTestManager(t)
 
 	// Should not error when deleting non-existent state
 	err := mgr.Delete("non-existent")
@@ -88,7 +97,7 @@ func TestManager_DeleteNonExistent(t *testing.T) {
 // === UpdateInteractiveTool Tests ===
 
 func TestManager_UpdateInteractiveTool_NewState(t *testing.T) {
-	mgr := NewManager()
+	mgr := newTestManager(t)
 	sessionID := "test-interactive-new"
 	defer func() { _ = mgr.Delete(sessionID) }()
 
@@ -107,7 +116,7 @@ func TestManager_UpdateInteractiveTool_NewState(t *testing.T) {
 }
 
 func TestManager_UpdateInteractiveTool_ExistingState(t *testing.T) {
-	mgr := NewManager()
+	mgr := newTestManager(t)
 	sessionID := "test-interactive-existing"
 	defer func() { _ = mgr.Delete(sessionID) }()
 
@@ -136,7 +145,7 @@ func TestManager_UpdateInteractiveTool_ExistingState(t *testing.T) {
 }
 
 func TestManager_UpdateGhosttyTerminalID_PreservesExistingFields(t *testing.T) {
-	mgr := NewManager()
+	mgr := newTestManager(t)
 	sessionID := "test-ghostty-terminal-id"
 	defer func() { _ = mgr.Delete(sessionID) }()
 
@@ -163,7 +172,7 @@ func TestManager_UpdateGhosttyTerminalID_PreservesExistingFields(t *testing.T) {
 // === UpdateTaskComplete Tests ===
 
 func TestManager_UpdateTaskComplete_NewState(t *testing.T) {
-	mgr := NewManager()
+	mgr := newTestManager(t)
 	sessionID := "test-task-new"
 	defer func() { _ = mgr.Delete(sessionID) }()
 
@@ -180,7 +189,7 @@ func TestManager_UpdateTaskComplete_NewState(t *testing.T) {
 }
 
 func TestManager_UpdateTaskComplete_ExistingState(t *testing.T) {
-	mgr := NewManager()
+	mgr := newTestManager(t)
 	sessionID := "test-task-existing"
 	defer func() { _ = mgr.Delete(sessionID) }()
 
@@ -209,7 +218,7 @@ func TestManager_UpdateTaskComplete_ExistingState(t *testing.T) {
 // === UpdateLastNotification Tests ===
 
 func TestManager_UpdateLastNotification_NewState(t *testing.T) {
-	mgr := NewManager()
+	mgr := newTestManager(t)
 	sessionID := "test-notif-new"
 	defer func() { _ = mgr.Delete(sessionID) }()
 
@@ -228,7 +237,7 @@ func TestManager_UpdateLastNotification_NewState(t *testing.T) {
 }
 
 func TestManager_UpdateLastNotification_ExistingState(t *testing.T) {
-	mgr := NewManager()
+	mgr := newTestManager(t)
 	sessionID := "test-notif-existing"
 	defer func() { _ = mgr.Delete(sessionID) }()
 
@@ -259,7 +268,7 @@ func TestManager_UpdateLastNotification_ExistingState(t *testing.T) {
 // === ShouldSuppressQuestion Tests ===
 
 func TestManager_ShouldSuppressQuestion_NoState(t *testing.T) {
-	mgr := NewManager()
+	mgr := newTestManager(t)
 
 	suppress, err := mgr.ShouldSuppressQuestion("non-existent", 5)
 	require.NoError(t, err)
@@ -267,7 +276,7 @@ func TestManager_ShouldSuppressQuestion_NoState(t *testing.T) {
 }
 
 func TestManager_ShouldSuppressQuestion_NoTaskCompleteTime(t *testing.T) {
-	mgr := NewManager()
+	mgr := newTestManager(t)
 	sessionID := "test-suppress-no-time"
 	defer func() { _ = mgr.Delete(sessionID) }()
 
@@ -282,7 +291,7 @@ func TestManager_ShouldSuppressQuestion_NoTaskCompleteTime(t *testing.T) {
 }
 
 func TestManager_ShouldSuppressQuestion_WithinCooldown(t *testing.T) {
-	mgr := NewManager()
+	mgr := newTestManager(t)
 	sessionID := "test-suppress-within"
 	defer func() { _ = mgr.Delete(sessionID) }()
 
@@ -301,7 +310,7 @@ func TestManager_ShouldSuppressQuestion_WithinCooldown(t *testing.T) {
 }
 
 func TestManager_ShouldSuppressQuestion_OutsideCooldown(t *testing.T) {
-	mgr := NewManager()
+	mgr := newTestManager(t)
 	sessionID := "test-suppress-outside"
 	defer func() { _ = mgr.Delete(sessionID) }()
 
@@ -320,7 +329,7 @@ func TestManager_ShouldSuppressQuestion_OutsideCooldown(t *testing.T) {
 }
 
 func TestManager_ShouldSuppressQuestion_ZeroCooldown(t *testing.T) {
-	mgr := NewManager()
+	mgr := newTestManager(t)
 	sessionID := "test-suppress-zero"
 	defer func() { _ = mgr.Delete(sessionID) }()
 
@@ -339,7 +348,7 @@ func TestManager_ShouldSuppressQuestion_ZeroCooldown(t *testing.T) {
 }
 
 func TestManager_ShouldSuppressQuestion_NegativeCooldown(t *testing.T) {
-	mgr := NewManager()
+	mgr := newTestManager(t)
 
 	suppress, err := mgr.ShouldSuppressQuestion("any-session", -5)
 	require.NoError(t, err)
@@ -349,7 +358,7 @@ func TestManager_ShouldSuppressQuestion_NegativeCooldown(t *testing.T) {
 // === ShouldSuppressQuestionAfterAnyNotification Tests ===
 
 func TestManager_ShouldSuppressAfterAny_NoState(t *testing.T) {
-	mgr := NewManager()
+	mgr := newTestManager(t)
 
 	suppress, err := mgr.ShouldSuppressQuestionAfterAnyNotification("non-existent", 5)
 	require.NoError(t, err)
@@ -357,7 +366,7 @@ func TestManager_ShouldSuppressAfterAny_NoState(t *testing.T) {
 }
 
 func TestManager_ShouldSuppressAfterAny_NoNotificationTime(t *testing.T) {
-	mgr := NewManager()
+	mgr := newTestManager(t)
 	sessionID := "test-suppress-any-no-time"
 	defer func() { _ = mgr.Delete(sessionID) }()
 
@@ -371,7 +380,7 @@ func TestManager_ShouldSuppressAfterAny_NoNotificationTime(t *testing.T) {
 }
 
 func TestManager_ShouldSuppressAfterAny_WithinCooldown(t *testing.T) {
-	mgr := NewManager()
+	mgr := newTestManager(t)
 	sessionID := "test-suppress-any-within"
 	defer func() { _ = mgr.Delete(sessionID) }()
 
@@ -388,7 +397,7 @@ func TestManager_ShouldSuppressAfterAny_WithinCooldown(t *testing.T) {
 }
 
 func TestManager_ShouldSuppressAfterAny_OutsideCooldown(t *testing.T) {
-	mgr := NewManager()
+	mgr := newTestManager(t)
 	sessionID := "test-suppress-any-outside"
 	defer func() { _ = mgr.Delete(sessionID) }()
 
@@ -407,7 +416,7 @@ func TestManager_ShouldSuppressAfterAny_OutsideCooldown(t *testing.T) {
 // === UpdateState Tests ===
 
 func TestManager_UpdateState_TaskComplete(t *testing.T) {
-	mgr := NewManager()
+	mgr := newTestManager(t)
 	sessionID := "test-update-task"
 	defer func() { _ = mgr.Delete(sessionID) }()
 
@@ -420,7 +429,7 @@ func TestManager_UpdateState_TaskComplete(t *testing.T) {
 }
 
 func TestManager_UpdateState_PlanReady(t *testing.T) {
-	mgr := NewManager()
+	mgr := newTestManager(t)
 	sessionID := "test-update-plan"
 	defer func() { _ = mgr.Delete(sessionID) }()
 
@@ -434,7 +443,7 @@ func TestManager_UpdateState_PlanReady(t *testing.T) {
 }
 
 func TestManager_UpdateState_Question(t *testing.T) {
-	mgr := NewManager()
+	mgr := newTestManager(t)
 	sessionID := "test-update-question"
 	defer func() { _ = mgr.Delete(sessionID) }()
 
@@ -447,7 +456,7 @@ func TestManager_UpdateState_Question(t *testing.T) {
 }
 
 func TestManager_UpdateState_UnknownStatus(t *testing.T) {
-	mgr := NewManager()
+	mgr := newTestManager(t)
 	sessionID := "test-update-unknown"
 	defer func() { _ = mgr.Delete(sessionID) }()
 
@@ -461,7 +470,7 @@ func TestManager_UpdateState_UnknownStatus(t *testing.T) {
 }
 
 func TestManager_UpdateState_QuestionWithoutTool(t *testing.T) {
-	mgr := NewManager()
+	mgr := newTestManager(t)
 	sessionID := "test-update-question-no-tool"
 	defer func() { _ = mgr.Delete(sessionID) }()
 
@@ -477,7 +486,7 @@ func TestManager_UpdateState_QuestionWithoutTool(t *testing.T) {
 // === Cleanup Tests ===
 
 func TestManager_Cleanup_OldFiles(t *testing.T) {
-	mgr := NewManager()
+	mgr := newTestManager(t)
 	mgr.tempDir = t.TempDir()
 
 	// Create two state files
@@ -515,7 +524,7 @@ func TestManager_Cleanup_OldFiles(t *testing.T) {
 }
 
 func TestManager_Cleanup_EmptyDirectory(t *testing.T) {
-	mgr := NewManager()
+	mgr := newTestManager(t)
 	mgr.tempDir = t.TempDir()
 
 	// Should not error on empty directory
@@ -526,7 +535,7 @@ func TestManager_Cleanup_EmptyDirectory(t *testing.T) {
 // === Integration Tests ===
 
 func TestManager_FullWorkflow(t *testing.T) {
-	mgr := NewManager()
+	mgr := newTestManager(t)
 	sessionID := "test-workflow"
 	defer func() { _ = mgr.Delete(sessionID) }()
 
@@ -566,7 +575,7 @@ func TestManager_FullWorkflow(t *testing.T) {
 }
 
 func TestManager_StateFilePath(t *testing.T) {
-	mgr := NewManager()
+	mgr := newTestManager(t)
 	sessionID := "test-abc-123"
 
 	path := mgr.getStatePath(sessionID)
@@ -583,7 +592,7 @@ func TestManager_StateFilePath(t *testing.T) {
 }
 
 func TestLoad_InvalidJSON(t *testing.T) {
-	mgr := NewManager()
+	mgr := newTestManager(t)
 	sessionID := "test-invalid-json"
 
 	// Create a file with invalid JSON
@@ -633,7 +642,7 @@ func TestDelete_PermissionDenied(t *testing.T) {
 // === IsDuplicateMessage Tests ===
 
 func TestManager_IsDuplicateMessage_NoState(t *testing.T) {
-	mgr := NewManager()
+	mgr := newTestManager(t)
 
 	isDuplicate, err := mgr.IsDuplicateMessage("non-existent", "test message", 180)
 	require.NoError(t, err)
@@ -641,7 +650,7 @@ func TestManager_IsDuplicateMessage_NoState(t *testing.T) {
 }
 
 func TestManager_IsDuplicateMessage_SameMessage(t *testing.T) {
-	mgr := NewManager()
+	mgr := newTestManager(t)
 	sessionID := "test-duplicate-same"
 	defer func() { _ = mgr.Delete(sessionID) }()
 
@@ -656,7 +665,7 @@ func TestManager_IsDuplicateMessage_SameMessage(t *testing.T) {
 }
 
 func TestManager_IsDuplicateMessage_NormalizedDots(t *testing.T) {
-	mgr := NewManager()
+	mgr := newTestManager(t)
 	sessionID := "test-duplicate-dots"
 	defer func() { _ = mgr.Delete(sessionID) }()
 
@@ -671,7 +680,7 @@ func TestManager_IsDuplicateMessage_NormalizedDots(t *testing.T) {
 }
 
 func TestManager_IsDuplicateMessage_NormalizedCase(t *testing.T) {
-	mgr := NewManager()
+	mgr := newTestManager(t)
 	sessionID := "test-duplicate-case"
 	defer func() { _ = mgr.Delete(sessionID) }()
 
@@ -686,7 +695,7 @@ func TestManager_IsDuplicateMessage_NormalizedCase(t *testing.T) {
 }
 
 func TestManager_IsDuplicateMessage_DifferentMessage(t *testing.T) {
-	mgr := NewManager()
+	mgr := newTestManager(t)
 	sessionID := "test-duplicate-diff"
 	defer func() { _ = mgr.Delete(sessionID) }()
 
@@ -701,7 +710,7 @@ func TestManager_IsDuplicateMessage_DifferentMessage(t *testing.T) {
 }
 
 func TestManager_IsDuplicateMessage_ZeroWindow(t *testing.T) {
-	mgr := NewManager()
+	mgr := newTestManager(t)
 	sessionID := "test-duplicate-zero"
 	defer func() { _ = mgr.Delete(sessionID) }()
 
@@ -716,7 +725,7 @@ func TestManager_IsDuplicateMessage_ZeroWindow(t *testing.T) {
 }
 
 func TestManager_IsDuplicateMessage_EmptyLastMessage(t *testing.T) {
-	mgr := NewManager()
+	mgr := newTestManager(t)
 	sessionID := "test-duplicate-empty"
 	defer func() { _ = mgr.Delete(sessionID) }()
 


### PR DESCRIPTION
Codex setup copied the notification executable but omitted the Windows GUI focus helper downloaded by install.sh. After bootstrap removed staging, toast clicks fell back to the console executable and could flash a console window. Preserve the exact amd64/arm64 focus helper names in the stable runtime copy.

README now separates Claude and Codex post-install/update steps, directs each product to its own manual fallback, and removes the incorrect once-only download claim. Codex hook registration is automatic; trust approval is still manual.

Validation: hosted isolated `go test ./internal/codexsetup` passes. Copy regression coverage verifies both Windows helper architectures and rejects an unsupported Linux helper. Independent read-only review found no actionable correctness defects. Final commit 446c0d6e2c24525b8f8cf9baad1bbf69cca77e2f passed all six Ubuntu/macOS/Windows jobs on Go 1.22/1.26, lint and Swift tests. Runs: Ubuntu 34326940595, macOS 34326940895, Windows 34326940558.

A separate interactive curl-pipe E2E on the merged bootstrap and real v1.42.0 draft binary selected Codex twice, verified automatic hook registration and preservation of foreign hooks/settings, executed the exact registered Stop command, and captured one webhook. This proves the installer path, not Windows GUI focus or interactive Codex trust. The existing v1.42.0 draft predates this fix and must not be treated as qualified for publication without an updated candidate.

Related: #142, #141.

CI exposed an existing cross-package fixture collision: hook tests remove test-session files from the shared system temporary directory while the state workflow test uses that directory. State tests now own a t.TempDir per manager. Five repeated state suite runs passed under an unprivileged hosted sandbox user, retaining permission-denied coverage. Production state code is unchanged.

Expanded real E2E also passed menu choice 3 (both), twice: actual Claude CLI installed from a disposable local marketplace, Codex registered automatically, and the exact registered Stop command delivered one webhook. Only sandbox profiles and loopback-mirrored actual draft artifacts were used.
