### PR TITLE
feat(landing): refresh feature cards and FAQ styling

### DIFF
--- a/landing/app.vue
+++ b/landing/app.vue
@@ -5,19 +5,19 @@ const features = [
     number: "01",
     title: "Step away, stay informed",
     text: "Get a desktop notification when your agent finishes or needs your attention. Spend less time watching a terminal.",
-    icon: "↗",
+    label: "DESKTOP NOTIFICATIONS",
   },
   {
     number: "02",
     title: "A sound for every moment",
     text: "Pick sounds, set the volume, and choose an audio device. Keep the signals you want and quiet the rest.",
-    icon: "♫",
+    label: "SOUND CONTROLS",
   },
   {
     number: "03",
     title: "Your workflow, connected",
     text: "Send updates to Slack, Discord, Telegram, Teams and more. Configure webhooks for wherever you work.",
-    icon: "⌁",
+    label: "WEBHOOK INTEGRATIONS",
   },
 ];
 </script>
@@ -70,12 +70,8 @@ const features = [
           <NotificationPreview />
         </section>
       </div>
-      <div class="compatibility">
-        <span>BUILT FOR YOUR WORKFLOW</span
-        ><strong><AgentLogo agent="claude" /> Claude Code</strong
-        ><strong
-          ><AgentLogo agent="codex" /> Codex CLI <small>beta</small></strong
-        ><PlatformLogos />
+      <div class="compatibility" role="group" aria-label="Supported operating systems">
+        <PlatformLogos />
       </div>
       <InstallWizard />
       <section id="features" class="section anchor-offset">
@@ -87,10 +83,23 @@ const features = [
             :key="feature.number"
             class="panel feature"
           >
-            <div class="feature-top">
-              <span>{{ feature.number }}</span
-              ><b>{{ feature.icon }}</b>
+            <div class="feature-visual" aria-hidden="true">
+              <div v-if="feature.number === '01'" class="mini-notification">
+                <span class="signal-icon">✓</span>
+                <div><strong>Your agent is done</strong><span>Ready when you are.</span></div>
+                <span class="mini-now">now</span>
+              </div>
+              <div v-else-if="feature.number === '02'" class="sound-preview">
+                <div class="sound-wave"><i v-for="(height, index) in [12, 22, 36, 20, 46, 30, 54, 38, 24, 44, 28, 16, 32, 20, 10]" :key="index" :style="{ height: height + 'px' }" /></div>
+                <span>Your sound. Your volume.</span>
+              </div>
+              <div v-else class="channel-preview">
+                <span class="channel-source">Agent event</span>
+                <span class="channel-line" />
+                <div class="channel-tags"><span>Slack</span><span>Discord</span><span>Telegram</span><span>Teams</span></div>
+              </div>
             </div>
+            <div class="feature-top"><span>{{ feature.label }}</span></div>
             <h3>{{ feature.title }}</h3>
             <p>{{ feature.text }}</p>
           </article>
@@ -101,20 +110,22 @@ const features = [
         </p>
       </section>
       <section id="faq" class="section faq anchor-offset">
-        <div>
+        <div class="faq-header">
           <p class="eyebrow">A FEW THINGS TO KNOW</p>
-          <h2>Before you<br />get back to work</h2>
+          <h2>Frequently asked questions</h2>
+          <p>Everything you need to get back to work.</p>
         </div>
+        <div class="faq-content">
         <div class="faq-list">
           <details>
-            <summary>Do I need both agents installed?</summary>
+            <summary><span class="faq-icon" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M8 3v3m8-3v3M5 6h14v14H5zM9 11h.01M15 11h.01M9 16h6" /></svg></span><span>Do I need both agents installed?</span><span class="faq-chevron" aria-hidden="true"></span></summary>
             <p>
               No. Select Claude Code, Codex CLI, or both. Install the selected
               agent CLI first; the command installs this notification plugin.
             </p>
           </details>
           <details>
-            <summary>Are Codex hooks installed automatically?</summary>
+            <summary><span class="faq-icon" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M8 4H4v6h4m8 4h4v6h-4M4 7h10a4 4 0 0 1 4 4v3M6 10v3a4 4 0 0 0 4 4h10" /></svg></span><span>Are Codex hooks installed automatically?</span><span class="faq-chevron" aria-hidden="true"></span></summary>
             <p>
               Yes. The installer registers the hooks and saves a stable runtime
               copy. Open <code>/hooks</code> in Codex to review and trust them.
@@ -122,7 +133,7 @@ const features = [
             </p>
           </details>
           <details>
-            <summary>Will an update reset my settings?</summary>
+            <summary><span class="faq-icon" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M20 7v5h-5M4 17v-5h5M6 7a7 7 0 0 1 12-1l2 6M4 12l2 6a7 7 0 0 0 12-1" /></svg></span><span>Will an update reset my settings?</span><span class="faq-chevron" aria-hidden="true"></span></summary>
             <p>
               The installer preserves your shared configuration and foreign
               Codex hooks. Install and update use the same command. Restart the
@@ -130,7 +141,7 @@ const features = [
             </p>
           </details>
           <details>
-            <summary>Can I choose what makes a sound?</summary>
+            <summary><span class="faq-icon" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M4 9h4l5-4v14l-5-4H4zM16 8a6 6 0 0 1 0 8M19 5a10 10 0 0 1 0 14" /></svg></span><span>Can I choose what makes a sound?</span><span class="faq-chevron" aria-hidden="true"></span></summary>
             <p>
               Yes. Configure sounds, volume, audio device and notification
               channels. Choose Configure in the guide for the steps specific to
@@ -138,7 +149,7 @@ const features = [
             </p>
           </details>
           <details>
-            <summary>Does click-to-focus work everywhere?</summary>
+            <summary><span class="faq-icon" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M4 4h16v12H4zM8 20h8m-4-4v4" /></svg></span><span>Does click-to-focus work everywhere?</span><span class="faq-chevron" aria-hidden="true"></span></summary>
             <p>
               Support varies by OS and terminal. iTerm2 needs its Python API for
               precise tab targeting. Windows focuses a window, not an exact tab.
@@ -148,7 +159,7 @@ const features = [
             </p>
           </details>
           <details>
-            <summary>What if I don't get a notification?</summary>
+            <summary><span class="faq-icon" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M9 9a3 3 0 1 1 5 2c-2 1-2 2-2 3m0 3h.01M22 12a10 10 0 1 1-20 0 10 10 0 0 1 20 0" /></svg></span><span>What if I don't get a notification?</span><span class="faq-chevron" aria-hidden="true"></span></summary>
             <p>
               Check your OS notification permissions and chosen channels. For
               Codex, confirm the hooks are trusted.
@@ -156,6 +167,8 @@ const features = [
               for platform-specific checks.
             </p>
           </details>
+        </div>
+        <div class="faq-decoration" aria-hidden="true"><span class="faq-ring" /><span class="faq-ring" /><span class="faq-ring" /><span class="faq-orb">?</span></div>
         </div>
       </section>
       <section class="closing">

--- a/landing/assets/main.css
+++ b/landing/assets/main.css
@@ -221,27 +221,10 @@ h1 em {
 }
 .compatibility {
   width: 100%;
-  margin: 0;
   display: flex;
-  justify-content: space-between;
+  justify-content: center;
   align-items: center;
-  gap: 20px;
-  border: 0;
-  padding: 14px 34px;
-}
-.compatibility > span {
-  font-size: 9px;
-  letter-spacing: 1.5px;
-  color: #7f8eaa;
-}
-.compatibility strong {
-  font-size: 17px;
-  font-weight: 500;
-}
-.compatibility small {
-  font-size: 9px;
-  color: #b699df;
-  margin-left: 5px;
+  padding: 20px 24px;
 }
 .section {
   max-width: 1260px;
@@ -263,31 +246,115 @@ h1 em {
   border-radius: 16px;
 }
 .feature {
-  padding: 28px;
+  padding: 24px;
+  overflow: hidden;
+}
+.feature-visual {
+  height: 150px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: -24px -24px 24px;
+  padding: 20px;
+  background: radial-gradient(ellipse at center, #72dce610, transparent 75%);
+  border-bottom: 1px solid #ffffff08;
 }
 .feature-top {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 38px;
+  margin-bottom: 12px;
 }
 .feature-top span {
-  font:
-    10px ui-monospace,
-    monospace;
-  color: #74839f;
-}
-.feature-top b {
-  font-size: 28px;
+  font: 10px ui-monospace, monospace;
+  letter-spacing: 1.2px;
   color: #87dce6;
-  font-weight: 400;
 }
 .feature h3 {
-  font-size: 18px;
+  font-size: 19px;
+  margin: 0 0 12px;
 }
 .feature p {
-  font-size: 13px;
-  margin-bottom: 0;
+  font-size: 14px;
+  margin: 0;
+}
+.mini-notification {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 16px;
+  border: 1px solid #ffffff18;
+  border-radius: 14px;
+  background: #1a2030;
+  box-shadow: 0 12px 28px #0003;
+  width: 100%;
+  max-width: 300px;
+}
+.signal-icon {
+  display: grid;
+  place-items: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 10px;
+  background: #87dce618;
+  color: #87dce6;
+  flex-shrink: 0;
+}
+.mini-notification strong {
+  display: block;
+  font-size: 12px;
+}
+.mini-notification div > span, .mini-now {
+  color: #9daac1;
+  font-size: 10px;
+}
+.mini-now {
+  align-self: flex-start;
+  margin-left: auto;
+}
+.sound-preview {
+  text-align: center;
+}
+.sound-wave {
+  height: 65px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 5px;
+}
+.sound-wave i {
+  width: 5px;
+  border-radius: 4px;
+  background: linear-gradient(#87dce6, #a58ad9);
+}
+.sound-preview > span {
+  font-size: 11px;
+  color: #9daac1;
+}
+.channel-preview {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  max-width: 300px;
+}
+.channel-source, .channel-tags span {
+  padding: 9px 11px;
+  border-radius: 8px;
+  border: 1px solid #87dce62a;
+  background: #151c29;
+  font-size: 10px;
+  white-space: nowrap;
+}
+.channel-source {
+  color: #87dce6;
+}
+.channel-line {
+  height: 1px;
+  min-width: 16px;
+  flex: 1;
+  background: #87dce655;
+}
+.channel-tags {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 7px;
 }
 .feature-foot {
   font-size: 11px;
@@ -409,23 +476,147 @@ textarea {
   padding: 3px 5px;
   border-radius: 4px;
 }
-.faq {
+.faq-header {
+  text-align: center;
+  margin-bottom: 48px;
+}
+.faq-header h2 {
+  background: linear-gradient(120deg, #e0e6ff 30%, #87dce6);
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+.faq-header > p:last-child {
+  font-size: 16px;
+  margin-top: 16px;
+}
+.faq-content {
   display: grid;
-  grid-template-columns: 0.8fr 1.2fr;
-  gap: 65px;
+  grid-template-columns: minmax(0, 1fr) 280px;
+  gap: 56px;
+  align-items: center;
+}
+.faq-list {
+  display: grid;
+  gap: 12px;
+  min-width: 0;
 }
 .faq details {
-  border-bottom: 1px solid var(--line);
-  padding: 20px 0;
+  border: 1px solid #87dce617;
+  border-radius: 16px;
+  background: #0b0e16cc;
+  overflow: hidden;
+  transition: border-color .2s, box-shadow .2s;
+}
+.faq details:hover, .faq details[open] {
+  border-color: #87dce63d;
+  box-shadow: 0 8px 32px #00f0ff08;
 }
 .faq summary {
   cursor: pointer;
-  font-size: 14px;
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 20px 24px;
+  font-size: 15px;
+  font-weight: 600;
   line-height: 1.5;
+  list-style: none;
+}
+.faq summary::-webkit-details-marker {
+  display: none;
+}
+.faq summary:focus-visible {
+  outline: 2px solid #87dce6;
+  outline-offset: -4px;
+  border-radius: 16px;
+}
+.faq-icon {
+  width: 42px;
+  height: 42px;
+  flex-shrink: 0;
+  display: grid;
+  place-items: center;
+  border-radius: 12px;
+  background: linear-gradient(135deg, #00f0ff15, #ff00ff10);
+  border: 1px solid #87dce620;
+  color: #87dce6;
+}
+.faq-icon svg {
+  width: 22px;
+  height: 22px;
+}
+.faq-chevron {
+  width: 8px;
+  height: 8px;
+  border-right: 1.5px solid #9daac1;
+  border-bottom: 1.5px solid #9daac1;
+  transform: rotate(45deg);
+  margin-left: auto;
+  flex-shrink: 0;
+  transition: transform .2s;
+}
+.faq details[open] .faq-chevron {
+  transform: rotate(225deg);
 }
 .faq details p {
-  font-size: 13px;
-  margin: 14px 0 0;
+  font-size: 14px;
+  line-height: 1.75;
+  margin: 0;
+  padding: 0 24px 22px 82px;
+}
+.faq-decoration {
+  position: relative;
+  height: 280px;
+  display: grid;
+  place-items: center;
+}
+.faq-ring {
+  position: absolute;
+  width: 148px;
+  height: 148px;
+  border: 1px solid #87dce618;
+  border-radius: 50%;
+}
+.faq-ring:nth-child(2) {
+  width: 200px;
+  height: 200px;
+}
+.faq-ring:nth-child(3) {
+  width: 256px;
+  height: 256px;
+}
+.faq-orb {
+  width: 100px;
+  height: 100px;
+  display: grid;
+  place-items: center;
+  border-radius: 50%;
+  border: 1px solid #87dce638;
+  background: linear-gradient(135deg, #00f0ff15, #ff00ff15);
+  color: #87dce6;
+  font-size: 40px;
+}
+@media (max-width: 960px) {
+  .faq-content {
+    grid-template-columns: 1fr;
+  }
+  .faq-decoration {
+    display: none;
+  }
+}
+@media (max-width: 600px) {
+  .faq summary {
+    padding: 16px;
+    gap: 12px;
+    font-size: 14px;
+  }
+  .faq details p {
+    padding: 0 16px 20px;
+  }
+  .faq-icon {
+    width: 36px;
+    height: 36px;
+  }
 }
 .closing {
   text-align: center;
@@ -480,31 +671,8 @@ footer .brand {
     width: 100%;
     margin: 0 auto;
   }
-  .compatibility {
-    margin: 0;
-    padding-inline: 28px;
-    flex-wrap: wrap;
-  }
-  .compatibility .platforms {
-    display: none;
-  }
   .feature-grid {
     grid-template-columns: 1fr;
-  }
-  .feature {
-    display: grid;
-    grid-template-columns: 45px 1fr;
-    column-gap: 20px;
-  }
-  .feature-top {
-    grid-row: span 2;
-    flex-direction: column;
-    justify-content: flex-start;
-    gap: 20px;
-    margin: 0;
-  }
-  .feature h3 {
-    margin-bottom: 10px;
   }
   .faq {
     gap: 30px;
@@ -593,18 +761,6 @@ footer .brand {
   .preview-label {
     left: 10px;
   }
-  .compatibility {
-    margin: 0;
-    padding-inline: 22px;
-    gap: 15px;
-  }
-  .compatibility > span:first-child {
-    width: 100%;
-    font-size: 8px;
-  }
-  .compatibility strong {
-    font-size: 14px;
-  }
   .section {
     padding: 60px 22px 0;
   }
@@ -669,11 +825,6 @@ footer .brand {
 .agent-logo {
   object-fit: contain;
   flex-shrink: 0;
-}
-.compatibility strong {
-  display: inline-flex;
-  align-items: center;
-  gap: 9px;
 }
 .notification-preview {
   width: 100%;
@@ -1237,24 +1388,92 @@ footer .brand {
 
 /* Give the headline priority over the illustrative notification stack. */
 @media (min-width: 901px) {
-  .hero { grid-template-columns: minmax(0, 1.8fr) minmax(0, 1fr); }
-  h1 { font-size: clamp(44px, 4.25vw, 60px); }
+.hero {
+  grid-template-columns: minmax(0, 1.8fr) minmax(0, 1fr);
 }
-.notification-preview { justify-self: center; max-width: 427.5px; }
-.notification-stack { gap: 9px; min-height: 300px; }
-.notification-card { min-height: 87px; padding: 13.5px; gap: 10.5px; border-radius: 16.5px; }
-.notification-card .agent-logo { width: 36px; height: 36px; }
-.notification-copy, .notification-copy p { font-size: 12px; line-height: 1.35; }
-.notification-title { gap: 4px; }
-.notification-title h3 { font-size: 13.5px; letter-spacing: -.1px; }
-.notification-title > span { font-size: 10.5px; }
-.notification-copy p, .notification-detail { margin-top: 2px; }
-.preview-heading { letter-spacing: 1px; font-size: 8px; }
-.install-command-line { position: relative; padding-right: 60px; }
-.copy-icon { position: absolute; top: 10px; right: 10px; display: grid; place-items: center; width: 36px; height: 36px; padding: 0; border: 1px solid #34435a; border-radius: 7px; background: #141c29; color: #b9d9ec; }
-.copy-icon:hover { background: #223249; color: #8ff5ff; }
-@media (min-width: 561px) and (max-width: 900px) { h1 { font-size: clamp(36px, 5.6vw, 50px); } }
+h1 {
+  font-size: clamp(44px, 4.25vw, 60px);
+}
+}
+.notification-preview {
+  justify-self: center;
+  max-width: 427.5px;
+}
+.notification-stack {
+  gap: 9px;
+  min-height: 300px;
+}
+.notification-card {
+  min-height: 87px;
+  padding: 13.5px;
+  gap: 10.5px;
+  border-radius: 16.5px;
+}
+.notification-card .agent-logo {
+  width: 36px;
+  height: 36px;
+}
+.notification-copy, .notification-copy p {
+  font-size: 12px;
+  line-height: 1.35;
+}
+.notification-title {
+  gap: 4px;
+}
+.notification-title h3 {
+  font-size: 13.5px;
+  letter-spacing: -.1px;
+}
+.notification-title > span {
+  font-size: 10.5px;
+}
+.notification-copy p, .notification-detail {
+  margin-top: 2px;
+}
+.preview-heading {
+  letter-spacing: 1px;
+  font-size: 8px;
+}
+.install-command-line {
+  position: relative;
+  padding-right: 60px;
+}
+.copy-icon {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  display: grid;
+  place-items: center;
+  width: 36px;
+  height: 36px;
+  padding: 0;
+  border: 1px solid #34435a;
+  border-radius: 7px;
+  background: #141c29;
+  color: #b9d9ec;
+}
+.copy-icon:hover {
+  background: #223249;
+  color: #8ff5ff;
+}
+@media (min-width: 561px) and (max-width: 900px) {
+  h1 {
+    font-size: clamp(36px, 5.6vw, 50px);
+  }
+}
 
-.platform-logos { display: inline-flex; align-items: center; gap: 22px; }
-.platform-logos img { object-fit: contain; filter: invert(85%); }
-@media (min-width: 1200px) { .notification-preview { width: 427.5px; max-width: none; } }
+.platform-logos {
+  display: inline-flex;
+  align-items: center;
+  gap: 22px;
+}
+.platform-logos img {
+  object-fit: contain;
+  filter: invert(85%);
+}
+@media (min-width: 1200px) {
+  .notification-preview {
+    width: 427.5px;
+    max-width: none;
+  }
+}


### PR DESCRIPTION
Refresh the feature cards with notification, audio and webhook illustrations. Restyle FAQ as expandable cards with icons and a decorative orbital graphic. Simplify the compatibility strip to centered macOS, Linux and Windows logos.

Validation: Nuxt typecheck passed. Desktop and 390px mobile layouts, OS logo alignment and FAQ expansion were checked in the browser. Independent static review found no regressions. GitHub Actions validates the production build and browser suite.