### PR TITLE
feat(native): add structured notification protocol

### DIFF
--- a/internal/notifier/nativeprotocol/envelope.go
+++ b/internal/notifier/nativeprotocol/envelope.go
@@ -1,0 +1,162 @@
+// Package nativeprotocol validates the versioned native helper replies.
+// It has no process, permission, notification, or legacy presentation effects.
+package nativeprotocol
+
+import (
+	"bytes"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"io"
+	"strings"
+	"unicode/utf8"
+)
+
+const MaxEnvelopeBytes = 16 * 1024
+
+// ErrInvalidEnvelope deliberately contains no caller text or native output.
+var ErrInvalidEnvelope = errors.New("invalid native protocol envelope")
+
+type Capabilities struct {
+	SchemaVersion                   int      `json:"schemaVersion"`
+	ProtocolVersions                []int    `json:"protocolVersions"`
+	ActionKinds                     []string `json:"actionKinds"`
+	ReceiptSupport                  bool     `json:"receiptSupport"`
+	Backend                         string   `json:"backend"`
+	ExplicitFeatureEnabledByDefault bool     `json:"explicitFeatureEnabledByDefault"`
+}
+
+func (c Capabilities) Supports(version int, action string) bool {
+	if !c.ReceiptSupport {
+		return false
+	}
+	for _, v := range c.ProtocolVersions {
+		if v != version {
+			continue
+		}
+		for _, a := range c.ActionKinds {
+			if a == action {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// DecodeCapabilities is only a codec. A trusted managed artifact fingerprint
+// must be verified before a caller launches a capabilities probe.
+func DecodeCapabilities(data []byte) (Capabilities, error) {
+	var c Capabilities
+	if decode(data, &c, "schemaVersion", "protocolVersions", "actionKinds", "receiptSupport", "backend", "explicitFeatureEnabledByDefault") != nil ||
+		c.SchemaVersion != 1 || c.Backend != "macos.usernotifications" ||
+		c.ExplicitFeatureEnabledByDefault || len(c.ProtocolVersions) == 0 || len(c.ActionKinds) == 0 {
+		return Capabilities{}, ErrInvalidEnvelope
+	}
+	versions := make(map[int]bool)
+	for _, v := range c.ProtocolVersions {
+		if v < 1 || versions[v] {
+			return Capabilities{}, ErrInvalidEnvelope
+		}
+		versions[v] = true
+	}
+	actions := make(map[string]bool)
+	for _, action := range c.ActionKinds {
+		if action == "" || len(action) > 64 || actions[action] {
+			return Capabilities{}, ErrInvalidEnvelope
+		}
+		for _, ch := range action {
+			if (ch < 'a' || ch > 'z') && (ch < '0' || ch > '9') && ch != '_' {
+				return Capabilities{}, ErrInvalidEnvelope
+			}
+		}
+		actions[action] = true
+	}
+	return c, nil
+}
+
+type Receipt struct {
+	SchemaVersion  int    `json:"schemaVersion"`
+	CorrelationID  string `json:"correlationID"`
+	Nonce          string `json:"nonce"`
+	NotificationID string `json:"notificationID"`
+	Status         string `json:"status"`
+	Reason         string `json:"reason"`
+	RetrySafe      bool   `json:"retrySafe"`
+}
+
+// DecodeReceipt requires the exact pending attempt's identity. Neither a
+// process exit code nor an uncorrelated receipt proves OS acceptance.
+func DecodeReceipt(data []byte, correlationID, nonce string) (Receipt, error) {
+	var r Receipt
+	if decode(data, &r, "schemaVersion", "correlationID", "nonce", "notificationID", "status", "reason", "retrySafe") != nil ||
+		r.SchemaVersion != 1 || !validUUID(correlationID) || !validUUID(nonce) || r.CorrelationID != correlationID ||
+		r.Nonce != nonce || r.NotificationID != correlationID || r.RetrySafe {
+		return Receipt{}, ErrInvalidEnvelope
+	}
+	switch r.Status {
+	case "submitted":
+		if r.Reason != "os_accepted" {
+			return Receipt{}, ErrInvalidEnvelope
+		}
+	case "unknown":
+		if r.Reason != "timeout" {
+			return Receipt{}, ErrInvalidEnvelope
+		}
+	case "rejected":
+		switch r.Reason {
+		case "malformed_request", "unsupported_version", "unsupported_action", "invalid_file", "expired", "activation_required", "permission_denied", "unsupported_notifier", "os_rejected":
+		default:
+			return Receipt{}, ErrInvalidEnvelope
+		}
+	default:
+		return Receipt{}, ErrInvalidEnvelope
+	}
+	return r, nil
+}
+
+func validUUID(value string) bool {
+	if len(value) != 36 || value[8] != '-' || value[13] != '-' || value[18] != '-' || value[23] != '-' {
+		return false
+	}
+	decoded, err := hex.DecodeString(strings.ReplaceAll(value, "-", ""))
+	return err == nil && len(decoded) == 16
+}
+
+// Native v1 replies are flat objects whose values are scalar or scalar arrays.
+// Check duplicate/missing/null fields before Go's permissive struct decoder.
+func decode(data []byte, dst any, fields ...string) error {
+	if len(data) == 0 || len(data) > MaxEnvelopeBytes || !utf8.Valid(data) {
+		return ErrInvalidEnvelope
+	}
+	d := json.NewDecoder(bytes.NewReader(data))
+	t, err := d.Token()
+	if err != nil || t != json.Delim('{') {
+		return ErrInvalidEnvelope
+	}
+	remaining := make(map[string]bool, len(fields))
+	for _, f := range fields {
+		remaining[f] = true
+	}
+	for d.More() {
+		t, err = d.Token()
+		key, ok := t.(string)
+		if err != nil || !ok || !remaining[key] {
+			return ErrInvalidEnvelope
+		}
+		delete(remaining, key)
+		var raw json.RawMessage
+		if d.Decode(&raw) != nil || bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
+			return ErrInvalidEnvelope
+		}
+	}
+	if t, err = d.Token(); err != nil || t != json.Delim('}') || len(remaining) != 0 {
+		return ErrInvalidEnvelope
+	}
+	if _, err = d.Token(); err != io.EOF {
+		return ErrInvalidEnvelope
+	}
+	if json.Unmarshal(data, dst) != nil {
+		return ErrInvalidEnvelope
+	}
+	return nil
+}

--- a/internal/notifier/nativeprotocol/envelope_test.go
+++ b/internal/notifier/nativeprotocol/envelope_test.go
@@ -1,0 +1,89 @@
+package nativeprotocol
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const capabilityFixture = `{"schemaVersion":1,"protocolVersions":[1],"actionKinds":["none"],"receiptSupport":true,"backend":"macos.usernotifications","explicitFeatureEnabledByDefault":false}`
+const receiptFixture = `{"schemaVersion":1,"correlationID":"00000000-0000-4000-8000-000000000001","nonce":"00000000-0000-4000-8000-000000000002","notificationID":"00000000-0000-4000-8000-000000000001","status":"submitted","reason":"os_accepted","retrySafe":false}`
+
+func TestSharedSwiftProtocolFixtures(t *testing.T) {
+	read := func(name string) []byte {
+		t.Helper()
+		data, err := os.ReadFile(filepath.Join("..", "..", "..", "swift-notifier", "Tests", "Fixtures", name))
+		if err != nil {
+			t.Fatal(err)
+		}
+		return data
+	}
+	if c, err := DecodeCapabilities(read("native-v1.capabilities.json")); err != nil || !c.Supports(1, "none") {
+		t.Fatalf("Swift capability contract mismatch: %v", err)
+	}
+	if _, err := DecodeReceipt(read("native-v1.receipt.json"), "00000000-0000-4000-8000-000000000001", "00000000-0000-4000-8000-000000000002"); err != nil {
+		t.Fatalf("Swift receipt contract mismatch: %v", err)
+	}
+}
+
+func TestCapabilitiesNegotiateOnlyAdvertisedProtocolAndAction(t *testing.T) {
+	c, err := DecodeCapabilities([]byte(capabilityFixture))
+	if err != nil || !c.Supports(1, "none") || c.Supports(2, "none") || c.Supports(1, "desktop_thread_v1") {
+		t.Fatalf("unexpected capabilities: %+v, %v", c, err)
+	}
+	for _, input := range []string{
+		"", "Usage: native helper", capabilityFixture + "{}",
+		strings.Replace(capabilityFixture, `"schemaVersion":1`, `"schemaVersion":2`, 1),
+		strings.Replace(capabilityFixture, `"schemaVersion":1`, `"schemaVersion":1,"schema\u0056ersion":1`, 1),
+		strings.Replace(capabilityFixture, `"actionKinds":["none"]`, `"actionKinds":["none","none"]`, 1),
+		strings.Replace(capabilityFixture, `"actionKinds":["none"]`, `"actionKinds":[null]`, 1),
+		strings.Replace(capabilityFixture, `"receiptSupport":true`, `"receiptSupport":null`, 1),
+		strings.Replace(capabilityFixture, `,"explicitFeatureEnabledByDefault":false`, "", 1),
+		strings.Replace(capabilityFixture, `"explicitFeatureEnabledByDefault":false`, `"explicitFeatureEnabledByDefault":true`, 1),
+		strings.Replace(capabilityFixture, `"backend":`, `"extra":1,"backend":`, 1),
+		strings.Repeat(" ", MaxEnvelopeBytes) + capabilityFixture,
+	} {
+		if _, err := DecodeCapabilities([]byte(input)); !errors.Is(err, ErrInvalidEnvelope) {
+			t.Errorf("invalid capability reply accepted (length %d)", len(input))
+		}
+	}
+}
+
+func TestReceiptRequiresAttemptCorrelationAndConsistentOutcome(t *testing.T) {
+	if r, err := DecodeReceipt([]byte(receiptFixture), "00000000-0000-4000-8000-000000000001", "00000000-0000-4000-8000-000000000002"); err != nil || r.Status != "submitted" {
+		t.Fatalf("valid receipt rejected: %+v, %v", r, err)
+	}
+	for _, ids := range [][2]string{{"attempt-b", "00000000-0000-4000-8000-000000000002"}, {"00000000-0000-4000-8000-000000000001", "nonce-b"}, {"", ""}} {
+		if _, err := DecodeReceipt([]byte(receiptFixture), ids[0], ids[1]); err == nil {
+			t.Error("wrong attempt identity accepted")
+		}
+	}
+	for _, change := range []struct {
+		field string
+		value any
+	}{
+		{"notificationID", "attempt-b"}, {"status", "unknown"}, {"status", "suppressed"},
+		{"reason", "timeout"}, {"retrySafe", true}, {"retrySafe", nil},
+		{"schemaVersion", 2}, {"body", "private text must not appear in errors"},
+	} {
+		var raw map[string]any
+		if err := json.Unmarshal([]byte(receiptFixture), &raw); err != nil {
+			t.Fatal(err)
+		}
+		raw[change.field] = change.value
+		data, err := json.Marshal(raw)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err = DecodeReceipt(data, "00000000-0000-4000-8000-000000000001", "00000000-0000-4000-8000-000000000002"); !errors.Is(err, ErrInvalidEnvelope) {
+			t.Errorf("accepted inconsistent receipt field %s", change.field)
+		}
+	}
+	unknown := strings.Replace(strings.Replace(receiptFixture, `"submitted"`, `"unknown"`, 1), `"os_accepted"`, `"timeout"`, 1)
+	if r, err := DecodeReceipt([]byte(unknown), "00000000-0000-4000-8000-000000000001", "00000000-0000-4000-8000-000000000002"); err != nil || r.RetrySafe {
+		t.Fatal("unknown must remain an explicit non-retryable outcome")
+	}
+}

--- a/scripts/native-protocol-smoke.py
+++ b/scripts/native-protocol-smoke.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""No-notification subprocess qualification of a newly built standalone helper.
+
+Never pass an installed/unknown notifier. A caller-supplied exact build hash is
+required, and .app executables are refused. No LaunchServices marker is sent,
+so valid structured requests stop before AppKit/UN initialization.
+"""
+import argparse
+import hashlib
+import json
+from pathlib import Path
+import subprocess
+import tempfile
+import uuid
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--binary", type=Path, required=True)
+    parser.add_argument("--expected-sha256", required=True)
+    args = parser.parse_args()
+    binary = args.binary.resolve(strict=True)
+    if any(part.endswith(".app") for part in binary.parts):
+        parser.error("use the standalone test build, not an app installation")
+    digest = hashlib.sha256(binary.read_bytes()).hexdigest()
+    if digest != args.expected_sha256:
+        parser.error("test binary fingerprint mismatch")
+    checks = []
+
+    def invoke(arguments):
+        return subprocess.run([str(binary), *arguments], capture_output=True,
+                              timeout=3, check=False)
+
+    cap = invoke(["--capabilities-json"])
+    assert cap.returncode == 0 and cap.stderr == b""
+    capabilities = json.loads(cap.stdout)
+    assert capabilities["schemaVersion"] == 1
+    assert capabilities["actionKinds"] == ["none"]
+    assert capabilities["receiptSupport"] is True
+    checks.append("standalone capabilities without permission or app launch")
+
+    help_result = invoke(["--help"])
+    assert help_result.returncode == 0 and b"Usage:" in help_result.stdout
+    for field in ["-title", "-message", "-subtitle"]:
+        for literal in ["--help", "--capabilities-json", "--send-json"]:
+            arguments = ["-title", "title", "-message", "body", field, literal]
+            result = invoke(arguments)
+            assert result.returncode != 0 and result.stdout == b""
+            assert b"LaunchServices" in result.stderr
+    checks.append("option-looking legacy text never chooses help or protocol mode")
+
+    with tempfile.TemporaryDirectory(prefix="native-protocol-smoke-") as scratch:
+        root = Path(scratch).resolve(strict=True)
+
+        def request(changes):
+            correlation, nonce = str(uuid.uuid4()), str(uuid.uuid4())
+            directory = root / correlation
+            directory.mkdir(mode=0o700)
+            request_file = directory / (nonce + ".request")
+            receipt_file = directory / (nonce + ".receipt")
+            payload = dict(schemaVersion=1, correlationID=correlation, nonce=nonce,
+                           bootID="test-boot", notAfter=10, title="--help",
+                           body="literal", category="info", action="none", silent=True)
+            payload.update(changes)
+            request_file.write_text(json.dumps(payload))
+            request_file.chmod(0o600)
+            return request_file, receipt_file, correlation, nonce
+
+        def submit(request_file, receipt_file):
+            return invoke(["--send-json", "--request-file", str(request_file),
+                           "--receipt-file", str(receipt_file)])
+
+        for changes, reason in [({"schemaVersion": 999}, "unsupported_version"),
+                                ({"action": "execute"}, "unsupported_action"),
+                                ({"body": "\0"}, "malformed_request"),
+                                ({}, "unsupported_notifier"),
+                                ({"title": "👩‍💻", "body": "می\u200cروم"}, "unsupported_notifier")]:
+            request_file, receipt_file, correlation, nonce = request(changes)
+            result = submit(request_file, receipt_file)
+            assert result.returncode == 0 and result.stdout == result.stderr == b""
+            raw = receipt_file.read_bytes()
+            receipt = json.loads(raw)
+            assert receipt["correlationID"] == correlation and receipt["nonce"] == nonce
+            assert receipt["notificationID"] == correlation
+            assert receipt["status"] == "rejected" and receipt["reason"] == reason
+            assert receipt["retrySafe"] is False
+            assert not request_file.exists()
+            assert submit(request_file, receipt_file).returncode != 0
+            assert receipt_file.read_bytes() == raw
+            checks.append("correlated " + reason + ", duplicate launch cannot overwrite")
+
+        request_file, receipt_file, _, _ = request({})
+        original = request_file.read_bytes()
+        target = request_file.with_name("target")
+        request_file.rename(target)
+        request_file.symlink_to(target)
+        assert submit(request_file, receipt_file).returncode == 0
+        assert json.loads(receipt_file.read_bytes())["reason"] == "invalid_file"
+        assert target.read_bytes() == original
+        checks.append("symlink payload rejected without altering target")
+
+    print(json.dumps({"binarySHA256": digest, "status": "passed", "checks": checks,
+                      "notificationsSent": 0, "scope": "standalone native boundary"}, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/swift-notifier/PROTOCOL.md
+++ b/swift-notifier/PROTOCOL.md
@@ -1,0 +1,104 @@
+# Native protocol v1 (PR1, inactive by default)
+
+This is the native foundation only. No installer, hook or feature enablement is
+changed. New actions support only `none`; legacy CLI and persisted ClickAction
+activate/execute/combined data continue to use their existing decoder. PR3 must
+add its typed action and capability together; it must not repurpose legacy shell
+actions or claim Codex navigation in PR1.
+
+`--capabilities-json` must be the entire argv. It emits one JSON object plus LF,
+without creating NSApplication, UNUserNotificationCenter, a delegate, permission
+probe, sound or callback executor. It declares versions `[1]`, actions `["none"]`,
+receipt support and backend `macos.usernotifications`; this is protocol support,
+not authorization or a claim that a banner will appear. Future caller must verify
+the offline managed artifact fingerprint/protocol floor first, then run a private
+direct probe with a one-second deadline. Never probe an unknown/old binary.
+
+Structured invocation (through LaunchServices, fresh instance):
+
+```
+--send-json --request-file /private/.../<correlation UUID>/<nonce UUID>.request --receipt-file /private/.../<correlation UUID>/<nonce UUID>.receipt -launchedViaLaunchServices
+```
+
+Paths must be absolute and free of symlink components (on macOS canonicalize
+`/tmp` to `/private/tmp`, `/var` to `/private/var`). Resolve the trusted spool
+root using `realpath` / Go `filepath.EvalSymlinks` before creating the attempt;
+Foundation `resolvingSymlinksInPath` can retain the `/var` alias. The native
+reader still rejects symlink components instead of resolving request paths.
+The caller exclusively owns a fresh 0700 directory and
+0600 regular request file, both owned by effective UID. Names are never reused.
+Files are bounded to 16 KiB before allocation and decoding, locked nonblocking,
+read through pinned directory descriptors, and consumed once before any effect.
+An exclusive empty `<nonce>.claim` marker gives only one native instance receipt
+ownership, including after body consumption. A competing or abandoned claim
+exits without publishing a false rejection while another instance may submit.
+The marker stays with the attempt for caller cleanup; it is not a replay journal.
+Symlinks, hardlinks, special files, permissive modes and existing receipts fail
+closed. File ownership isolates other users; it does not authenticate a caller
+against malicious same-UID processes. The copied body is removed after reading;
+invalid oversized/unowned files are left to the caller, never submitted.
+
+Required request keys: schemaVersion (integer 1), correlationID (directory UUID),
+nonce (filename UUID), bootID (`kern.bootsessionuuid`), notAfter (seconds from
+`mach_continuous_time` converted with mach_timebase_info), title, body, category
+(`info|attention|progress`), action (`none`), silent (boolean). Optional subtitle
+is a single-line string or null. No unknown or duplicate keys, invalid UTF-8 or
+unpaired surrogate escapes. UTF-8 limits: title/subtitle 256 bytes, body 4096;
+Unicode control scalars (general category Cc, including NUL/ESC) are rejected
+except LF/TAB in body. Format scalars (Cf), including ZWJ/ZWNJ and emoji tags,
+are preserved without stripping or normalization. The Go producer must use
+the same policy (`unicode.IsControl`, not the broader Cf category).
+Text is never truncated.
+Title/subtitle reject Unicode line separators as well. All text is literal.
+Category does not enable time-sensitive interruption.
+
+The sender inherits the original admission deadline, including validation,
+locks, launches and sleep, with at most 15 seconds remaining. Boot mismatch,
+expiry or a larger budget rejects before permission lookup. Permission is read
+without requesting authorization; undetermined means activation_required, denied
+means permission_denied. Deadline is rechecked after lookup and completion. A
+serialized owner ignores repeated/late callbacks. Only positive UN `add`
+completion yields submitted; OS error yields rejected, deadline after handoff
+unknown. Timeout before handoff is rejected/expired. No retry, fallback or bell.
+
+Receipt keys: schemaVersion=1, correlationID, nonce, notificationID (same as
+correlationID), status, reason, retrySafe=false. Atomic exclusive publication
+never overwrites another receipt or recreates a removed directory. Receipt has
+no title/body. Structured send stdout is empty; exit 0 means a receipt was
+written, not that delivery succeeded. Missing/invalid/mismatched receipt after
+handoff means unknown. Invalid argv or unsafe directory cannot safely receive a
+receipt and exit 1. The consumer must validate version, correlation, nonce and
+status/reason, not just exit code. Suppressed is reserved for the future policy
+layer and not emitted by native.
+
+| Reason | Native status | Meaning |
+| --- | --- | --- |
+| malformed_request | rejected | JSON, fields, limits or correlation invalid |
+| unsupported_version | rejected | unsupported schema |
+| unsupported_action | rejected | action unavailable (including PR3 target) |
+| invalid_file | rejected | unsafe/missing/bounded file read failed |
+| expired | rejected | boot/deadline invalid or elapsed before handoff |
+| activation_required | rejected | permission undetermined; setup needed |
+| permission_denied | rejected | permission denied |
+| unsupported_notifier | rejected | bundle/LaunchServices/boot clock unavailable |
+| os_rejected | rejected | negative OS completion |
+| os_accepted | submitted | positive OS completion, not banner/read/click |
+| timeout | unknown | handoff could have occurred; never automatically retry |
+
+The caller's future spool/admission owner must impose total byte/count limits,
+retain attempts while LaunchServices may still launch, clean its expired orphans
+with a bounded scan on notify/status/setup, and remove directories only after
+terminal receipt plus sender exit, or original deadline under its ownership
+protocol. PR1 creates no spool or request files and implements no journal,
+installer, global cleanup scan or daemon. This per-attempt native reader neither
+recreates a missing attempt nor depends on the caller's cwd. There is no promise
+of cleanup at a fixed time after every owner has crashed. These caller gates are
+required before activating a producer in later PRs.
+
+Tests are pure codecs/parser/state-machine spies and isolated filesystem tests.
+Eight legacy action fixtures characterize current source behavior, including
+its intentional ignoring of extra schemaVersion; they are reconstructed here,
+not copied from inaccessible historical spike artifacts. Run the complete Swift
+suite on macOS. Linux source review cannot qualify AppKit/UN or macOS filesystem
+APIs. Native permission, delayed LaunchServices, sleep, atomic receipt, old
+artifact rejection and installed UI behavior remain macOS integration gates.

--- a/swift-notifier/Sources/terminal-notifier-modern/CLI/ArgumentParser.swift
+++ b/swift-notifier/Sources/terminal-notifier-modern/CLI/ArgumentParser.swift
@@ -139,7 +139,23 @@ enum ArgumentParser {
         )
     }
 
+    // Consume values before classifying options. A value is literal even when it
+    // happens to be another flag (including the LaunchServices marker).
+    static func optionPositions(_ arguments: [String]) -> [String] {
+        let valued: Set<String> = ["-title", "-message", "-subtitle", "-activate",
+                                   "-execute", "-group", "-threadID",
+                                   "--request-file", "--receipt-file"]
+        var options: [String] = []
+        var i = 0
+        while i < arguments.count {
+            let value = arguments[i]
+            options.append(value)
+            i += valued.contains(value) ? 2 : 1
+        }
+        return options
+    }
+
     static func isSendMode(_ arguments: [String]) -> Bool {
-        return arguments.contains("-title")
+        return optionPositions(arguments).contains("-title")
     }
 }

--- a/swift-notifier/Sources/terminal-notifier-modern/Protocol/NativeProtocol.swift
+++ b/swift-notifier/Sources/terminal-notifier-modern/Protocol/NativeProtocol.swift
@@ -1,0 +1,227 @@
+import Foundation
+
+// Separate from legacy ClickAction: new send cannot manufacture shell actions.
+// PR3 can add a versioned typed action without changing the legacy decoder.
+enum NativeAction: String, Codable { case none }
+enum NativeStatus: String, Codable { case rejected, suppressed, submitted, unknown }
+enum NativeReason: String, Codable, Error {
+    case malformed_request, unsupported_version, unsupported_action, invalid_file
+    case expired, activation_required, permission_denied, unsupported_notifier
+    case os_rejected, os_accepted, timeout
+}
+
+struct NativeRequest: Codable {
+    let schemaVersion: Int
+    let correlationID: String
+    let nonce: String
+    let bootID: String
+    let notAfter: Double // mach_continuous_time converted to seconds; includes sleep
+    let title: String
+    let body: String
+    let subtitle: String?
+    let category: Category
+    let action: NativeAction
+    let silent: Bool
+    enum Category: String, Codable { case info, attention, progress }
+}
+
+struct NativeReceipt: Codable {
+    let schemaVersion: Int
+    let correlationID: String
+    let nonce: String
+    let notificationID: String
+    let status: NativeStatus
+    let reason: NativeReason
+    let retrySafe: Bool
+
+    init(correlationID: String, nonce: String, status: NativeStatus, reason: NativeReason) {
+        schemaVersion = 1
+        self.correlationID = correlationID
+        self.nonce = nonce
+        notificationID = correlationID
+        self.status = status
+        self.reason = reason
+        retrySafe = false // native does not own replay admission
+    }
+}
+
+struct NativeCapabilities: Codable, Equatable {
+    let schemaVersion: Int
+    let protocolVersions: [Int]
+    let actionKinds: [String]
+    let receiptSupport: Bool
+    let backend: String
+    let explicitFeatureEnabledByDefault: Bool
+
+    init() {
+        schemaVersion = 1
+        protocolVersions = [1]
+        actionKinds = ["none"]
+        receiptSupport = true
+        backend = "macos.usernotifications"
+        explicitFeatureEnabledByDefault = false
+    }
+}
+
+enum NativeCodec {
+    static let maxBytes = 16 * 1024
+
+    static func text(_ value: String, limit: Int, multiline: Bool = false) throws {
+        guard value.utf8.count <= limit,
+              value.unicodeScalars.allSatisfy({ scalar in
+                  // Foundation's controlCharacters also includes format (Cf),
+                  // such as emoji ZWJ and Persian ZWNJ. Preserve literal format
+                  // scalars; reject actual control (Cc) except body LF/TAB.
+                  scalar.properties.generalCategory != .control ||
+                  (multiline && (scalar.value == 10 || scalar.value == 9))
+              }), multiline || !value.unicodeScalars.contains(where: {
+                  CharacterSet.newlines.contains($0)
+              }) else { throw NativeReason.malformed_request }
+    }
+
+    static func decodeRequest(_ data: Data) throws -> NativeRequest {
+        let object = try StrictJSON.object(data)
+        let keys: Set<String> = ["schemaVersion", "correlationID", "nonce", "bootID",
+                                  "notAfter", "title", "body", "subtitle", "category", "action", "silent"]
+        guard Set(object.keys).isSubset(of: keys) else { throw NativeReason.malformed_request }
+        guard let version = object["schemaVersion"] as? NSNumber,
+              CFGetTypeID(version) != CFBooleanGetTypeID(), version.doubleValue == 1 else {
+            throw NativeReason.unsupported_version
+        }
+        guard object["action"] as? String == "none" else { throw NativeReason.unsupported_action }
+        let request: NativeRequest
+        do { request = try JSONDecoder().decode(NativeRequest.self, from: data) }
+        catch { throw NativeReason.malformed_request }
+        guard UUID(uuidString: request.correlationID) != nil,
+              UUID(uuidString: request.nonce) != nil,
+              !request.bootID.isEmpty, request.bootID.utf8.count <= 256,
+              request.notAfter.isFinite, request.notAfter > 0 else { throw NativeReason.malformed_request }
+        try text(request.title, limit: 256)
+        try text(request.body, limit: 4096, multiline: true)
+        if let subtitle = request.subtitle { try text(subtitle, limit: 256) }
+        return request
+    }
+
+    static func decodeCapabilities(_ data: Data) throws -> NativeCapabilities {
+        let object = try StrictJSON.object(data)
+        let expected = try StrictJSON.object(JSONEncoder().encode(NativeCapabilities()))
+        guard Set(object.keys) == Set(expected.keys),
+              let decoded = try? JSONDecoder().decode(NativeCapabilities.self, from: data),
+              decoded == NativeCapabilities() else {
+            throw NativeReason.unsupported_version
+        }
+        return NativeCapabilities()
+    }
+
+    static func decodeReceipt(_ data: Data, correlationID: String, nonce: String) throws -> NativeReceipt {
+        let object = try StrictJSON.object(data)
+        guard Set(object.keys) == Set(["schemaVersion", "correlationID", "nonce", "notificationID",
+                                      "status", "reason", "retrySafe"]) else { throw NativeReason.malformed_request }
+        let receipt: NativeReceipt
+        do { receipt = try JSONDecoder().decode(NativeReceipt.self, from: data) }
+        catch { throw NativeReason.malformed_request }
+        guard receipt.schemaVersion == 1 else { throw NativeReason.unsupported_version }
+        guard UUID(uuidString: correlationID) != nil, UUID(uuidString: nonce) != nil,
+              receipt.correlationID == correlationID, receipt.nonce == nonce,
+              receipt.notificationID == correlationID, !receipt.retrySafe,
+              ((receipt.status == .submitted && receipt.reason == .os_accepted) ||
+               (receipt.status == .unknown && receipt.reason == .timeout) ||
+               (receipt.status == .rejected && receipt.reason != .os_accepted && receipt.reason != .timeout)) else { throw NativeReason.malformed_request }
+        return receipt
+    }
+}
+
+import CoreFoundation
+
+// Foundation decoders may accept duplicate keys. Walk the bounded JSON syntax
+// before decoding, comparing decoded keys (including escaped spellings).
+private struct StrictJSON {
+    var bytes: [UInt8]
+    var i = 0
+    static func object(_ data: Data) throws -> [String: Any] {
+        guard data.count <= NativeCodec.maxBytes, String(data: data, encoding: .utf8) != nil else {
+            throw NativeReason.malformed_request
+        }
+        var scanner = StrictJSON(bytes: Array(data))
+        try scanner.value(depth: 0)
+        scanner.space()
+        guard scanner.i == scanner.bytes.count,
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw NativeReason.malformed_request
+        }
+        return object
+    }
+    mutating func space() { while i < bytes.count && [9, 10, 13, 32].contains(bytes[i]) { i += 1 } }
+    mutating func take(_ byte: UInt8) throws {
+        space()
+        guard i < bytes.count, bytes[i] == byte else { throw NativeReason.malformed_request }
+        i += 1
+    }
+    mutating func string() throws -> String {
+        space()
+        let start = i
+        try take(34)
+        while i < bytes.count {
+            let byte = bytes[i]; i += 1
+            if byte == 34 {
+                let data = Data(bytes[start..<i])
+                guard let result = try? JSONSerialization.jsonObject(with: data, options: .fragmentsAllowed) as? String else {
+                    throw NativeReason.malformed_request
+                }
+                return result
+            }
+            if byte == 92 {
+                guard i < bytes.count else { throw NativeReason.malformed_request }
+                if bytes[i] == 117 {
+                    i += 1
+                    let unit = try hexUnit()
+                    if (0xD800...0xDBFF).contains(unit) {
+                        guard i + 2 <= bytes.count, bytes[i] == 92, bytes[i + 1] == 117 else {
+                            throw NativeReason.malformed_request
+                        }
+                        i += 2
+                        guard (0xDC00...0xDFFF).contains(try hexUnit()) else { throw NativeReason.malformed_request }
+                    } else if (0xDC00...0xDFFF).contains(unit) { throw NativeReason.malformed_request }
+                } else { i += 1 }
+            }
+        }
+        throw NativeReason.malformed_request
+    }
+    mutating func hexUnit() throws -> UInt16 {
+        guard i + 4 <= bytes.count,
+              let value = UInt16(String(decoding: bytes[i..<i+4], as: UTF8.self), radix: 16) else {
+            throw NativeReason.malformed_request
+        }
+        i += 4
+        return value
+    }
+    mutating func value(depth: Int) throws {
+        space()
+        guard depth < 16, i < bytes.count else { throw NativeReason.malformed_request }
+        switch bytes[i] {
+        case 123:
+            i += 1; space()
+            if i < bytes.count && bytes[i] == 125 { i += 1; return }
+            var keys = Set<String>()
+            while true {
+                guard keys.insert(try string()).inserted else { throw NativeReason.malformed_request }
+                try take(58); try value(depth: depth + 1); space()
+                if i < bytes.count && bytes[i] == 125 { i += 1; return }
+                try take(44)
+            }
+        case 91:
+            i += 1; space()
+            if i < bytes.count && bytes[i] == 93 { i += 1; return }
+            while true {
+                try value(depth: depth + 1); space()
+                if i < bytes.count && bytes[i] == 93 { i += 1; return }
+                try take(44)
+            }
+        case 34: _ = try string()
+        default:
+            let start = i
+            while i < bytes.count && ![9, 10, 13, 32, 44, 93, 125].contains(bytes[i]) { i += 1 }
+            guard i > start else { throw NativeReason.malformed_request }
+        }
+    }
+}

--- a/swift-notifier/Sources/terminal-notifier-modern/Protocol/OwnedRequest.swift
+++ b/swift-notifier/Sources/terminal-notifier-modern/Protocol/OwnedRequest.swift
@@ -1,0 +1,112 @@
+import Foundation
+import Darwin
+
+// Caller creates a fresh 0700 UUID directory and 0600 nonce.request file.
+// Descriptor-relative operations pin the owned directory, never follow symlinks,
+// never recreate it, and never overwrite an existing terminal receipt.
+final class OwnedRequest {
+    let correlationID: String
+    let nonce: String
+    private let directory: Int32
+    private let requestName: String
+    private let receiptName: String
+    private var attempted = false
+    private var ownsReceipt = false
+
+    init(requestPath: String, receiptPath: String) throws {
+        let request = URL(fileURLWithPath: requestPath)
+        let receipt = URL(fileURLWithPath: receiptPath)
+        let parent = request.deletingLastPathComponent()
+        correlationID = parent.lastPathComponent
+        nonce = request.deletingPathExtension().lastPathComponent
+        requestName = request.lastPathComponent
+        receiptName = receipt.lastPathComponent
+        guard requestPath.hasPrefix("/"), receiptPath.hasPrefix("/"),
+              parent.path == receipt.deletingLastPathComponent().path,
+              UUID(uuidString: correlationID) != nil, UUID(uuidString: nonce) != nil,
+              requestName == nonce + ".request", receiptName == nonce + ".receipt" else {
+            throw NativeReason.invalid_file
+        }
+        // Walk all components with O_NOFOLLOW, including ancestors.
+        var fd = open("/", O_RDONLY | O_DIRECTORY | O_CLOEXEC)
+        guard fd >= 0 else { throw NativeReason.invalid_file }
+        for component in parent.pathComponents.dropFirst() {
+            let next = openat(fd, component, O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC)
+            close(fd)
+            guard next >= 0 else { throw NativeReason.invalid_file }
+            fd = next
+        }
+        var metadata = stat()
+        guard fstat(fd, &metadata) == 0, metadata.st_uid == geteuid(),
+              metadata.st_mode & 0o7777 == 0o700 else {
+            close(fd); throw NativeReason.invalid_file
+        }
+        directory = fd
+    }
+    deinit { close(directory) }
+
+    func consume() throws -> Data {
+        guard !attempted else { throw NativeReason.invalid_file }
+        attempted = true
+        var existing = stat()
+        guard fstatat(directory, receiptName, &existing, AT_SYMLINK_NOFOLLOW) != 0,
+              errno == ENOENT else { throw NativeReason.invalid_file }
+        // A second LaunchServices instance must not publish a rejected receipt
+        // while the first instance is submitting. This exclusive attempt marker
+        // survives body consumption and stays until the caller cleans the attempt.
+        // It is not a replay journal: an abandoned claim remains unknown.
+        let claim = openat(directory, nonce + ".claim",
+                           O_WRONLY | O_CREAT | O_EXCL | O_NOFOLLOW | O_CLOEXEC, 0o600)
+        guard claim >= 0 else { throw NativeReason.invalid_file }
+        close(claim)
+        ownsReceipt = true
+        let fd = openat(directory, requestName, O_RDONLY | O_NOFOLLOW | O_NONBLOCK | O_CLOEXEC)
+        guard fd >= 0 else { throw NativeReason.invalid_file }
+        defer { close(fd) }
+        var metadata = stat()
+        guard flock(fd, LOCK_EX | LOCK_NB) == 0, fstat(fd, &metadata) == 0,
+              metadata.st_mode & S_IFMT == S_IFREG, metadata.st_mode & 0o7777 == 0o600,
+              metadata.st_uid == geteuid(), metadata.st_nlink == 1,
+              metadata.st_size > 0, metadata.st_size <= NativeCodec.maxBytes else {
+            throw NativeReason.invalid_file
+        }
+        var bytes = [UInt8](repeating: 0, count: NativeCodec.maxBytes + 1)
+        var count = 0
+        while count < bytes.count {
+            let n = bytes.withUnsafeMutableBytes { buffer in
+                read(fd, buffer.baseAddress!.advanced(by: count), buffer.count - count)
+            }
+            if n == 0 { break }
+            if n < 0 { if errno == EINTR { continue }; throw NativeReason.invalid_file }
+            count += n
+        }
+        guard count == metadata.st_size, count <= NativeCodec.maxBytes else { throw NativeReason.invalid_file }
+        // Delete only after the full bounded copy, while holding the claim.
+        guard unlinkat(directory, requestName, 0) == 0 else { throw NativeReason.invalid_file }
+        return Data(bytes.prefix(count))
+    }
+
+    func write(_ receipt: NativeReceipt) throws {
+        guard ownsReceipt, receipt.correlationID == correlationID, receipt.nonce == nonce else {
+            throw NativeReason.invalid_file
+        }
+        let data = try JSONEncoder().encode(receipt)
+        let temporary = nonce + "." + UUID().uuidString + ".tmp"
+        let fd = openat(directory, temporary, O_WRONLY | O_CREAT | O_EXCL | O_NOFOLLOW | O_CLOEXEC, 0o600)
+        guard fd >= 0 else { throw NativeReason.invalid_file }
+        defer { close(fd); unlinkat(directory, temporary, 0) }
+        try data.withUnsafeBytes { buffer in
+            var offset = 0
+            while offset < buffer.count {
+                let n = Darwin.write(fd, buffer.baseAddress!.advanced(by: offset), buffer.count - offset)
+                if n < 0 && errno == EINTR { continue }
+                guard n > 0 else { throw NativeReason.invalid_file }
+                offset += n
+            }
+        }
+        guard fsync(fd) == 0,
+              linkat(directory, temporary, directory, receiptName, 0) == 0 else {
+            throw NativeReason.invalid_file
+        }
+    }
+}

--- a/swift-notifier/Sources/terminal-notifier-modern/Protocol/StructuredDelivery.swift
+++ b/swift-notifier/Sources/terminal-notifier-modern/Protocol/StructuredDelivery.swift
@@ -1,0 +1,67 @@
+import Foundation
+
+enum NativePermission { case allowed, denied, undetermined }
+protocol NativeBackend {
+    func permission(_ completion: @escaping (NativePermission) -> Void)
+    func add(_ request: NativeRequest, completion: @escaping (Bool) -> Void)
+}
+
+// All callbacks, including timeout(), must be serialized by the owner. No OS
+// calls occur until validation; timeout after handoff is never a safe retry.
+final class StructuredDelivery {
+    private let backend: NativeBackend
+    private let now: () -> Double
+    private let bootID: String
+    private let emit: (NativeReceipt) -> Void
+    private var request: NativeRequest?
+    private var handedOff = false
+    private var finished = false
+
+    init(backend: NativeBackend, bootID: String, now: @escaping () -> Double,
+         emit: @escaping (NativeReceipt) -> Void) {
+        self.backend = backend; self.bootID = bootID; self.now = now; self.emit = emit
+    }
+
+    func start(data: Data, correlationID: String, nonce: String) {
+        guard request == nil, !finished else { return }
+        do {
+            let parsed = try NativeCodec.decodeRequest(data)
+            guard parsed.correlationID == correlationID, parsed.nonce == nonce else {
+                throw NativeReason.malformed_request
+            }
+            request = parsed
+            guard validDeadline(parsed) else { finish(.rejected, .expired); return }
+            backend.permission { [self] permission in
+                guard !finished, !handedOff else { return }
+                guard validDeadline(parsed) else { finish(.rejected, .expired); return }
+                switch permission {
+                case .denied: finish(.rejected, .permission_denied)
+                case .undetermined: finish(.rejected, .activation_required)
+                case .allowed:
+                    handedOff = true
+                    backend.add(parsed) { [self] accepted in
+                        guard !finished else { return }
+                        guard validDeadline(parsed) else { finish(.unknown, .timeout); return }
+                        finish(accepted ? .submitted : .rejected, accepted ? .os_accepted : .os_rejected)
+                    }
+                }
+            }
+        } catch {
+            finished = true
+            emit(NativeReceipt(correlationID: correlationID, nonce: nonce, status: .rejected,
+                               reason: (error as? NativeReason) ?? .malformed_request))
+        }
+    }
+
+    func timeout() { finish(handedOff ? .unknown : .rejected, handedOff ? .timeout : .expired) }
+    private func validDeadline(_ request: NativeRequest) -> Bool {
+        let remaining = request.notAfter - now()
+        return request.bootID == bootID && remaining > 0 && remaining <= 15
+    }
+    private func finish(_ status: NativeStatus, _ reason: NativeReason) {
+        guard !finished, let request = request else { return }
+        finished = true
+        emit(NativeReceipt(correlationID: request.correlationID, nonce: request.nonce,
+                           status: status, reason: reason))
+    }
+}

--- a/swift-notifier/Sources/terminal-notifier-modern/Protocol/StructuredRuntime.swift
+++ b/swift-notifier/Sources/terminal-notifier-modern/Protocol/StructuredRuntime.swift
@@ -1,0 +1,115 @@
+import AppKit
+import Darwin
+import UserNotifications
+
+private enum ContinuousClock {
+    static func now() -> Double {
+        var info = mach_timebase_info_data_t()
+        mach_timebase_info(&info)
+        return Double(mach_continuous_time()) * Double(info.numer) / Double(info.denom) / 1_000_000_000
+    }
+    static func bootID() -> String? {
+        var size = 0
+        guard sysctlbyname("kern.bootsessionuuid", nil, &size, nil, 0) == 0, size > 1, size <= 256 else { return nil }
+        var bytes = [CChar](repeating: 0, count: size)
+        guard sysctlbyname("kern.bootsessionuuid", &bytes, &size, nil, 0) == 0 else { return nil }
+        return String(cString: bytes)
+    }
+}
+
+private final class StructuredUNBackend: NativeBackend {
+    private let center = UNUserNotificationCenter.current()
+    func permission(_ completion: @escaping (NativePermission) -> Void) {
+        center.getNotificationSettings { settings in
+            DispatchQueue.main.async {
+                switch settings.authorizationStatus {
+                case .authorized, .provisional: completion(.allowed)
+                case .notDetermined: completion(.undetermined)
+                default: completion(.denied)
+                }
+            }
+        }
+    }
+    func add(_ request: NativeRequest, completion: @escaping (Bool) -> Void) {
+        let content = UNMutableNotificationContent()
+        content.title = request.title
+        content.body = request.body
+        content.subtitle = request.subtitle ?? ""
+        content.sound = request.silent ? nil : .default
+        // PR1 supports no navigation. No legacy action, shell, category or route.
+        center.add(UNNotificationRequest(identifier: request.correlationID, content: content, trigger: nil)) { error in
+            DispatchQueue.main.async { completion(error == nil) }
+        }
+    }
+}
+
+enum StructuredRuntime {
+    static func capabilities(arguments: [String]) -> Never {
+        guard arguments == ["--capabilities-json"],
+              let data = try? JSONEncoder().encode(NativeCapabilities()) else { exit(1) }
+        FileHandle.standardOutput.write(data)
+        FileHandle.standardOutput.write(Data([10]))
+        exit(0)
+    }
+
+    static func send(arguments: [String]) -> Never {
+        // Fixed grammar: no data-bearing argument can select another mode.
+        var paths: [String: String] = [:]
+        var i = 0
+        var sendCount = 0
+        var launchCount = 0
+        while i < arguments.count {
+            switch arguments[i] {
+            case "--send-json": sendCount += 1
+            case "-launchedViaLaunchServices": launchCount += 1
+            case "--request-file", "--receipt-file":
+                let key = arguments[i]
+                guard i + 1 < arguments.count, paths[key] == nil else { exit(1) }
+                i += 1; paths[key] = arguments[i]
+            default: exit(1)
+            }
+            i += 1
+        }
+        guard sendCount == 1, launchCount <= 1,
+              let requestPath = paths["--request-file"], let receiptPath = paths["--receipt-file"],
+              let files = try? OwnedRequest(requestPath: requestPath, receiptPath: receiptPath) else { exit(1) }
+        func emit(_ receipt: NativeReceipt) -> Never {
+            do { try files.write(receipt); exit(0) }
+            catch { exit(1) } // no receipt is an unknown handoff, never a retry signal
+        }
+        let data: Data
+        do { data = try files.consume() }
+        catch { emit(NativeReceipt(correlationID: files.correlationID, nonce: files.nonce,
+                                  status: .rejected, reason: .invalid_file)) }
+        // Validate before initializing AppKit / UN (including bundle guard).
+        let request: NativeRequest
+        do {
+            request = try NativeCodec.decodeRequest(data)
+            guard request.correlationID == files.correlationID, request.nonce == files.nonce else {
+                throw NativeReason.malformed_request
+            }
+        } catch {
+            emit(NativeReceipt(correlationID: files.correlationID, nonce: files.nonce,
+                               status: .rejected, reason: (error as? NativeReason) ?? .malformed_request))
+        }
+        guard launchCount == 1, Bundle.main.bundleIdentifier != nil,
+              Bundle.main.bundleURL.pathExtension == "app", let boot = ContinuousClock.bootID() else {
+            emit(NativeReceipt(correlationID: files.correlationID, nonce: files.nonce,
+                               status: .rejected, reason: .unsupported_notifier))
+        }
+        let app = NSApplication.shared
+        app.setActivationPolicy(.accessory)
+        let delivery = StructuredDelivery(backend: StructuredUNBackend(), bootID: boot,
+                                          now: ContinuousClock.now, emit: { emit($0) })
+        // Short polling also catches suspend: continuous clock, not a fresh launch budget.
+        let timer = Timer(timeInterval: 0.05, repeats: true) { _ in
+            if ContinuousClock.now() >= request.notAfter {
+                delivery.timeout()
+            }
+        }
+        RunLoop.main.add(timer, forMode: .common)
+        DispatchQueue.main.async { delivery.start(data: data, correlationID: files.correlationID, nonce: files.nonce) }
+        withExtendedLifetime(delivery) { app.run() }
+        exit(1)
+    }
+}

--- a/swift-notifier/Sources/terminal-notifier-modern/main.swift
+++ b/swift-notifier/Sources/terminal-notifier-modern/main.swift
@@ -7,7 +7,13 @@ private let notificationTimeoutSeconds = 10.0
 
 let arguments = Array(CommandLine.arguments.dropFirst())
 
-if arguments.contains("-help") || arguments.contains("--help") {
+let options = ArgumentParser.optionPositions(arguments)
+
+if options.contains("--capabilities-json") {
+    StructuredRuntime.capabilities(arguments: arguments)
+} else if options.contains("--send-json") {
+    StructuredRuntime.send(arguments: arguments)
+} else if options.contains("-help") || options.contains("--help") {
     print("Usage: terminal-notifier-modern -title <title> -message <message> [options]")
     print("")
     print("  -title          Notification title (required)")
@@ -37,7 +43,7 @@ func runSendMode(arguments: [String]) {
         return
     }
 
-    guard arguments.contains(launchServicesMarker) else {
+    guard ArgumentParser.optionPositions(arguments).contains(launchServicesMarker) else {
         failAndExit("ClaudeNotifier must be launched via LaunchServices (use 'open -W -n ClaudeNotifier.app --args ...')")
         return
     }

--- a/swift-notifier/Tests/Fixtures/legacy-actions.json
+++ b/swift-notifier/Tests/Fixtures/legacy-actions.json
@@ -1,0 +1,10 @@
+[
+  {"json":"{\"type\":\"none\"}","valid":true},
+  {"json":"{\"type\":\"activate\",\"value\":\"com.apple.Terminal\"}","valid":true},
+  {"json":"{\"type\":\"execute\",\"value\":\"echo '--help'\"}","valid":true},
+  {"json":"{\"type\":\"executeAndActivate\",\"value\":\"echo test\",\"bundleID\":\"com.apple.Terminal\"}","valid":true},
+  {"json":"{\"type\":\"unknown\"}","valid":false},
+  {"json":"{\"type\":\"activate\"}","valid":false},
+  {"json":"{\"type\":\"executeAndActivate\",\"value\":\"echo test\"}","valid":false},
+  {"json":"{\"schemaVersion\":999,\"type\":\"none\"}","valid":true}
+]

--- a/swift-notifier/Tests/Fixtures/native-v1.capabilities.json
+++ b/swift-notifier/Tests/Fixtures/native-v1.capabilities.json
@@ -1,0 +1,12 @@
+{
+  "schemaVersion": 1,
+  "protocolVersions": [
+    1
+  ],
+  "actionKinds": [
+    "none"
+  ],
+  "receiptSupport": true,
+  "backend": "macos.usernotifications",
+  "explicitFeatureEnabledByDefault": false
+}

--- a/swift-notifier/Tests/Fixtures/native-v1.receipt.json
+++ b/swift-notifier/Tests/Fixtures/native-v1.receipt.json
@@ -1,0 +1,9 @@
+{
+  "schemaVersion": 1,
+  "correlationID": "00000000-0000-4000-8000-000000000001",
+  "nonce": "00000000-0000-4000-8000-000000000002",
+  "notificationID": "00000000-0000-4000-8000-000000000001",
+  "status": "submitted",
+  "reason": "os_accepted",
+  "retrySafe": false
+}

--- a/swift-notifier/Tests/Fixtures/native-v1.request.json
+++ b/swift-notifier/Tests/Fixtures/native-v1.request.json
@@ -1,0 +1,13 @@
+{
+  "schemaVersion": 1,
+  "correlationID": "00000000-0000-4000-8000-000000000001",
+  "nonce": "00000000-0000-4000-8000-000000000002",
+  "bootID": "fixture-only",
+  "notAfter": 110,
+  "title": "--help",
+  "body": "-launchedViaLaunchServices",
+  "subtitle": "-title",
+  "category": "info",
+  "action": "none",
+  "silent": true
+}

--- a/swift-notifier/Tests/Fixtures/native-v1.schema.json
+++ b/swift-notifier/Tests/Fixtures/native-v1.schema.json
@@ -1,0 +1,211 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Native PR1 protocol",
+  "description": "Choose a $defs schema. Runtime also checks UTF-8 byte limits, duplicates, controls, boot deadline and filename correlation. Entire wire request <=16384 bytes.",
+  "$defs": {
+    "request": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schemaVersion",
+        "correlationID",
+        "nonce",
+        "bootID",
+        "notAfter",
+        "title",
+        "body",
+        "category",
+        "action",
+        "silent"
+      ],
+      "properties": {
+        "schemaVersion": {
+          "const": 1
+        },
+        "correlationID": {
+          "type": "string",
+          "format": "uuid",
+          "maxLength": 36
+        },
+        "nonce": {
+          "type": "string",
+          "format": "uuid",
+          "maxLength": 36
+        },
+        "bootID": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 256
+        },
+        "notAfter": {
+          "type": "number",
+          "exclusiveMinimum": 0
+        },
+        "title": {
+          "type": "string",
+          "description": "Single line; max 256 UTF-8 bytes; no controls."
+        },
+        "body": {
+          "type": "string",
+          "description": "Max 4096 UTF-8 bytes; no controls except LF and TAB."
+        },
+        "subtitle": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Single line; max 256 UTF-8 bytes; no controls."
+        },
+        "category": {
+          "enum": [
+            "info",
+            "attention",
+            "progress"
+          ]
+        },
+        "action": {
+          "const": "none"
+        },
+        "silent": {
+          "type": "boolean"
+        }
+      }
+    },
+    "receipt": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schemaVersion",
+        "correlationID",
+        "nonce",
+        "notificationID",
+        "status",
+        "reason",
+        "retrySafe"
+      ],
+      "properties": {
+        "schemaVersion": {
+          "const": 1
+        },
+        "correlationID": {
+          "type": "string",
+          "format": "uuid",
+          "maxLength": 36
+        },
+        "nonce": {
+          "type": "string",
+          "format": "uuid",
+          "maxLength": 36
+        },
+        "notificationID": {
+          "type": "string",
+          "format": "uuid",
+          "maxLength": 36
+        },
+        "status": {
+          "enum": [
+            "rejected",
+            "submitted",
+            "unknown"
+          ]
+        },
+        "reason": {
+          "enum": [
+            "malformed_request",
+            "unsupported_version",
+            "unsupported_action",
+            "invalid_file",
+            "expired",
+            "activation_required",
+            "permission_denied",
+            "unsupported_notifier",
+            "os_rejected",
+            "os_accepted",
+            "timeout"
+          ]
+        },
+        "retrySafe": {
+          "const": false
+        }
+      },
+      "oneOf": [
+        {
+          "properties": {
+            "status": {
+              "const": "rejected"
+            },
+            "reason": {
+              "enum": [
+                "malformed_request",
+                "unsupported_version",
+                "unsupported_action",
+                "invalid_file",
+                "expired",
+                "activation_required",
+                "permission_denied",
+                "unsupported_notifier",
+                "os_rejected"
+              ]
+            }
+          }
+        },
+        {
+          "properties": {
+            "status": {
+              "const": "submitted"
+            },
+            "reason": {
+              "const": "os_accepted"
+            }
+          }
+        },
+        {
+          "properties": {
+            "status": {
+              "const": "unknown"
+            },
+            "reason": {
+              "const": "timeout"
+            }
+          }
+        }
+      ]
+    },
+    "capabilities": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schemaVersion",
+        "protocolVersions",
+        "actionKinds",
+        "receiptSupport",
+        "backend",
+        "explicitFeatureEnabledByDefault"
+      ],
+      "properties": {
+        "schemaVersion": {
+          "const": 1
+        },
+        "protocolVersions": {
+          "const": [
+            1
+          ]
+        },
+        "actionKinds": {
+          "const": [
+            "none"
+          ]
+        },
+        "receiptSupport": {
+          "const": true
+        },
+        "backend": {
+          "const": "macos.usernotifications"
+        },
+        "explicitFeatureEnabledByDefault": {
+          "const": false
+        }
+      }
+    }
+  }
+}

--- a/swift-notifier/Tests/terminal-notifier-modernTests/ArgumentParserTests.swift
+++ b/swift-notifier/Tests/terminal-notifier-modernTests/ArgumentParserTests.swift
@@ -223,3 +223,23 @@ final class ArgumentParserTests: XCTestCase {
         }
     }
 }
+
+
+extension ArgumentParserTests {
+    func testOptionLookingValuesNeverSelectModes() throws {
+        let fields = ["-title", "-message", "-subtitle", "-activate", "-execute", "-group", "-threadID"]
+        for field in fields {
+            for literal in ["--help", "-help", "-title", "-launchedViaLaunchServices", "--capabilities-json", "--send-json"] {
+                let args = [field, literal]
+                XCTAssertEqual(ArgumentParser.optionPositions(args), [field])
+                XCTAssertEqual(ArgumentParser.isSendMode(args), field == "-title")
+                let config = try ArgumentParser.parse(["-title", "title", "-message", "body"] + args)
+                if field == "-title" { XCTAssertEqual(config.title, literal) }
+                if field == "-message" { XCTAssertEqual(config.message, literal) }
+                if field == "-subtitle" { XCTAssertEqual(config.subtitle, literal) }
+            }
+        }
+        XCTAssertEqual(ArgumentParser.optionPositions(["-title", "--help", "--help"]), ["-title", "--help"])
+        XCTAssertEqual(ArgumentParser.optionPositions(["--request-file", "--capabilities-json", "--send-json"]), ["--request-file", "--send-json"])
+    }
+}

--- a/swift-notifier/Tests/terminal-notifier-modernTests/ClickActionTests.swift
+++ b/swift-notifier/Tests/terminal-notifier-modernTests/ClickActionTests.swift
@@ -97,3 +97,20 @@ final class ClickActionTests: XCTestCase {
         XCTAssertEqual(decoded, action)
     }
 }
+
+extension ClickActionTests {
+    func testLegacyCompatibilityFixtures() throws {
+        struct Fixture: Decodable { let json: String; let valid: Bool }
+        let url = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+            .deletingLastPathComponent().appendingPathComponent("Fixtures/legacy-actions.json")
+        let fixtures = try JSONDecoder().decode([Fixture].self, from: Data(contentsOf: url))
+        XCTAssertEqual(fixtures.count, 8)
+        for fixture in fixtures {
+            let action = ClickAction.fromJSON(fixture.json)
+            XCTAssertEqual(action != nil, fixture.valid)
+            if let action = action {
+                XCTAssertEqual(ClickAction.fromJSON(try XCTUnwrap(action.toJSON())), action)
+            }
+        }
+    }
+}

--- a/swift-notifier/Tests/terminal-notifier-modernTests/NativeProtocolTests.swift
+++ b/swift-notifier/Tests/terminal-notifier-modernTests/NativeProtocolTests.swift
@@ -1,0 +1,173 @@
+import XCTest
+@testable import terminal_notifier_modern
+
+final class NativeProtocolTests: XCTestCase {
+    let correlation = "00000000-0000-4000-8000-000000000001"
+    let nonce = "00000000-0000-4000-8000-000000000002"
+    func payload(_ changes: [String: Any] = [:]) throws -> Data {
+        var object: [String: Any] = ["schemaVersion": 1, "correlationID": correlation,
+            "nonce": nonce, "bootID": "boot", "notAfter": 110.0, "title": "title",
+            "body": "body", "category": "info", "action": "none", "silent": true]
+        object.merge(changes) { _, new in new }
+        return try JSONSerialization.data(withJSONObject: object, options: .sortedKeys)
+    }
+    func testLiteralAndByteBoundaries() throws {
+        for literal in ["--help", "-help", "-title", "-launchedViaLaunchServices", "-execute", "[important]", "'\"$(echo data)"] {
+            let request = try NativeCodec.decodeRequest(payload(["title": literal, "body": literal, "subtitle": literal]))
+            XCTAssertEqual(request.title, literal)
+            XCTAssertEqual(request.body, literal)
+            XCTAssertEqual(request.subtitle, literal)
+        }
+        XCTAssertNoThrow(try NativeCodec.decodeRequest(payload(["title": String(repeating: "😀", count: 64), "body": String(repeating: "é", count: 2048)])))
+        XCTAssertThrowsError(try NativeCodec.decodeRequest(payload(["title": String(repeating: "😀", count: 65)])))
+        XCTAssertThrowsError(try NativeCodec.decodeRequest(payload(["body": String(repeating: "é", count: 2049)])))
+        XCTAssertNoThrow(try NativeCodec.decodeRequest(payload(["body": "line\nnext\tcolumn"])))
+        for value in ["line\nnext", "nul\0", "escape\u{1b}", "line\u{2028}next"] {
+            XCTAssertThrowsError(try NativeCodec.decodeRequest(payload(["title": value])))
+        }
+    }
+    func testJoinedUnicodeIsPreservedWithByteLimits() throws {
+        for value in ["👩‍💻", "👨‍👩‍👧‍👦", "می\u{200c}روم", "\u{1f3f4}\u{e0067}\u{e0062}\u{e007f}"] {
+            let request = try NativeCodec.decodeRequest(payload(["title": value, "body": value, "subtitle": value]))
+            XCTAssertEqual(Array(request.title.utf8), Array(value.utf8))
+            XCTAssertEqual(Array(request.body.utf8), Array(value.utf8))
+            XCTAssertEqual(Array(try XCTUnwrap(request.subtitle).utf8), Array(value.utf8))
+            for (field, limit) in [("title", 256), ("subtitle", 256), ("body", 4096)] {
+                let boundary = String(repeating: value, count: limit / value.utf8.count)
+                    + String(repeating: "x", count: limit % value.utf8.count)
+                XCTAssertNoThrow(try NativeCodec.decodeRequest(payload([field: boundary])))
+                XCTAssertThrowsError(try NativeCodec.decodeRequest(payload([field: boundary + "x"])))
+            }
+        }
+        for field in ["title", "body", "subtitle"] {
+            for control in ["\0", "\u{1b}", "\u{85}"] {
+                XCTAssertThrowsError(try NativeCodec.decodeRequest(payload([field: control])))
+            }
+        }
+        for field in ["title", "subtitle"] {
+            for linebreak in ["\n", "\r", "\u{2028}", "\u{2029}"] {
+                XCTAssertThrowsError(try NativeCodec.decodeRequest(payload([field: linebreak])))
+            }
+        }
+    }
+
+    func testStrictJSONAndVersions() throws {
+        let valid = try payload()
+        XCTAssertThrowsError(try NativeCodec.decodeRequest(Data([0xff])))
+        XCTAssertThrowsError(try NativeCodec.decodeRequest(Data(repeating: 32, count: 16385)))
+        for changes in [["schemaVersion": 999], ["schemaVersion": true], ["unknown": 1], ["action": "desktop_thread_v1"], ["action": "execute"], ["nonce": "bad"]] as [[String: Any]] {
+            XCTAssertThrowsError(try NativeCodec.decodeRequest(payload(changes)))
+        }
+        let json = String(decoding: valid, as: UTF8.self)
+        for prefix in [#""title":"duplicate","# , #""ti\u0074le":"duplicate","#] {
+            XCTAssertThrowsError(try NativeCodec.decodeRequest(Data(("{" + prefix + json.dropFirst()).utf8)))
+        }
+        for escape in [#"\uD800"#, #"\uDC00"#, #"\uD800\u0041"#] {
+            let malformed = json.replacingOccurrences(of: #""body":"body""#, with: "\"body\":\"" + escape + "\"")
+            XCTAssertThrowsError(try NativeCodec.decodeRequest(Data(malformed.utf8)))
+        }
+    }
+    func testReceiptCorrelationAndRoundtrip() throws {
+        let receipt = NativeReceipt(correlationID: correlation, nonce: nonce, status: .submitted, reason: .os_accepted)
+        let data = try JSONEncoder().encode(receipt)
+        XCTAssertEqual(try NativeCodec.decodeReceipt(data, correlationID: correlation, nonce: nonce).status, .submitted)
+        XCTAssertThrowsError(try NativeCodec.decodeReceipt(data, correlationID: nonce, nonce: nonce))
+        XCTAssertThrowsError(try NativeCodec.decodeReceipt(data, correlationID: correlation, nonce: correlation))
+        XCTAssertFalse(String(decoding: data, as: UTF8.self).contains("body"))
+    }
+    func testCapabilitiesArePureAndConservative() throws {
+        let data = try JSONEncoder().encode(NativeCapabilities())
+        XCTAssertNoThrow(try NativeCodec.decodeCapabilities(data))
+        XCTAssertThrowsError(try NativeCodec.decodeCapabilities(Data("{}".utf8)))
+        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        XCTAssertEqual(object["actionKinds"] as? [String], ["none"])
+        XCTAssertEqual(object["explicitFeatureEnabledByDefault"] as? Bool, false)
+    }
+    func testRepositoryWireFixtures() throws {
+        let root = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+            .deletingLastPathComponent().appendingPathComponent("Fixtures")
+        let request = try NativeCodec.decodeRequest(Data(contentsOf: root.appendingPathComponent("native-v1.request.json")))
+        XCTAssertEqual(request.title, "--help")
+        _ = try NativeCodec.decodeReceipt(Data(contentsOf: root.appendingPathComponent("native-v1.receipt.json")),
+                                           correlationID: request.correlationID, nonce: request.nonce)
+        _ = try NativeCodec.decodeCapabilities(Data(contentsOf: root.appendingPathComponent("native-v1.capabilities.json")))
+    }
+
+    final class Spy: NativeBackend {
+        var probes = 0
+        var sends = 0
+        var permissionCompletion: ((NativePermission) -> Void)?
+        var addCompletion: ((Bool) -> Void)?
+        func permission(_ completion: @escaping (NativePermission) -> Void) { probes += 1; permissionCompletion = completion }
+        func add(_ request: NativeRequest, completion: @escaping (Bool) -> Void) { sends += 1; addCompletion = completion }
+    }
+    func testInvalidInputHasNoEffects() throws {
+        for data in [Data("bad".utf8), try payload(["schemaVersion": 2]), try payload(["correlationID": nonce]), try payload(["body": "\0"])] {
+            let spy = Spy()
+            var receipts: [NativeReceipt] = []
+            let delivery = StructuredDelivery(backend: spy, bootID: "boot", now: { 100 }, emit: { receipts.append($0) })
+            delivery.start(data: data, correlationID: correlation, nonce: nonce)
+            XCTAssertEqual(spy.probes, 0)
+            XCTAssertEqual(spy.sends, 0)
+            XCTAssertEqual(receipts.count, 1)
+            XCTAssertEqual(receipts.first?.status, .rejected)
+        }
+    }
+    func testExpiredAndDifferentBootNeverProbe() throws {
+        for changes in [["notAfter": 99], ["notAfter": 116], ["bootID": "other"]] as [[String: Any]] {
+            let spy = Spy()
+            var receipts: [NativeReceipt] = []
+            let delivery = StructuredDelivery(backend: spy, bootID: "boot", now: { 100 }, emit: { receipts.append($0) })
+            delivery.start(data: try payload(changes), correlationID: correlation, nonce: nonce)
+            XCTAssertEqual(spy.probes, 0)
+            XCTAssertEqual(receipts.first?.reason, .expired)
+        }
+    }
+    func testPermissionAndDelayedProbe() throws {
+        for permission in [NativePermission.denied, .undetermined, .allowed] {
+            let spy = Spy()
+            var time = 100.0
+            var receipts: [NativeReceipt] = []
+            let delivery = StructuredDelivery(backend: spy, bootID: "boot", now: { time }, emit: { receipts.append($0) })
+            delivery.start(data: try payload(), correlationID: correlation, nonce: nonce)
+            if case .allowed = permission { time = 111 }
+            spy.permissionCompletion?(permission)
+            XCTAssertEqual(spy.sends, 0)
+            XCTAssertEqual(receipts.count, 1)
+            XCTAssertEqual(receipts.first?.status, .rejected)
+        }
+    }
+    func testPositiveCompletionOnlyAndTimeoutExactlyOnce() throws {
+        for timeout in [false, true] {
+            let spy = Spy()
+            var receipts: [NativeReceipt] = []
+            let delivery = StructuredDelivery(backend: spy, bootID: "boot", now: { 100 }, emit: { receipts.append($0) })
+            delivery.start(data: try payload(), correlationID: correlation, nonce: nonce)
+            spy.permissionCompletion?(.allowed)
+            spy.permissionCompletion?(.denied) // duplicate probe must not override an in-flight add
+            XCTAssertTrue(receipts.isEmpty)
+            XCTAssertEqual(spy.sends, 1)
+            if timeout { delivery.timeout() }
+            spy.addCompletion?(true)
+            spy.addCompletion?(false)
+            spy.permissionCompletion?(.allowed)
+            delivery.timeout()
+            XCTAssertEqual(spy.sends, 1)
+            XCTAssertEqual(receipts.count, 1)
+            XCTAssertEqual(receipts.first?.status, timeout ? .unknown : .submitted)
+        }
+    }
+    func testLateAckIsUnknownAndKnownFailureIsRejected() throws {
+        for late in [false, true] {
+            let spy = Spy()
+            var time = 100.0
+            var receipts: [NativeReceipt] = []
+            let delivery = StructuredDelivery(backend: spy, bootID: "boot", now: { time }, emit: { receipts.append($0) })
+            delivery.start(data: try payload(), correlationID: correlation, nonce: nonce)
+            spy.permissionCompletion?(.allowed)
+            if late { time = 111 }
+            spy.addCompletion?(late)
+            XCTAssertEqual(receipts.first?.status, late ? .unknown : .rejected)
+        }
+    }
+}

--- a/swift-notifier/Tests/terminal-notifier-modernTests/OwnedRequestTests.swift
+++ b/swift-notifier/Tests/terminal-notifier-modernTests/OwnedRequestTests.swift
@@ -1,0 +1,125 @@
+import XCTest
+import Darwin
+@testable import terminal_notifier_modern
+
+final class OwnedRequestTests: XCTestCase {
+    // Only disposable test files; no native backend, notifications or settings.
+    func fixture(_ test: (URL, String, OwnedRequest) throws -> Void) throws {
+        // Foundation preserves the /var alias on macOS. Use the physical
+        // directory required by the protocol, without relaxing O_NOFOLLOW.
+        let resolved = try XCTUnwrap(realpath(FileManager.default.temporaryDirectory.path, nil))
+        let physicalRoot = String(cString: resolved)
+        free(resolved)
+        let directory = URL(fileURLWithPath: physicalRoot)
+            .appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: false,
+                                                attributes: [.posixPermissions: 0o700])
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let nonce = UUID().uuidString
+        let files = try OwnedRequest(requestPath: directory.appendingPathComponent(nonce + ".request").path,
+                                     receiptPath: directory.appendingPathComponent(nonce + ".receipt").path)
+        try test(directory, nonce, files)
+    }
+    func body(_ directory: URL, _ nonce: String, data: Data, mode: Int = 0o600) throws -> URL {
+        let file = directory.appendingPathComponent(nonce + ".request")
+        XCTAssertTrue(FileManager.default.createFile(atPath: file.path, contents: data,
+                                                    attributes: [.posixPermissions: mode]))
+        return file
+    }
+    func testConsumeOnceAndAtomicReceiptNoOverwrite() throws {
+        try fixture { directory, nonce, files in
+            let file = try body(directory, nonce, data: Data("{}".utf8))
+            XCTAssertEqual(try files.consume(), Data("{}".utf8))
+            XCTAssertFalse(FileManager.default.fileExists(atPath: file.path))
+            XCTAssertThrowsError(try files.consume())
+            let receipt = NativeReceipt(correlationID: directory.lastPathComponent, nonce: nonce,
+                                        status: .rejected, reason: .expired)
+            try files.write(receipt)
+            XCTAssertThrowsError(try files.write(receipt))
+            let data = try Data(contentsOf: directory.appendingPathComponent(nonce + ".receipt"))
+            XCTAssertEqual(try NativeCodec.decodeReceipt(data, correlationID: directory.lastPathComponent, nonce: nonce).reason, .expired)
+        }
+    }
+    func testDuplicateReaderCannotPublishFalseRejection() throws {
+        try fixture { directory, nonce, first in
+            _ = try body(directory, nonce, data: Data("{}".utf8))
+            let second = try OwnedRequest(
+                requestPath: directory.appendingPathComponent(nonce + ".request").path,
+                receiptPath: directory.appendingPathComponent(nonce + ".receipt").path)
+            _ = try first.consume()
+            XCTAssertThrowsError(try second.consume())
+            XCTAssertThrowsError(try second.write(NativeReceipt(
+                correlationID: directory.lastPathComponent, nonce: nonce,
+                status: .rejected, reason: .invalid_file)))
+            XCTAssertFalse(FileManager.default.fileExists(
+                atPath: directory.appendingPathComponent(nonce + ".receipt").path))
+            try first.write(NativeReceipt(correlationID: directory.lastPathComponent,
+                nonce: nonce, status: .submitted, reason: .os_accepted))
+        }
+    }
+
+    func testAbandonedClaimCannotResubmitOrWriteReceipt() throws {
+        try fixture { directory, nonce, files in
+            _ = try body(directory, nonce, data: Data("{}".utf8))
+            XCTAssertTrue(FileManager.default.createFile(
+                atPath: directory.appendingPathComponent(nonce + ".claim").path,
+                contents: Data(), attributes: [.posixPermissions: 0o600]))
+            XCTAssertThrowsError(try files.consume())
+            XCTAssertThrowsError(try files.write(NativeReceipt(
+                correlationID: directory.lastPathComponent, nonce: nonce,
+                status: .rejected, reason: .invalid_file)))
+            XCTAssertTrue(FileManager.default.fileExists(
+                atPath: directory.appendingPathComponent(nonce + ".request").path))
+        }
+    }
+
+    func testUnsafeModeOversizeAndSymlink() throws {
+        for mode in [0o644, 0o660] {
+            try fixture { directory, nonce, files in
+                _ = try body(directory, nonce, data: Data("{}".utf8), mode: mode)
+                XCTAssertThrowsError(try files.consume())
+            }
+        }
+        try fixture { directory, nonce, files in
+            _ = try body(directory, nonce, data: Data(repeating: 65, count: 16385))
+            XCTAssertThrowsError(try files.consume())
+        }
+        try fixture { directory, nonce, files in
+            let target = directory.appendingPathComponent("target")
+            try Data("{}".utf8).write(to: target)
+            try FileManager.default.createSymbolicLink(at: directory.appendingPathComponent(nonce + ".request"), withDestinationURL: target)
+            XCTAssertThrowsError(try files.consume())
+            XCTAssertEqual(try Data(contentsOf: target), Data("{}".utf8))
+        }
+    }
+    func testParentSymlinkIsRejectedWithoutConsumingBody() throws {
+        try fixture { directory, nonce, _ in
+            let bodyURL = try body(directory, nonce, data: Data("{}".utf8))
+            let alias = directory.appendingPathComponent(UUID().uuidString)
+            try FileManager.default.createSymbolicLink(at: alias, withDestinationURL: directory)
+            XCTAssertThrowsError(try OwnedRequest(
+                requestPath: alias.appendingPathComponent(nonce + ".request").path,
+                receiptPath: alias.appendingPathComponent(nonce + ".receipt").path))
+            XCTAssertEqual(try Data(contentsOf: bodyURL), Data("{}".utf8))
+        }
+    }
+
+    func testHardlinkFIFOAndDeletedDirectory() throws {
+        try fixture { directory, nonce, files in
+            let file = try body(directory, nonce, data: Data("{}".utf8))
+            XCTAssertEqual(link(file.path, directory.appendingPathComponent("link").path), 0)
+            XCTAssertThrowsError(try files.consume())
+        }
+        try fixture { directory, nonce, files in
+            XCTAssertEqual(mkfifo(directory.appendingPathComponent(nonce + ".request").path, 0o600), 0)
+            XCTAssertThrowsError(try files.consume()) // O_NONBLOCK: never wait on a writer
+        }
+        try fixture { directory, nonce, files in
+            try FileManager.default.removeItem(at: directory)
+            XCTAssertThrowsError(try files.consume())
+            XCTAssertThrowsError(try files.write(NativeReceipt(correlationID: directory.lastPathComponent,
+                nonce: nonce, status: .unknown, reason: .timeout)))
+            XCTAssertFalse(FileManager.default.fileExists(atPath: directory.path))
+        }
+    }
+}


### PR DESCRIPTION
Literal `--help` in notification content currently selects CLI help and exits successfully without sending. Parse options by position and introduce a versioned native request/receipt protocol with strict validation, per-attempt file ownership, and side-effect-free capability discovery.

This is the first bounded checkpoint of agent-initiated notifications. Existing hooks and legacy click actions retain their behavior. The new protocol advertises only `none`; installer activation, Codex routing, the journal and MCP tools follow in dependent PRs.

Validation:
- 48 macOS Swift package tests passed before the Unicode review fix; all 11 native protocol tests passed after that fix.
- Go nativeprotocol tests passed, including shared Swift wire fixtures.
- Standalone native subprocess smoke passed, including literal flags, correlated rejection receipts, duplicate launches, symlink rejection and joined Unicode; no notifications sent.
- Independent Astra review found one Unicode validation issue, fixed with byte-preserving emoji/ZWNJ regressions. Full installed Desktop E2E and upgrade/cold-start qualification remain later gates.
