### PR TITLE
fix(landing): simplify installation command layout

### DIFF
--- a/landing/assets/main.css
+++ b/landing/assets/main.css
@@ -1031,7 +1031,7 @@ footer .brand {
   line-height: 1.6;
   font-size: 12px;
 }
-.install-command-line .primary {
+.command-tools .primary {
   flex-shrink: 0;
   padding: 16px 20px;
   color: white;
@@ -1164,7 +1164,7 @@ footer .brand {
   .install-command-line {
     flex-wrap: wrap;
   }
-  .install-command-line .primary {
+  .command-tools .primary {
     width: 100%;
   }
   .next-steps {
@@ -1190,5 +1190,44 @@ footer .brand {
   }
   .next-step h3 {
     font-size: 18px;
+  }
+}
+
+/* Keep the command separate from its controls and remove the outer card. */
+.command-tools {
+  display: flex;
+  align-items: center;
+  gap: 18px;
+}
+.command-tools > span {
+  color: #acbfdc;
+  font-size: 12px;
+}
+.install-command-line {
+  align-items: flex-start;
+}
+.install-command-line textarea {
+  padding: 0;
+  white-space: pre;
+  overflow-wrap: normal;
+  word-break: normal;
+  overflow-x: auto;
+}
+.terminal-prompt {
+  font-size: 12px;
+  line-height: 1.6;
+}
+.update-under-command {
+  display: inline-block;
+  margin-top: 12px;
+  font-size: 12px;
+}
+@media (max-width: 700px) {
+  .command-tools .primary {
+    width: auto;
+    padding: 12px;
+  }
+  .command-tools {
+    gap: 10px;
   }
 }

--- a/landing/components/InstallWizard.vue
+++ b/landing/components/InstallWizard.vue
@@ -38,6 +38,7 @@ const commandField = ref<HTMLTextAreaElement>();
 const snippet = computed(() =>
   command(product.value, target.value, intent.value),
 );
+const displaySnippet = computed(() => snippet.value?.replace(" | ", " |\n"));
 onMounted(() => {
   detected.value = detectTarget(navigator.userAgent, navigator.maxTouchPoints);
   if (!manualOverride.value) target.value = detected.value;
@@ -192,38 +193,49 @@ async function copy() {
       </p>
     </div>
     <template v-else>
-      <div class="setup-panel installation-command">
+      <div class="installation-command">
         <div class="command-panel-heading">
           <label for="command"
             >{{ intent === "update" ? "Update" : "Install" }} command</label
           >
-          <span>{{ target === "windows" ? "Git Bash" : "Bash" }}</span>
+          <div class="command-tools">
+            <span>{{ target === "windows" ? "Git Bash" : "Bash" }}</span>
+            <button class="primary" @click="copy">
+              <svg
+                width="18"
+                height="18"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="1.6"
+                aria-hidden="true"
+              >
+                <rect x="8" y="3" width="12" height="15" rx="2" />
+                <path d="M16 18v3H4V7h4" /></svg
+              >Copy command
+            </button>
+          </div>
         </div>
         <div class="install-command-line">
           <span class="terminal-prompt" aria-hidden="true">$</span>
           <textarea
             id="command"
             ref="commandField"
-            :value="snippet"
+            :value="displaySnippet"
             readonly
             spellcheck="false"
-            rows="3"
+            rows="2"
+            wrap="off"
           />
-          <button class="primary" @click="copy">
-            <svg
-              width="18"
-              height="18"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="1.6"
-              aria-hidden="true"
-            >
-              <rect x="8" y="3" width="12" height="15" rx="2" />
-              <path d="M16 18v3H4V7h4" /></svg
-            >Copy command
-          </button>
         </div>
+        <button
+          v-if="intent === 'install'"
+          class="text-action update-under-command"
+          aria-label="Update"
+          @click="changeIntent('update')"
+        >
+          Updating instead?
+        </button>
         <p role="status" class="copy-status">{{ copyStatus }}</p>
         <p v-if="intent === 'update'" class="update-note">
           Install and update use the same command. Your existing settings are
@@ -302,14 +314,7 @@ async function copy() {
         >
           Installation instructions
         </button>
-        <button
-          v-if="intent !== 'update'"
-          class="text-action"
-          aria-label="Update"
-          @click="changeIntent('update')"
-        >
-          Updating instead?
-        </button>
+
         <button
           v-if="intent !== 'configure'"
           class="text-action"

--- a/landing/tests/browser/install.spec.ts
+++ b/landing/tests/browser/install.spec.ts
@@ -38,7 +38,7 @@ test("production command matrix, aftercare, clipboard and configuration", async 
         )
           await page.getByRole("button", { name: intent, exact: true }).click();
         await expect(page.getByLabel(intent + " command")).toHaveValue(
-          "curl -fsSL https://raw.githubusercontent.com/777genius/claude-notifications-go/main/bin/bootstrap.sh | bash -s -- --product " +
+          "curl -fsSL https://raw.githubusercontent.com/777genius/claude-notifications-go/main/bin/bootstrap.sh |\nbash -s -- --product " +
             product,
         );
       }


### PR DESCRIPTION
Remove the outer installation-command card, move Copy command into the header, and place Updating instead directly below the command. Align the shell prompt with the first line and display a deliberate newline after the pipe; clipboard output remains the original one-line command. Narrow screens scroll long command lines instead of breaking URLs.

Validation: hosted Nuxt typecheck and all nine production browser E2E tests pass. Inspected the updated section screenshot, including prompt alignment and control placement.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Redesigned the installation command panel for clearer separation between the command and its controls.
  - Install commands now preserve formatting and support horizontal scrolling instead of wrapping.
  - Added an easier way to switch from installation to updating directly below the command.
  - Improved responsive behavior on smaller screens, including more compact controls and spacing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->