### PR TITLE
fix(landing): make header and compatibility strip full width

### DIFF
--- a/landing/assets/main.css
+++ b/landing/assets/main.css
@@ -82,14 +82,15 @@ h3 {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  max-width: 1260px;
-  margin: auto;
-  padding: 0 34px;
-  border-bottom: 1px solid var(--line);
+  width: 100%;
+  margin: 0;
+  padding: 0 max(34px, calc((100% - 1192px) / 2));
+  border-bottom: 1px solid rgba(0, 240, 255, 0.08);
   position: sticky;
   top: 0;
-  background: #0a0a0feb;
-  backdrop-filter: blur(18px);
+  background: rgba(10, 10, 15, 0.9);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
   z-index: 30;
 }
 .brand {
@@ -219,14 +220,14 @@ h1 em {
   margin-top: 20px;
 }
 .compatibility {
-  max-width: 1192px;
-  margin: 65px auto 0;
+  width: 100%;
+  margin: 0;
   display: flex;
   justify-content: space-between;
   align-items: center;
   gap: 20px;
-  border-block: 1px solid var(--line);
-  padding: 24px 0;
+  border: 0;
+  padding: 14px 34px;
 }
 .compatibility > span {
   font-size: 9px;
@@ -480,7 +481,8 @@ footer .brand {
     margin: 0 auto;
   }
   .compatibility {
-    margin: 0 28px;
+    margin: 0;
+    padding-inline: 28px;
     flex-wrap: wrap;
   }
   .compatibility .platforms {
@@ -592,7 +594,8 @@ footer .brand {
     left: 10px;
   }
   .compatibility {
-    margin: 0 22px;
+    margin: 0;
+    padding-inline: 22px;
     gap: 15px;
   }
   .compatibility > span:first-child {
@@ -862,7 +865,7 @@ footer .brand {
 /* Owner-selected installation reference: docs/design/installation-reference.png */
 .guided-install {
   max-width: 1120px;
-  padding-top: 65px;
+  padding-top: 24px;
 }
 .install-heading {
   text-align: center;


### PR DESCRIPTION
Extend the sticky header background across the viewport and match the reference header opacity and 12px backdrop blur. Remove compatibility-strip borders and outer margins, use full width, and reduce the gap before installation.

Validation: static production build and all nine browser E2E tests pass, including mobile overflow and sticky-header scrolling.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the header to span the full viewport with refreshed edge spacing, a translucent cyan bottom border, and a lighter background blur.
  - Expanded the compatibility bar to full width with reduced padding and simplified borders.
  - Improved compatibility bar spacing across desktop, tablet, and mobile breakpoints.
  - Reduced the top spacing above the guided installation section for a more compact layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->