### PR TITLE
fix(landing): enlarge hero title and compact notification previews

### DIFF
--- a/landing/assets/main.css
+++ b/landing/assets/main.css
@@ -1231,3 +1231,23 @@ footer .brand {
     gap: 10px;
   }
 }
+
+/* Give the headline priority over the illustrative notification stack. */
+@media (min-width: 901px) {
+  .hero { grid-template-columns: minmax(0, 1.8fr) minmax(0, 1fr); }
+  h1 { font-size: clamp(44px, 4.25vw, 60px); }
+}
+.notification-preview { justify-self: center; max-width: 285px; }
+.notification-stack { gap: 6px; min-height: 200px; }
+.notification-card { min-height: 58px; padding: 9px; gap: 7px; border-radius: 11px; }
+.notification-card .agent-logo { width: 24px; height: 24px; }
+.notification-copy, .notification-copy p { font-size: 8px; line-height: 1.35; }
+.notification-title { gap: 4px; }
+.notification-title h3 { font-size: 9px; letter-spacing: -.1px; }
+.notification-title > span { font-size: 7px; }
+.notification-copy p, .notification-detail { margin-top: 2px; }
+.preview-heading { letter-spacing: 1px; font-size: 8px; }
+.install-command-line { position: relative; padding-right: 60px; }
+.copy-icon { position: absolute; top: 10px; right: 10px; display: grid; place-items: center; width: 36px; height: 36px; padding: 0; border: 1px solid #34435a; border-radius: 7px; background: #141c29; color: #b9d9ec; }
+.copy-icon:hover { background: #223249; color: #8ff5ff; }
+@media (min-width: 561px) and (max-width: 900px) { h1 { font-size: clamp(36px, 5.6vw, 50px); } }

--- a/landing/components/InstallWizard.vue
+++ b/landing/components/InstallWizard.vue
@@ -200,7 +200,11 @@ async function copy() {
           >
           <div class="command-tools">
             <span>{{ target === "windows" ? "Git Bash" : "Bash" }}</span>
-            <button class="primary" @click="copy">
+
+          </div>
+        </div>
+        <div class="install-command-line">
+            <button class="copy-icon" aria-label="Copy command" title="Copy command" @click="copy">
               <svg
                 width="18"
                 height="18"
@@ -212,11 +216,8 @@ async function copy() {
               >
                 <rect x="8" y="3" width="12" height="15" rx="2" />
                 <path d="M16 18v3H4V7h4" /></svg
-              >Copy command
+              >
             </button>
-          </div>
-        </div>
-        <div class="install-command-line">
           <span class="terminal-prompt" aria-hidden="true">$</span>
           <textarea
             id="command"

--- a/landing/tests/browser/install.spec.ts
+++ b/landing/tests/browser/install.spec.ts
@@ -277,7 +277,7 @@ test("hero headline remains a single unclipped line at narrow widths", async ({
     await page.goto("");
     const box = await page.locator("h1 em").boundingBox();
     expect(box!.x + box!.width).toBeLessThanOrEqual(width);
-    expect(box!.height).toBeLessThan(60);
+    expect(box!.height).toBeLessThan(76);
   }
 });
 test("guided reference layout, detected OS and mode focus", async ({


### PR DESCRIPTION
Move the copy action into the command block as an accessible icon button at the upper right. Increase desktop/tablet hero headline size and give it more horizontal space; reduce notification cards to approximately half size while preserving the sequence and controls.

Validation: Nuxt typecheck and all nine production browser E2E tests pass, including copy success/failure, responsive headline widths, notification sequence and reduced motion.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a compact copy icon button to the install command panel, with accessible labeling and tooltip text.
* **Style**
  * Refined the landing page hero and notification preview layout for wide screens.
  * Adjusted notification card typography and spacing for a more compact presentation.
  * Improved responsive headline sizing for mid-range screen widths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->