### PR TITLE
feat(notify): add durable explicit notification journal

### DIFF
--- a/internal/agentnotify/journal/clock_darwin.go
+++ b/internal/agentnotify/journal/clock_darwin.go
@@ -1,0 +1,22 @@
+//go:build darwin
+
+package journal
+
+import "golang.org/x/sys/unix"
+
+// PlatformClock uses kernel boot-session identity, not boot wall time. A kernel
+// without that identity explicitly freezes logical time rather than guessing.
+// Darwin execution qualification belongs to the macOS coordinator.
+type PlatformClock struct{}
+
+func (PlatformClock) Sample() Sample {
+	boot, e := unix.Sysctl("kern.bootsessionuuid")
+	if e != nil || !validText(boot, 256, true) {
+		return Sample{}
+	}
+	var ts unix.Timespec
+	if e = unix.ClockGettime(unix.CLOCK_MONOTONIC_RAW, &ts); e != nil || ts.Sec < 0 {
+		return Sample{}
+	}
+	return Sample{Boot: boot, Seconds: uint64(ts.Sec), Available: true}
+}

--- a/internal/agentnotify/journal/clock_darwin_test.go
+++ b/internal/agentnotify/journal/clock_darwin_test.go
@@ -1,0 +1,18 @@
+//go:build darwin
+
+package journal
+
+import "testing"
+
+// This is an actual OS-port qualification: fake clocks in journal tests cannot
+// prove that the shipped Darwin syscall constants and boot identity work.
+func TestDarwinPlatformClockAvailableAndStableWithinBoot(t *testing.T) {
+	clock := PlatformClock{}
+	first, second := clock.Sample(), clock.Sample()
+	if !first.Available || !second.Available || first.Boot == "" || second.Boot != first.Boot {
+		t.Fatal("Darwin clock did not return a stable available boot identity")
+	}
+	if second.Seconds < first.Seconds {
+		t.Fatal("Darwin monotonic sample regressed within one boot")
+	}
+}

--- a/internal/agentnotify/journal/clock_linux.go
+++ b/internal/agentnotify/journal/clock_linux.go
@@ -1,0 +1,45 @@
+//go:build linux
+
+package journal
+
+import (
+	"io"
+	"os"
+	"strings"
+
+	"golang.org/x/sys/unix"
+)
+
+// PlatformClock requires an explicitly injected boot ID path on Linux (normally
+// the trusted procfs boot_id file). No user HOME/config path is consulted.
+// CLOCK_BOOTTIME includes elapsed suspend time and never uses wall time.
+type PlatformClock struct{ BootIDPath string }
+
+func (c PlatformClock) Sample() Sample {
+	if c.BootIDPath == "" {
+		return Sample{}
+	}
+	fd, e := unix.Open(c.BootIDPath, unix.O_RDONLY|unix.O_NOFOLLOW|unix.O_NONBLOCK|unix.O_CLOEXEC, 0)
+	if e != nil {
+		return Sample{}
+	}
+	f := os.NewFile(uintptr(fd), c.BootIDPath)
+	defer f.Close()
+	st, e := f.Stat()
+	if e != nil || !st.Mode().IsRegular() {
+		return Sample{}
+	}
+	b, e := io.ReadAll(io.LimitReader(f, 258))
+	if e != nil || len(b) > 257 {
+		return Sample{}
+	}
+	boot := strings.TrimSuffix(string(b), "\n")
+	if !validText(boot, 256, true) {
+		return Sample{}
+	}
+	var ts unix.Timespec
+	if e = unix.ClockGettime(unix.CLOCK_BOOTTIME, &ts); e != nil || ts.Sec < 0 {
+		return Sample{}
+	}
+	return Sample{Boot: boot, Seconds: uint64(ts.Sec), Available: true}
+}

--- a/internal/agentnotify/journal/clock_linux.go
+++ b/internal/agentnotify/journal/clock_linux.go
@@ -24,7 +24,7 @@ func (c PlatformClock) Sample() Sample {
 		return Sample{}
 	}
 	f := os.NewFile(uintptr(fd), c.BootIDPath)
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	st, e := f.Stat()
 	if e != nil || !st.Mode().IsRegular() {
 		return Sample{}

--- a/internal/agentnotify/journal/clock_linux_test.go
+++ b/internal/agentnotify/journal/clock_linux_test.go
@@ -1,0 +1,27 @@
+//go:build linux
+
+package journal
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestPlatformClockInjectedBootFile(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "boot_id")
+	c := PlatformClock{BootIDPath: p}
+	if c.Sample().Available {
+		t.Fatal("missing boot identity")
+	}
+	if e := os.WriteFile(p, []byte("test-boot\n"), 0600); e != nil {
+		t.Fatal(e)
+	}
+	a, b := c.Sample(), c.Sample()
+	if !a.Available || a.Boot != "test-boot" || b.Seconds < a.Seconds {
+		t.Fatal(a, b)
+	}
+	if (PlatformClock{}).Sample().Available {
+		t.Fatal("implicit filesystem root")
+	}
+}

--- a/internal/agentnotify/journal/clock_unsupported.go
+++ b/internal/agentnotify/journal/clock_unsupported.go
@@ -1,0 +1,7 @@
+//go:build !linux && !darwin
+
+package journal
+
+type PlatformClock struct{}
+
+func (PlatformClock) Sample() Sample { return Sample{} }

--- a/internal/agentnotify/journal/journal.go
+++ b/internal/agentnotify/journal/journal.go
@@ -1,0 +1,482 @@
+// Package journal implements durable admission only. Callers perform preflight
+// between Lookup and Admit, and effects after Admit returns Fresh, outside locks.
+// An error from Admit never permits an effect, even if a write reached disk.
+package journal
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"math"
+	"strings"
+	"unicode/utf8"
+)
+
+const Protocol = "agent-notify/journal/v1"
+const MinRetention uint64 = 7 * 24 * 60 * 60
+
+var (
+	ErrRepair      = errors.New("state_repair_required")
+	ErrFull        = errors.New("journal_full")
+	ErrConflict    = errors.New("idempotency_conflict")
+	ErrRate        = errors.New("rate_limited")
+	ErrCAS         = errors.New("attempt_mismatch")
+	ErrUnavailable = errors.New("journal_unavailable")
+	ErrInvalid     = errors.New("invalid_journal_argument")
+)
+
+type KeyKind string
+
+const (
+	Explicit   KeyKind = "explicit"
+	ClientCall KeyKind = "client_call"
+	Generated  KeyKind = "generated"
+)
+
+type Key struct {
+	Source, Session string
+	Kind            KeyKind
+	Request         string
+}
+
+// Digest is computed by the service from versioned normalized caller payload,
+// never from mutable delivery configuration. No payload is accepted or stored.
+type Digest [32]byte
+
+func hash(parts ...string) string {
+	h := sha256.New()
+	for _, p := range parts {
+		var n [8]byte
+		binary.BigEndian.PutUint64(n[:], uint64(len(p)))
+		h.Write(n[:])
+		h.Write([]byte(p))
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}
+func (k Key) scoped(ns string) string {
+	return hash(Protocol, ns, k.Source, k.Session, string(k.Kind), k.Request)
+}
+func (k Key) session(ns string) string { return hash(Protocol, ns, k.Source, k.Session) }
+func validText(s string, n int, required bool) bool {
+	return (!required || s != "") && len(s) <= n && utf8.ValidString(s) && !strings.ContainsRune(s, 0)
+}
+func (k Key) valid() bool {
+	return validText(k.Source, 256, true) && validText(k.Session, 256, true) && validText(k.Request, 256, true) && validKind(k.Kind)
+}
+func validKind(k KeyKind) bool { return k == Explicit || k == ClientCall || k == Generated }
+func isHex(s string) bool {
+	b, e := hex.DecodeString(s)
+	return e == nil && len(b) == 32 && s == strings.ToLower(s)
+}
+func token() (string, error) {
+	var b [32]byte
+	if _, e := rand.Read(b[:]); e != nil {
+		return "", e
+	}
+	return hex.EncodeToString(b[:]), nil
+}
+
+// Snapshot is a minimal immutable decision, not a callback dependency. The
+// service maps these DTOs to the final notification receipt contract.
+type Target struct {
+	Kind        string `json:"kind"`
+	ID          string `json:"id"`
+	Application string `json:"application"`
+	Identity    string `json:"identity"`
+}
+type Navigation struct {
+	Capability string `json:"capability"`
+	Precision  string `json:"precision"`
+	Scope      string `json:"scope"`
+	Reason     string `json:"reason"`
+}
+type Snapshot struct {
+	Target     Target     `json:"target"`
+	Policy     string     `json:"policy"`
+	Navigation Navigation `json:"navigation"`
+}
+type Receipt struct {
+	Status     string   `json:"status"`
+	Reason     string   `json:"reason"`
+	Backend    string   `json:"backend"`
+	RequestID  *string  `json:"request_id"`
+	TrackingID string   `json:"tracking_id"`
+	KeyKind    KeyKind  `json:"key_kind"`
+	Decision   Snapshot `json:"decision"`
+}
+type Admission struct {
+	Key        Key
+	Digest     Digest
+	TrackingID string
+	Decision   Snapshot
+}
+type Record struct {
+	Session string  `json:"session"`
+	Digest  string  `json:"digest"`
+	Attempt string  `json:"attempt"`
+	Created uint64  `json:"created"`
+	State   string  `json:"state"`
+	Receipt Receipt `json:"receipt"`
+}
+type Result struct {
+	// ScopedKey and Attempt let the service derive a stable native notification ID.
+	ScopedKey string
+	Found     bool
+	Fresh     bool
+	Record    Record
+}
+
+// Dispatching is always exposed as unknown/pending_submission. It is never a
+// lease, and neither Lookup nor Admit takes over an existing attempt.
+func result(key string, r Record, fresh bool) Result {
+	return Result{ScopedKey: key, Found: true, Fresh: fresh, Record: r}
+}
+
+type Sample struct {
+	Boot      string
+	Seconds   uint64
+	Available bool
+}
+
+// Clock must return promptly and be safe for concurrent calls. Unavailable
+// samples freeze collection and rate recovery; nil has the same behavior.
+type Clock interface{ Sample() Sample }
+type ClockFunc func() Sample
+
+func (f ClockFunc) Sample() Sample { return f() }
+
+type Limits struct {
+	Records   int    `json:"records"`
+	Bytes     int    `json:"bytes"`
+	Retention uint64 `json:"retention"`
+}
+
+func (l Limits) normalize() (Limits, error) {
+	if l.Records == 0 {
+		l.Records = 10000
+	}
+	if l.Bytes == 0 {
+		l.Bytes = 8 << 20
+	}
+	if l.Retention == 0 {
+		l.Retention = MinRetention
+	}
+	if l.Records < 1 || l.Records > 10000 || l.Bytes < 1024 || l.Bytes > 8<<20 || l.Retention < MinRetention || l.Retention > 365*86400 {
+		return l, ErrInvalid
+	}
+	return l, nil
+}
+
+type Options struct {
+	Root   string
+	Clock  Clock
+	Limits Limits
+}
+type Store struct {
+	root      string
+	clock     Clock
+	limits    Limits
+	namespace string
+	fault     func(string) error
+}
+type elapsed struct {
+	Logical uint64 `json:"logical"`
+	Boot    string `json:"boot"`
+	Seconds uint64 `json:"seconds"`
+}
+type event struct {
+	At      uint64 `json:"at"`
+	Session string `json:"session"`
+}
+type disk struct {
+	Version   int               `json:"version"`
+	Namespace string            `json:"namespace"`
+	Limits    Limits            `json:"limits"`
+	Clock     elapsed           `json:"clock"`
+	Events    []event           `json:"events"`
+	Records   map[string]Record `json:"records"`
+}
+
+func (s *Store) advance(d *disk) (bool, error) {
+	x := Sample{}
+	if s.clock != nil {
+		x = s.clock.Sample()
+	}
+	if !x.Available || !validText(x.Boot, 256, true) {
+		d.Clock.Boot = ""
+		d.Clock.Seconds = 0
+		return false, nil
+	}
+	if d.Clock.Boot != x.Boot {
+		d.Clock.Boot = x.Boot
+		d.Clock.Seconds = x.Seconds
+		return false, nil
+	}
+	if x.Seconds < d.Clock.Seconds {
+		return false, nil
+	} // retain high water, do not double-credit recovery
+	delta := x.Seconds - d.Clock.Seconds
+	// Whole-second endpoints prove at least delta-1 whole elapsed seconds.
+	// Discard rounding uncertainty on each interval so GC/rates cannot run early.
+	if delta > 0 {
+		delta--
+	}
+	if delta > math.MaxUint64-d.Clock.Logical {
+		return false, ErrFull
+	}
+	d.Clock.Logical += delta
+	d.Clock.Seconds = x.Seconds
+	return true, nil
+}
+func (s *Store) Namespace() string { return s.namespace }
+func newStore(o Options) (*Store, error) {
+	l, e := o.Limits.normalize()
+	if e != nil {
+		return nil, e
+	}
+	return &Store{root: o.Root, clock: o.Clock, limits: l}, nil
+}
+
+// Initialize is setup-only, for an explicitly never-initialized private root.
+// The registry must remember initialization outside caches. Normal consumers
+// must use Open; missing expected state must never trigger Initialize.
+func Initialize(ctx context.Context, o Options) (*Store, error) {
+	s, e := newStore(o)
+	if e != nil {
+		return nil, e
+	}
+	if e = s.bootstrap(ctx); e != nil {
+		return nil, e
+	}
+	return s, nil
+}
+
+// Open requires a complete existing namespace/journal/lock set. It never repairs
+// or creates missing state, including when the entire expected root was lost.
+func Open(ctx context.Context, o Options) (*Store, error) {
+	s, e := newStore(o)
+	if e != nil {
+		return nil, e
+	}
+	if e = s.transaction(ctx, func(d *disk) (bool, error) { s.namespace = d.Namespace; return false, nil }); e != nil {
+		return nil, e
+	}
+	return s, nil
+}
+func (s *Store) Lookup(ctx context.Context, k Key, digest Digest) (out Result, err error) {
+	if !k.valid() {
+		return out, ErrInvalid
+	}
+	err = s.transaction(ctx, func(d *disk) (bool, error) { var e error; out, e = lookup(d, k, digest); return false, e })
+	return
+}
+func lookup(d *disk, k Key, digest Digest) (Result, error) {
+	r, ok := d.Records[k.scoped(d.Namespace)]
+	if !ok {
+		return Result{}, nil
+	}
+	if r.Digest != hex.EncodeToString(digest[:]) {
+		return Result{}, ErrConflict
+	}
+	return result(k.scoped(d.Namespace), r, false), nil
+}
+func (s *Store) Admit(ctx context.Context, a Admission) (out Result, err error) {
+	if !a.Key.valid() || !validText(a.TrackingID, 256, true) || !validSnapshot(a.Decision) {
+		return out, ErrInvalid
+	}
+	err = s.transaction(ctx, func(d *disk) (bool, error) {
+		var e error
+		out, e = lookup(d, a.Key, a.Digest)
+		if e != nil || out.Found {
+			return false, e
+		}
+		proven, e := s.advance(d)
+		if e != nil {
+			return false, e
+		}
+		now := d.Clock.Logical
+		if proven {
+			for k, r := range d.Records {
+				if now-r.Created >= d.Limits.Retention {
+					delete(d.Records, k)
+				}
+			}
+		}
+		// Existing keys replay until another admission/Collect commits their removal.
+		if len(d.Records) >= d.Limits.Records {
+			return false, ErrFull
+		}
+		events := d.Events[:0]
+		session := a.Key.session(d.Namespace)
+		perSession, burst := 0, 0
+		for _, v := range d.Events {
+			if now-v.At < 60 {
+				events = append(events, v)
+				if v.Session == session {
+					perSession++
+				}
+				if now-v.At < 2 {
+					burst++
+				}
+			}
+		}
+		if len(events) >= 30 || perSession >= 6 || burst >= 3 {
+			return false, ErrRate
+		}
+		d.Events = append(events, event{now, session})
+		attempt, e := token()
+		if e != nil {
+			return false, e
+		}
+		receipt := Receipt{Status: "unknown", Reason: "pending_submission", TrackingID: a.TrackingID, KeyKind: a.Key.Kind, Decision: a.Decision}
+		if a.Key.Kind == Explicit {
+			id := a.Key.Request
+			receipt.RequestID = &id
+		}
+		r := Record{Session: session, Digest: hex.EncodeToString(a.Digest[:]), Attempt: attempt, Created: now, State: "dispatching", Receipt: receipt}
+		d.Records[a.Key.scoped(d.Namespace)] = r
+		out = result(a.Key.scoped(d.Namespace), r, true)
+		return true, nil
+	})
+	if err != nil {
+		out = Result{}
+	}
+	return
+}
+
+// Finalize only changes status/reason/backend; original identity and decision
+// are immutable. On any error after the effect the caller reports unknown and
+// must not retry delivery. A completed token cannot be finalized twice.
+func (s *Store) Finalize(ctx context.Context, k Key, attempt, status, reason, backend string) error {
+	if !k.valid() || !isHex(attempt) || !validTerminal(status) || !validText(reason, 128, true) || !validText(backend, 128, false) {
+		return ErrInvalid
+	}
+	return s.transaction(ctx, func(d *disk) (bool, error) {
+		id := k.scoped(d.Namespace)
+		r, ok := d.Records[id]
+		if !ok || r.Attempt != attempt || r.State != "dispatching" {
+			return false, ErrCAS
+		}
+		r.State = status
+		r.Receipt.Status = status
+		r.Receipt.Reason = reason
+		r.Receipt.Backend = backend
+		d.Records[id] = r
+		return true, nil
+	})
+}
+
+// Collect never affects OS notifications or callbacks. Unavailable/regressed
+// clocks freeze GC. The logical clock baseline is persisted even when frozen.
+func (s *Store) Collect(ctx context.Context) error {
+	return s.transaction(ctx, func(d *disk) (bool, error) {
+		proven, e := s.advance(d)
+		if e != nil {
+			return false, e
+		}
+		if proven {
+			for k, r := range d.Records {
+				if d.Clock.Logical-r.Created >= d.Limits.Retention {
+					delete(d.Records, k)
+				}
+			}
+		}
+		return true, nil
+	})
+}
+func validTerminal(s string) bool { return s == "submitted" || s == "rejected" || s == "unknown" }
+func validSnapshot(s Snapshot) bool {
+	for _, v := range []string{s.Target.Kind, s.Target.ID, s.Target.Application, s.Target.Identity, s.Policy, s.Navigation.Capability, s.Navigation.Precision, s.Navigation.Scope, s.Navigation.Reason} {
+		if !validText(v, 1024, false) {
+			return false
+		}
+	}
+	return true
+}
+func (d *disk) validate(s *Store) error {
+	if d.Version != 1 || !isHex(d.Namespace) || d.Limits != s.limits || d.Records == nil || d.Events == nil || len(d.Records) > d.Limits.Records || len(d.Events) > 30 || !validText(d.Clock.Boot, 256, false) || (d.Clock.Boot == "" && d.Clock.Seconds != 0) {
+		return ErrRepair
+	}
+	for _, v := range d.Events {
+		if v.At > d.Clock.Logical || !isHex(v.Session) {
+			return ErrRepair
+		}
+	}
+	var prev uint64
+	for _, v := range d.Events {
+		if v.At < prev {
+			return ErrRepair
+		}
+		prev = v.At
+	}
+	// Live rate events correspond one-for-one to retained admissions. Removing
+	// counters while recent records remain is corruption, not a rate reset.
+	type rateKey struct {
+		at      uint64
+		session string
+	}
+	counts := map[rateKey]int{}
+	for _, v := range d.Events {
+		if d.Clock.Logical-v.At < 60 {
+			counts[rateKey{v.At, v.Session}]++
+		}
+	}
+	attempts := map[string]bool{}
+	for k, r := range d.Records {
+		if attempts[r.Attempt] {
+			return ErrRepair
+		}
+		attempts[r.Attempt] = true
+		if r.Created <= d.Clock.Logical && d.Clock.Logical-r.Created < 60 {
+			counts[rateKey{r.Created, r.Session}]--
+		}
+		p := r.Receipt
+		if !isHex(r.Session) || !isHex(k) || !isHex(r.Digest) || !isHex(r.Attempt) || r.Created > d.Clock.Logical || !validKind(p.KeyKind) || !validText(p.TrackingID, 256, true) || !validSnapshot(p.Decision) || !validText(p.Reason, 128, true) || !validText(p.Backend, 128, false) {
+			return ErrRepair
+		}
+		if p.KeyKind == Explicit {
+			if p.RequestID == nil || !validText(*p.RequestID, 256, true) {
+				return ErrRepair
+			}
+		} else if p.RequestID != nil {
+			return ErrRepair
+		}
+		if r.State == "dispatching" {
+			if p.Status != "unknown" || p.Reason != "pending_submission" || p.Backend != "" {
+				return ErrRepair
+			}
+		} else if !validTerminal(r.State) || p.Status != r.State {
+			return ErrRepair
+		}
+	}
+	for _, n := range counts {
+		if n != 0 {
+			return ErrRepair
+		}
+	}
+	for i, v := range d.Events {
+		session, burst := 0, 0
+		for _, previous := range d.Events[:i+1] {
+			if v.At-previous.At < 60 && v.Session == previous.Session {
+				session++
+			}
+			if v.At-previous.At < 2 {
+				burst++
+			}
+		}
+		if session > 6 || burst > 3 {
+			return ErrRepair
+		}
+	}
+	return nil
+}
+func wrap(e error) error {
+	if e == nil {
+		return nil
+	}
+	return fmt.Errorf("%w: %v", ErrRepair, e)
+}

--- a/internal/agentnotify/journal/journal_test.go
+++ b/internal/agentnotify/journal/journal_test.go
@@ -298,7 +298,7 @@ func TestCorruptionAndLostState(t *testing.T) {
 	}
 }
 func TestBoundsAndCounterOverflow(t *testing.T) {
-	s, c := fixture(t, Limits{Bytes: 1024})
+	s, _ := fixture(t, Limits{Bytes: 1024})
 	a := admission("large")
 	a.Decision.Target.Application = strings.Repeat("x", 1024)
 	if _, e := s.Admit(testContext(t), a); !errors.Is(e, ErrFull) {
@@ -308,7 +308,7 @@ func TestBoundsAndCounterOverflow(t *testing.T) {
 	if e != nil || r.Found {
 		t.Fatal(r, e)
 	}
-	s, c = fixture(t, Limits{})
+	s, c := fixture(t, Limits{})
 	if e = s.transaction(testContext(t), func(d *disk) (bool, error) { d.Clock.Logical = math.MaxUint64; return true, nil }); e != nil {
 		t.Fatal(e)
 	}
@@ -356,7 +356,7 @@ func TestUnsafePathsAndLockCancellation(t *testing.T) {
 	if e != nil {
 		t.Fatal(e)
 	}
-	defer dir.Close()
+	defer func() { requireNoError(t, dir.Close()) }()
 	l, e := lock(testContext(t), dir, false)
 	if e != nil {
 		t.Fatal(e)
@@ -366,7 +366,7 @@ func TestUnsafePathsAndLockCancellation(t *testing.T) {
 	if _, e = s.Admit(ctx, admission("R")); !errors.Is(e, context.DeadlineExceeded) {
 		t.Fatal(e)
 	}
-	l.Close()
+	requireNoError(t, l.Close())
 	if _, e = s.Lookup(context.Background(), admission("R").Key, Digest{}); !errors.Is(e, ErrInvalid) {
 		t.Fatal(e)
 	}
@@ -381,15 +381,15 @@ func TestUnsafePathsAndLockCancellation(t *testing.T) {
 			p := filepath.Join(s.root, "journal.json")
 			switch kind {
 			case "symlink":
-				os.Rename(p, p+".old")
-				os.Symlink(p+".old", p)
+				requireNoError(t, os.Rename(p, p+".old"))
+				requireNoError(t, os.Symlink(p+".old", p))
 			case "hardlink":
-				os.Link(p, p+".link")
+				requireNoError(t, os.Link(p, p+".link"))
 			case "mode":
-				os.Chmod(p, 0644)
+				requireNoError(t, os.Chmod(p, 0644))
 			case "fifo":
-				os.Remove(p)
-				unix.Mkfifo(p, 0600)
+				requireNoError(t, os.Remove(p))
+				requireNoError(t, unix.Mkfifo(p, 0600))
 			}
 			if _, e := s.Admit(testContext(t), admission("R")); !errors.Is(e, ErrRepair) {
 				t.Fatal(e)
@@ -398,11 +398,11 @@ func TestUnsafePathsAndLockCancellation(t *testing.T) {
 	}
 	root := t.TempDir()
 	link := filepath.Join(root, "link")
-	os.Symlink(s.root, link)
+	requireNoError(t, os.Symlink(s.root, link))
 	if _, e = Open(testContext(t), Options{Root: link}); !errors.Is(e, ErrRepair) {
 		t.Fatal(e)
 	}
-	os.Chmod(s.root, 0777)
+	requireNoError(t, os.Chmod(s.root, 0777))
 	if _, e = s.Admit(testContext(t), admission("R")); !errors.Is(e, ErrRepair) {
 		t.Fatal(e)
 	}
@@ -499,7 +499,7 @@ func TestJournalProcess(t *testing.T) {
 	if e = f.Sync(); e != nil {
 		t.Fatal(e)
 	}
-	f.Close()
+	requireNoError(t, f.Close())
 	if phase == "after_effect" {
 		os.Exit(71)
 	}
@@ -610,13 +610,14 @@ func TestActualCrashBoundaries(t *testing.T) {
 				if effects(t, s) != want {
 					t.Fatalf("effects=%d want=%d output=%s", effects(t, s), want, b)
 				}
-				dir, _ := openRoot(s.root)
+				dir, e := openRoot(s.root)
+				requireNoError(t, e)
 				l, e := lock(testContext(t), dir, false)
 				if e != nil {
 					t.Fatal("dead process retained lock", e)
 				}
-				l.Close()
-				dir.Close()
+				requireNoError(t, l.Close())
+				requireNoError(t, dir.Close())
 			})
 		}
 	}
@@ -627,7 +628,7 @@ func TestStrictJSON(t *testing.T) {
 			t.Fatal(b)
 		}
 	}
-	for _, b := range []string{`{"emoji":"\ud83d\ude00"}`, `{"x":"\\ud800"}`, `{"x":"a‍b"}`} {
+	for _, b := range []string{`{"emoji":"\ud83d\ude00"}`, `{"x":"\\ud800"}`, "{\"x\":\"a\u200db\"}"} {
 		if e := strictJSON([]byte(b)); e != nil {
 			t.Fatal(b, e)
 		}
@@ -647,8 +648,8 @@ func TestActualLookupAdmitRace(t *testing.T) {
 		}
 		t.Cleanup(func() {
 			if cmd.ProcessState == nil {
-				cmd.Process.Kill()
-				cmd.Wait()
+				_ = cmd.Process.Kill()
+				_ = cmd.Wait()
 			}
 		})
 	}
@@ -833,7 +834,7 @@ func TestMissingFieldsAndStateInvariants(t *testing.T) {
 			}
 			if change == "missing-clock" {
 				var fields map[string]json.RawMessage
-				json.Unmarshal(b, &fields)
+				requireNoError(t, json.Unmarshal(b, &fields))
 				delete(fields, "clock")
 				b, e = json.Marshal(fields)
 				if e != nil {
@@ -937,5 +938,13 @@ func TestLimitsAndReadOnlyLookup(t *testing.T) {
 		if e != nil || !bytes.Equal(b, before[p]) {
 			t.Fatal("lookup wrote state", p, e)
 		}
+	}
+}
+
+// Fail on fixture setup errors so a safety test cannot pass without its intended mutation.
+func requireNoError(t *testing.T, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatal(err)
 	}
 }

--- a/internal/agentnotify/journal/journal_test.go
+++ b/internal/agentnotify/journal/journal_test.go
@@ -1,0 +1,941 @@
+//go:build linux || darwin
+
+package journal
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+type testClock struct{ x Sample }
+
+func (c *testClock) Sample() Sample { return c.x }
+func testContext(t *testing.T) context.Context {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	t.Cleanup(cancel)
+	return ctx
+}
+func fixture(t *testing.T, l Limits) (*Store, *testClock) {
+	t.Helper()
+	root, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if e := os.Chmod(root, 0700); e != nil {
+		t.Fatal(e)
+	}
+	c := &testClock{Sample{"boot-A", 100, true}}
+	s, e := Initialize(testContext(t), Options{root, c, l})
+	if e != nil {
+		t.Fatal(e)
+	}
+	return s, c
+}
+func admission(id string) Admission {
+	return Admission{Key: Key{"codex/local", "session-A", Explicit, id}, Digest: sha256.Sum256([]byte("normalized payload")), TrackingID: "tracking-" + id, Decision: Snapshot{Target: Target{"chat_id", "chat-A", "/test/Original.app", "team-A"}, Policy: "local-enabled", Navigation: Navigation{"available", "chat_id", "local_current_profile", "configured"}}}
+}
+func mustAdmit(t *testing.T, s *Store, a Admission) Result {
+	t.Helper()
+	r, e := s.Admit(testContext(t), a)
+	if e != nil || !r.Fresh {
+		t.Fatalf("admit fresh=%v: %v", r.Fresh, e)
+	}
+	return r
+}
+func reopen(t *testing.T, s *Store, c Clock) *Store {
+	t.Helper()
+	r, e := Open(testContext(t), Options{s.root, c, s.limits})
+	if e != nil {
+		t.Fatal(e)
+	}
+	return r
+}
+func TestReplayIdentityAndCAS(t *testing.T) {
+	s, c := fixture(t, Limits{})
+	a := admission("R")
+	if r, e := s.Lookup(testContext(t), a.Key, a.Digest); e != nil || r.Found {
+		t.Fatal(r, e)
+	}
+	first := mustAdmit(t, s, a)
+	if first.ScopedKey != a.Key.scoped(s.namespace) {
+		t.Fatal("missing native identity input")
+	}
+	a.Decision.Target.Application = "/new/Changed.app"
+	a.TrackingID = "replacement"
+	s = reopen(t, s, c)
+	r, e := s.Admit(testContext(t), a)
+	if e != nil || r.Fresh {
+		t.Fatal(r, e)
+	}
+	old, _ := json.Marshal(first.Record)
+	got, _ := json.Marshal(r.Record)
+	if string(old) != string(got) {
+		t.Fatal("original decision changed")
+	}
+	if r.Record.Receipt.Status != "unknown" || r.Record.Receipt.Reason != "pending_submission" {
+		t.Fatal(r)
+	}
+	if e = s.Finalize(testContext(t), a.Key, strings.Repeat("a", 64), "submitted", "os_accepted", "test"); !errors.Is(e, ErrCAS) {
+		t.Fatal(e)
+	}
+	if e = s.Finalize(testContext(t), a.Key, first.Record.Attempt, "rejected", "permission_denied", "test"); e != nil {
+		t.Fatal(e)
+	}
+	r, e = s.Lookup(testContext(t), a.Key, a.Digest)
+	if e != nil || r.Record.Receipt.Status != "rejected" || r.Record.Receipt.Decision.Target.Application != "/test/Original.app" {
+		t.Fatal(r, e)
+	}
+	if e = s.Finalize(testContext(t), a.Key, first.Record.Attempt, "submitted", "late", "test"); !errors.Is(e, ErrCAS) {
+		t.Fatal(e)
+	}
+	a.Digest = sha256.Sum256([]byte("different"))
+	if _, e = s.Admit(testContext(t), a); !errors.Is(e, ErrConflict) {
+		t.Fatal(e)
+	}
+	b, e := os.ReadFile(filepath.Join(s.root, "journal.json"))
+	if e != nil {
+		t.Fatal(e)
+	}
+	for _, secret := range []string{"normalized payload", "different", "session-A", "codex/local"} {
+		if strings.Contains(string(b), secret) {
+			t.Fatalf("stored raw input %s", secret)
+		}
+	}
+}
+func TestKeyFramingAndKinds(t *testing.T) {
+	if hash("ab", "c") == hash("a", "bc") {
+		t.Fatal("ambiguous framing")
+	}
+	s, _ := fixture(t, Limits{})
+	a := admission("same")
+	mustAdmit(t, s, a)
+	a.Key.Kind = ClientCall
+	r := mustAdmit(t, s, a)
+	if r.Record.Receipt.RequestID != nil {
+		t.Fatal("tracking is not explicit")
+	}
+	a.Key.Kind = Generated
+	mustAdmit(t, s, a)
+	if a.Key.scoped(s.namespace) == a.Key.scoped(strings.Repeat("a", 64)) {
+		t.Fatal("namespace ignored")
+	}
+}
+func TestSessionIsolation(t *testing.T) {
+	s, _ := fixture(t, Limits{})
+	a := admission("same-call")
+	a.Key.Kind = ClientCall
+	one := mustAdmit(t, s, a)
+	a.Key.Session = "session-B"
+	two := mustAdmit(t, s, a)
+	if one.Record.Attempt == two.Record.Attempt {
+		t.Fatal("same attempt")
+	}
+}
+func TestClockRetentionAndLateCAS(t *testing.T) {
+	s, c := fixture(t, Limits{Records: 1})
+	a := admission("R")
+	old := mustAdmit(t, s, a)
+	// A process restart preserves the same boot high-water mark. No wall time is used.
+	s = reopen(t, s, c)
+	c.x.Seconds += 61
+	if e := s.Collect(testContext(t)); e != nil {
+		t.Fatal(e)
+	}
+	c.x.Seconds = 1
+	if e := s.Collect(testContext(t)); e != nil {
+		t.Fatal(e)
+	} // regression
+	c.x = Sample{"boot-B", 900000, true}
+	if e := s.Collect(testContext(t)); e != nil {
+		t.Fatal(e)
+	} // reboot adds zero
+	c.x.Available = false
+	if e := s.Collect(testContext(t)); e != nil {
+		t.Fatal(e)
+	}
+	c.x = Sample{"boot-B", 1900000, true}
+	if e := s.Collect(testContext(t)); e != nil {
+		t.Fatal(e)
+	} // unavailable gap adds zero
+	if _, e := s.Admit(testContext(t), admission("other")); !errors.Is(e, ErrFull) {
+		t.Fatal(e)
+	}
+	c.x.Seconds += MinRetention - 60
+	if e := s.Collect(testContext(t)); e != nil {
+		t.Fatal(e)
+	}
+	r, e := s.Lookup(testContext(t), a.Key, a.Digest)
+	if e != nil || !r.Found {
+		t.Fatal("early eviction", r, e)
+	}
+	c.x.Seconds += 2
+	if e := s.Collect(testContext(t)); e != nil {
+		t.Fatal(e)
+	}
+	fresh := mustAdmit(t, s, a)
+	if fresh.Record.Attempt == old.Record.Attempt {
+		t.Fatal("reused token")
+	}
+	if e := s.Finalize(testContext(t), a.Key, old.Record.Attempt, "submitted", "late", "test"); !errors.Is(e, ErrCAS) {
+		t.Fatal(e)
+	}
+}
+func TestRateWindowsReplayRestartReboot(t *testing.T) {
+	s, c := fixture(t, Limits{})
+	for i := 0; i < 3; i++ {
+		mustAdmit(t, s, admission(strconv.Itoa(i)))
+	}
+	for i := 0; i < 20; i++ {
+		r, e := s.Admit(testContext(t), admission("0"))
+		if e != nil || r.Fresh {
+			t.Fatal(r, e)
+		}
+	}
+	if _, e := s.Admit(testContext(t), admission("burst")); !errors.Is(e, ErrRate) {
+		t.Fatal(e)
+	}
+	c.x.Seconds += 11
+	for i := 3; i < 6; i++ {
+		mustAdmit(t, s, admission(strconv.Itoa(i)))
+	}
+	c.x.Seconds += 11
+	if _, e := s.Admit(testContext(t), admission("session-full")); !errors.Is(e, ErrRate) {
+		t.Fatal(e)
+	}
+	s = reopen(t, s, c)
+	c.x = Sample{"boot-B", 9000000, true}
+	if e := s.Collect(testContext(t)); e != nil {
+		t.Fatal(e)
+	}
+	if _, e := s.Admit(testContext(t), admission("no-reset")); !errors.Is(e, ErrRate) {
+		t.Fatal(e)
+	}
+	c.x.Available = false
+	for i := 0; i < 2; i++ {
+		if _, e := s.Admit(testContext(t), admission("clock-missing")); !errors.Is(e, ErrRate) {
+			t.Fatal(e)
+		}
+	}
+	c.x.Available = true
+	c.x.Seconds += 61
+	mustAdmit(t, s, admission("after-window"))
+}
+func TestRuntimeRate(t *testing.T) {
+	s, c := fixture(t, Limits{})
+	for group := 0; group < 10; group++ {
+		for j := 0; j < 3; j++ {
+			a := admission(fmt.Sprintf("%d-%d", group, j))
+			a.Key.Session = fmt.Sprintf("session-%d", group)
+			mustAdmit(t, s, a)
+		}
+		c.x.Seconds += 3
+	}
+	a := admission("runtime-full")
+	a.Key.Session = "new-session"
+	if _, e := s.Admit(testContext(t), a); !errors.Is(e, ErrRate) {
+		t.Fatal(e)
+	}
+	s = reopen(t, s, c)
+	if _, e := s.Admit(testContext(t), a); !errors.Is(e, ErrRate) {
+		t.Fatal(e)
+	}
+	c.x.Seconds += 40
+	mustAdmit(t, s, a)
+}
+func TestCorruptionAndLostState(t *testing.T) {
+	cases := map[string]func([]byte) []byte{"partial": func(b []byte) []byte { return b[:len(b)/2] }, "version": func(b []byte) []byte { return []byte(strings.Replace(string(b), `"version":1`, `"version":999`, 1)) }, "unknown-field": func(b []byte) []byte { return append([]byte(`{"unexpected":1,`), b[1:]...) }, "duplicate": func(b []byte) []byte { return append([]byte(`{"version":1,`), b[1:]...) }, "null-records": func(b []byte) []byte { return []byte(strings.Replace(string(b), `"records":{}`, `"records":null`, 1)) }, "trailing": func(b []byte) []byte { return append(b, []byte(` {}`)...) }}
+	for name, damage := range cases {
+		t.Run(name, func(t *testing.T) {
+			s, _ := fixture(t, Limits{})
+			p := filepath.Join(s.root, "journal.json")
+			b, _ := os.ReadFile(p)
+			broken := damage(b)
+			if e := os.WriteFile(p, broken, 0600); e != nil {
+				t.Fatal(e)
+			}
+			if _, e := s.Admit(testContext(t), admission("R")); !errors.Is(e, ErrRepair) {
+				t.Fatal(e)
+			}
+			after, _ := os.ReadFile(p)
+			if string(after) != string(broken) {
+				t.Fatal("silently repaired")
+			}
+		})
+	}
+	for _, name := range []string{"journal.json", "namespace", "lock"} {
+		t.Run("lost-"+name, func(t *testing.T) {
+			s, c := fixture(t, Limits{})
+			mustAdmit(t, s, admission("R"))
+			if e := os.Remove(filepath.Join(s.root, name)); e != nil {
+				t.Fatal(e)
+			}
+			if _, e := Open(testContext(t), Options{s.root, c, s.limits}); !errors.Is(e, ErrRepair) {
+				t.Fatal(e)
+			}
+			if _, e := Initialize(testContext(t), Options{s.root, c, s.limits}); !errors.Is(e, ErrRepair) {
+				t.Fatal("bootstrap reset", e)
+			}
+			if _, e := os.Lstat(filepath.Join(s.root, name)); !os.IsNotExist(e) {
+				t.Fatal("bootstrap recreated lost expected file", name, e)
+			}
+		})
+	}
+}
+func TestBoundsAndCounterOverflow(t *testing.T) {
+	s, c := fixture(t, Limits{Bytes: 1024})
+	a := admission("large")
+	a.Decision.Target.Application = strings.Repeat("x", 1024)
+	if _, e := s.Admit(testContext(t), a); !errors.Is(e, ErrFull) {
+		t.Fatal(e)
+	}
+	r, e := s.Lookup(testContext(t), a.Key, a.Digest)
+	if e != nil || r.Found {
+		t.Fatal(r, e)
+	}
+	s, c = fixture(t, Limits{})
+	if e = s.transaction(testContext(t), func(d *disk) (bool, error) { d.Clock.Logical = math.MaxUint64; return true, nil }); e != nil {
+		t.Fatal(e)
+	}
+	c.x.Seconds += 2
+	if _, e = s.Admit(testContext(t), admission("overflow")); !errors.Is(e, ErrFull) {
+		t.Fatal(e)
+	}
+	if e = os.WriteFile(filepath.Join(s.root, "journal.json"), []byte(strings.Repeat(" ", 8<<20+1)), 0600); e != nil {
+		t.Fatal(e)
+	}
+	if _, e = s.Lookup(testContext(t), admission("R").Key, Digest{}); !errors.Is(e, ErrRepair) {
+		t.Fatal(e)
+	}
+}
+func TestFaultsPreserveAdmission(t *testing.T) {
+	for _, stage := range []string{"before_temp", "partial_write", "before_file_sync", "after_file_sync", "before_rename", "after_rename", "after_directory_sync"} {
+		t.Run(stage, func(t *testing.T) {
+			s, c := fixture(t, Limits{})
+			a := admission("R")
+			r := mustAdmit(t, s, a)
+			fault := errors.New("injected disk failure")
+			s.fault = func(at string) error {
+				if at == stage {
+					return fault
+				}
+				return nil
+			}
+			if e := s.Finalize(testContext(t), a.Key, r.Record.Attempt, "submitted", "os_accepted", "test"); !errors.Is(e, fault) {
+				t.Fatal(e)
+			}
+			s = reopen(t, s, c)
+			got, e := s.Admit(testContext(t), a)
+			if e != nil || got.Fresh {
+				t.Fatal(got, e)
+			}
+			if stage != "after_rename" && stage != "after_directory_sync" && got.Record.State != "dispatching" {
+				t.Fatal("pending lost")
+			}
+		})
+	}
+}
+func TestUnsafePathsAndLockCancellation(t *testing.T) {
+	s, _ := fixture(t, Limits{})
+	dir, e := openRoot(s.root)
+	if e != nil {
+		t.Fatal(e)
+	}
+	defer dir.Close()
+	l, e := lock(testContext(t), dir, false)
+	if e != nil {
+		t.Fatal(e)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Millisecond)
+	defer cancel()
+	if _, e = s.Admit(ctx, admission("R")); !errors.Is(e, context.DeadlineExceeded) {
+		t.Fatal(e)
+	}
+	l.Close()
+	if _, e = s.Lookup(context.Background(), admission("R").Key, Digest{}); !errors.Is(e, ErrInvalid) {
+		t.Fatal(e)
+	}
+	canceled, stop := context.WithCancel(testContext(t))
+	stop()
+	if _, e = s.Admit(canceled, admission("R")); !errors.Is(e, context.Canceled) {
+		t.Fatal(e)
+	}
+	for _, kind := range []string{"symlink", "hardlink", "mode", "fifo"} {
+		t.Run(kind, func(t *testing.T) {
+			s, _ := fixture(t, Limits{})
+			p := filepath.Join(s.root, "journal.json")
+			switch kind {
+			case "symlink":
+				os.Rename(p, p+".old")
+				os.Symlink(p+".old", p)
+			case "hardlink":
+				os.Link(p, p+".link")
+			case "mode":
+				os.Chmod(p, 0644)
+			case "fifo":
+				os.Remove(p)
+				unix.Mkfifo(p, 0600)
+			}
+			if _, e := s.Admit(testContext(t), admission("R")); !errors.Is(e, ErrRepair) {
+				t.Fatal(e)
+			}
+		})
+	}
+	root := t.TempDir()
+	link := filepath.Join(root, "link")
+	os.Symlink(s.root, link)
+	if _, e = Open(testContext(t), Options{Root: link}); !errors.Is(e, ErrRepair) {
+		t.Fatal(e)
+	}
+	os.Chmod(s.root, 0777)
+	if _, e = s.Admit(testContext(t), admission("R")); !errors.Is(e, ErrRepair) {
+		t.Fatal(e)
+	}
+}
+
+// Every helper runs this same test binary in a separate OS process and accesses
+// only injected test roots. The effect counter is a test file, never delivery.
+func TestJournalProcess(t *testing.T) {
+	if os.Getenv("JOURNAL_CHILD") != "1" {
+		return
+	}
+	root := os.Getenv("JOURNAL_ROOT")
+	if os.Getenv("JOURNAL_PHASE") == "bootstrap" {
+		s, e := newStore(Options{Root: root, Clock: ClockFunc(func() Sample { return Sample{"boot-A", 100, true} })})
+		if e != nil {
+			t.Fatal(e)
+		}
+		s.fault = func(stage string) error {
+			if stage == os.Getenv("JOURNAL_CRASH") {
+				os.Exit(71)
+			}
+			return nil
+		}
+		if e = s.bootstrap(testContext(t)); e != nil {
+			t.Fatal(e)
+		}
+		t.Fatal("crash hook missed")
+	}
+	s, e := Open(testContext(t), Options{Root: root, Clock: ClockFunc(func() Sample { return Sample{"boot-A", 100, true} })})
+	if e != nil {
+		t.Fatal(e)
+	}
+	a := admission(os.Getenv("JOURNAL_KEY"))
+	if os.Getenv("JOURNAL_DIGEST") == "other" {
+		a.Digest = sha256.Sum256([]byte("conflict"))
+	}
+	if gate := os.Getenv("JOURNAL_GATE"); gate != "" {
+		r, e := s.Lookup(testContext(t), a.Key, a.Digest)
+		if e != nil || r.Found {
+			t.Fatal("preflight lookup", r, e)
+		}
+		if e = os.WriteFile(filepath.Join(root, "ready-"+strconv.Itoa(os.Getpid())), []byte("ready"), 0600); e != nil {
+			t.Fatal(e)
+		}
+		ctx := testContext(t)
+		for {
+			if _, e = os.Stat(filepath.Join(root, gate)); e == nil {
+				break
+			}
+			select {
+			case <-ctx.Done():
+				t.Fatal(ctx.Err())
+			case <-time.After(time.Millisecond):
+			}
+		}
+	}
+	phase := os.Getenv("JOURNAL_PHASE")
+	stage := os.Getenv("JOURNAL_CRASH")
+	if phase == "admit" {
+		s.fault = func(at string) error {
+			if at == stage {
+				os.Exit(71)
+			}
+			return nil
+		}
+	}
+	r, e := s.Admit(testContext(t), a)
+	if errors.Is(e, ErrConflict) {
+		fmt.Println("CONFLICT")
+		return
+	}
+	if errors.Is(e, ErrRate) {
+		fmt.Println("RATE")
+		return
+	}
+	if e != nil {
+		t.Fatal(e)
+	}
+	if !r.Fresh {
+		fmt.Println("REPLAY")
+		return
+	}
+	fmt.Println("FRESH")
+	if phase == "before_effect" {
+		os.Exit(71)
+	}
+	f, e := os.OpenFile(filepath.Join(root, "effects"), os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0600)
+	if e != nil {
+		t.Fatal(e)
+	}
+	if _, e = f.WriteString("effect\n"); e != nil {
+		t.Fatal(e)
+	}
+	if e = f.Sync(); e != nil {
+		t.Fatal(e)
+	}
+	f.Close()
+	if phase == "after_effect" {
+		os.Exit(71)
+	}
+	if phase == "finalize" {
+		s.fault = func(at string) error {
+			if at == stage {
+				os.Exit(71)
+			}
+			return nil
+		}
+	}
+	if e = s.Finalize(testContext(t), a.Key, r.Record.Attempt, "submitted", "os_accepted", "counter"); e != nil {
+		t.Fatal(e)
+	}
+}
+func child(s *Store, key, phase, stage, digest string) *exec.Cmd {
+	cmd := exec.Command(os.Args[0], "-test.run=^TestJournalProcess$", "-test.timeout=10s")
+	cmd.Env = append(os.Environ(), "JOURNAL_CHILD=1", "JOURNAL_ROOT="+s.root, "JOURNAL_KEY="+key, "JOURNAL_PHASE="+phase, "JOURNAL_CRASH="+stage, "JOURNAL_DIGEST="+digest)
+	return cmd
+}
+func effects(t *testing.T, s *Store) int {
+	t.Helper()
+	b, e := os.ReadFile(filepath.Join(s.root, "effects"))
+	if os.IsNotExist(e) {
+		return 0
+	}
+	if e != nil {
+		t.Fatal(e)
+	}
+	return strings.Count(string(b), "effect\n")
+}
+func TestActualProcessesSameKeyAndConflict(t *testing.T) {
+	for _, conflict := range []bool{false, true} {
+		t.Run(strconv.FormatBool(conflict), func(t *testing.T) {
+			s, _ := fixture(t, Limits{})
+			cmds := []*exec.Cmd{child(s, "R", "", "", ""), child(s, "R", "", "", "")}
+			if conflict {
+				cmds[1] = child(s, "R", "", "", "other")
+			}
+			var wg sync.WaitGroup
+			out := make([][]byte, 2)
+			errs := make([]error, 2)
+			for i := range cmds {
+				wg.Add(1)
+				go func(i int) { defer wg.Done(); out[i], errs[i] = cmds[i].CombinedOutput() }(i)
+			}
+			wg.Wait()
+			for i, e := range errs {
+				if e != nil {
+					t.Fatalf("%v: %s", e, out[i])
+				}
+			}
+			joined := string(out[0]) + string(out[1])
+			if strings.Count(joined, "FRESH") != 1 || effects(t, s) != 1 {
+				t.Fatal(joined)
+			}
+			if conflict && !strings.Contains(joined, "CONFLICT") {
+				t.Fatal(joined)
+			}
+		})
+	}
+}
+func TestActualProcessesDifferentKeysRate(t *testing.T) {
+	s, _ := fixture(t, Limits{})
+	const n = 8
+	var wg sync.WaitGroup
+	outputs := make([]string, n)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			b, e := child(s, strconv.Itoa(i), "", "", "").CombinedOutput()
+			outputs[i] = string(b)
+			if e != nil {
+				outputs[i] += " ERROR " + e.Error()
+			}
+		}(i)
+	}
+	wg.Wait()
+	all := strings.Join(outputs, "\n")
+	if strings.Contains(all, "ERROR") || strings.Count(all, "FRESH") != 3 || strings.Count(all, "RATE") != 5 || effects(t, s) != 3 {
+		t.Fatal(all)
+	}
+}
+func TestActualCrashBoundaries(t *testing.T) {
+	stages := []string{"before_temp", "partial_write", "before_file_sync", "after_file_sync", "before_rename", "after_rename", "after_directory_sync"}
+	for _, phase := range []string{"admit", "finalize", "before_effect", "after_effect"} {
+		for _, stage := range stages {
+			if (phase == "before_effect" || phase == "after_effect") && stage != "before_temp" {
+				continue
+			}
+			t.Run(phase+"/"+stage, func(t *testing.T) {
+				s, c := fixture(t, Limits{})
+				b, e := child(s, "R", phase, stage, "").CombinedOutput()
+				var exit *exec.ExitError
+				if !errors.As(e, &exit) || exit.ExitCode() != 71 {
+					t.Fatalf("crash missing: %v %s", e, b)
+				}
+				s = reopen(t, s, c)
+				b, e = child(s, "R", "", "", "").CombinedOutput()
+				if e != nil {
+					t.Fatalf("restart %v: %s", e, b)
+				}
+				want := 1
+				if phase == "before_effect" || (phase == "admit" && (stage == "after_rename" || stage == "after_directory_sync")) {
+					want = 0
+				}
+				if effects(t, s) != want {
+					t.Fatalf("effects=%d want=%d output=%s", effects(t, s), want, b)
+				}
+				dir, _ := openRoot(s.root)
+				l, e := lock(testContext(t), dir, false)
+				if e != nil {
+					t.Fatal("dead process retained lock", e)
+				}
+				l.Close()
+				dir.Close()
+			})
+		}
+	}
+}
+func TestStrictJSON(t *testing.T) {
+	for _, b := range []string{`{"x":1,"x":2}`, `{"x":"\ud800"}`, `{"x":"\udc00"}`, `{}[]`, strings.Repeat("[", 18) + strings.Repeat("]", 18)} {
+		if strictJSON([]byte(b)) == nil {
+			t.Fatal(b)
+		}
+	}
+	for _, b := range []string{`{"emoji":"\ud83d\ude00"}`, `{"x":"\\ud800"}`, `{"x":"a‍b"}`} {
+		if e := strictJSON([]byte(b)); e != nil {
+			t.Fatal(b, e)
+		}
+	}
+}
+
+func TestActualLookupAdmitRace(t *testing.T) {
+	s, _ := fixture(t, Limits{})
+	cmds := []*exec.Cmd{child(s, "R", "", "", ""), child(s, "R", "", "", "")}
+	var outputs [2]bytes.Buffer
+	for i, cmd := range cmds {
+		cmd.Env = append(cmd.Env, "JOURNAL_GATE=go")
+		cmd.Stdout = &outputs[i]
+		cmd.Stderr = &outputs[i]
+		if e := cmd.Start(); e != nil {
+			t.Fatal(e)
+		}
+		t.Cleanup(func() {
+			if cmd.ProcessState == nil {
+				cmd.Process.Kill()
+				cmd.Wait()
+			}
+		})
+	}
+	ctx := testContext(t)
+	for {
+		ready, e := filepath.Glob(filepath.Join(s.root, "ready-*"))
+		if e != nil {
+			t.Fatal(e)
+		}
+		if len(ready) == 2 {
+			break
+		}
+		select {
+		case <-ctx.Done():
+			t.Fatal("preflight barrier timeout")
+		case <-time.After(time.Millisecond):
+		}
+	}
+	if e := os.WriteFile(filepath.Join(s.root, "go"), []byte("go"), 0600); e != nil {
+		t.Fatal(e)
+	}
+	for i, cmd := range cmds {
+		if e := cmd.Wait(); e != nil {
+			t.Fatalf("%v %s", e, outputs[i].String())
+		}
+	}
+	all := outputs[0].String() + outputs[1].String()
+	if strings.Count(all, "FRESH") != 1 || strings.Count(all, "REPLAY") != 1 || effects(t, s) != 1 {
+		t.Fatal(all)
+	}
+}
+func TestRateCounterCorruption(t *testing.T) {
+	s, _ := fixture(t, Limits{})
+	mustAdmit(t, s, admission("R"))
+	p := filepath.Join(s.root, "journal.json")
+	b, e := os.ReadFile(p)
+	if e != nil {
+		t.Fatal(e)
+	}
+	var d disk
+	if e = json.Unmarshal(b, &d); e != nil {
+		t.Fatal(e)
+	}
+	d.Events = []event{}
+	b, e = json.Marshal(d)
+	if e != nil {
+		t.Fatal(e)
+	}
+	if e = os.WriteFile(p, b, 0600); e != nil {
+		t.Fatal(e)
+	}
+	if _, e = s.Admit(testContext(t), admission("new")); !errors.Is(e, ErrRepair) {
+		t.Fatal(e)
+	}
+}
+func TestPermanentLockAndRealWriteDenial(t *testing.T) {
+	s, c := fixture(t, Limits{})
+	a := admission("R")
+	r := mustAdmit(t, s, a)
+	before, e := os.Stat(filepath.Join(s.root, "lock"))
+	if e != nil {
+		t.Fatal(e)
+	}
+	s.fault = func(stage string) error {
+		if stage == "before_temp" {
+			return os.Chmod(s.root, 0500)
+		}
+		return nil
+	}
+	e = s.Finalize(testContext(t), a.Key, r.Record.Attempt, "submitted", "os_accepted", "test")
+	if restore := os.Chmod(s.root, 0700); restore != nil {
+		t.Fatal(restore)
+	}
+	if !errors.Is(e, os.ErrPermission) {
+		t.Fatalf("expected actual EACCES, got %v", e)
+	}
+	s.fault = nil
+	got, e := s.Lookup(testContext(t), a.Key, a.Digest)
+	if e != nil || got.Record.State != "dispatching" {
+		t.Fatal(got, e)
+	}
+	c.x.Seconds += MinRetention + 1
+	if e = s.Collect(testContext(t)); e != nil {
+		t.Fatal(e)
+	}
+	after, e := os.Stat(filepath.Join(s.root, "lock"))
+	if e != nil || !os.SameFile(before, after) {
+		t.Fatal("lock inode changed", e)
+	}
+}
+func TestFailedAdmissionDoesNotConsumeKeyOrRate(t *testing.T) {
+	for _, stage := range []string{"before_temp", "partial_write", "before_file_sync", "after_file_sync", "before_rename"} {
+		t.Run(stage, func(t *testing.T) {
+			s, _ := fixture(t, Limits{})
+			s.fault = func(at string) error {
+				if at == stage {
+					return unix.ENOSPC
+				}
+				return nil
+			}
+			if _, e := s.Admit(testContext(t), admission("R")); !errors.Is(e, unix.ENOSPC) {
+				t.Fatal(e)
+			}
+			s.fault = nil
+			for _, id := range []string{"R", "R2", "R3"} {
+				mustAdmit(t, s, admission(id))
+			}
+		})
+	}
+}
+
+func TestClockHighWaterAndFrozenRate(t *testing.T) {
+	s, c := fixture(t, Limits{})
+	mustAdmit(t, s, admission("R"))
+	for _, step := range []struct{ seconds, logical uint64 }{{110, 9}, {1, 9}, {105, 9}, {112, 10}} {
+		c.x.Seconds = step.seconds
+		if e := s.Collect(testContext(t)); e != nil {
+			t.Fatal(e)
+		}
+		if e := s.transaction(testContext(t), func(d *disk) (bool, error) {
+			if d.Clock.Logical != step.logical {
+				t.Fatalf("logical=%d want=%d", d.Clock.Logical, step.logical)
+			}
+			return false, nil
+		}); e != nil {
+			t.Fatal(e)
+		}
+	}
+	// With no qualified clock, fresh capacity is finite and never replenishes.
+	s = reopen(t, s, nil)
+	for _, id := range []string{"a", "b", "c"} {
+		mustAdmit(t, s, admission(id))
+	}
+	if _, e := s.Admit(testContext(t), admission("frozen")); !errors.Is(e, ErrRate) {
+		t.Fatal(e)
+	}
+	if e := s.Collect(testContext(t)); e != nil {
+		t.Fatal(e)
+	}
+	s = reopen(t, s, nil)
+	if _, e := s.Admit(testContext(t), admission("frozen")); !errors.Is(e, ErrRate) {
+		t.Fatal(e)
+	}
+}
+func TestMissingFieldsAndStateInvariants(t *testing.T) {
+	for _, change := range []string{"missing-clock", "null-events", "future-record", "mismatched-status", "duplicate-attempt", "unknown-kind"} {
+		t.Run(change, func(t *testing.T) {
+			s, _ := fixture(t, Limits{})
+			mustAdmit(t, s, admission("R"))
+			mustAdmit(t, s, admission("S"))
+			p := filepath.Join(s.root, "journal.json")
+			b, e := os.ReadFile(p)
+			if e != nil {
+				t.Fatal(e)
+			}
+			var d disk
+			if e = json.Unmarshal(b, &d); e != nil {
+				t.Fatal(e)
+			}
+			id := admission("R").Key.scoped(s.namespace)
+			r := d.Records[id]
+			switch change {
+			case "null-events":
+				d.Events = nil
+			case "future-record":
+				r.Created = d.Clock.Logical + 1
+				d.Records[id] = r
+			case "mismatched-status":
+				r.Receipt.Status = "submitted"
+				d.Records[id] = r
+			case "duplicate-attempt":
+				other := d.Records[admission("S").Key.scoped(s.namespace)]
+				r.Attempt = other.Attempt
+				d.Records[id] = r
+			case "unknown-kind":
+				r.Receipt.KeyKind = "tracking"
+				d.Records[id] = r
+			}
+			b, e = json.Marshal(d)
+			if e != nil {
+				t.Fatal(e)
+			}
+			if change == "missing-clock" {
+				var fields map[string]json.RawMessage
+				json.Unmarshal(b, &fields)
+				delete(fields, "clock")
+				b, e = json.Marshal(fields)
+				if e != nil {
+					t.Fatal(e)
+				}
+			}
+			if e = os.WriteFile(p, b, 0600); e != nil {
+				t.Fatal(e)
+			}
+			if _, e = s.Admit(testContext(t), admission("new")); !errors.Is(e, ErrRepair) {
+				t.Fatal(e)
+			}
+		})
+	}
+}
+func TestCancellationAtWriteBoundary(t *testing.T) {
+	s, _ := fixture(t, Limits{})
+	ctx, cancel := context.WithCancel(testContext(t))
+	s.fault = func(stage string) error {
+		if stage == "after_file_sync" {
+			cancel()
+		}
+		return nil
+	}
+	if r, e := s.Admit(ctx, admission("R")); !errors.Is(e, context.Canceled) || r.Fresh {
+		t.Fatal(r, e)
+	}
+	s.fault = nil
+	mustAdmit(t, s, admission("R"))
+	// Once durable admission exists, cancellation of finalization preserves pending.
+	canceled, stop := context.WithCancel(testContext(t))
+	stop()
+	a := admission("R")
+	r, e := s.Lookup(testContext(t), a.Key, a.Digest)
+	if e != nil {
+		t.Fatal(e)
+	}
+	if e = s.Finalize(canceled, a.Key, r.Record.Attempt, "submitted", "os_accepted", "test"); !errors.Is(e, context.Canceled) {
+		t.Fatal(e)
+	}
+	r, e = s.Lookup(testContext(t), a.Key, a.Digest)
+	if e != nil || r.Record.State != "dispatching" {
+		t.Fatal(r, e)
+	}
+}
+
+func TestActualBootstrapCrashBoundaries(t *testing.T) {
+	for _, stage := range []string{"after_namespace_sync", "partial_write", "after_file_sync", "before_rename", "after_rename", "after_directory_sync"} {
+		t.Run(stage, func(t *testing.T) {
+			root, e := filepath.EvalSymlinks(t.TempDir())
+			if e != nil {
+				t.Fatal(e)
+			}
+			if e = os.Chmod(root, 0700); e != nil {
+				t.Fatal(e)
+			}
+			s, _ := newStore(Options{Root: root})
+			b, e := child(s, "R", "bootstrap", stage, "").CombinedOutput()
+			var exit *exec.ExitError
+			if !errors.As(e, &exit) || exit.ExitCode() != 71 {
+				t.Fatalf("%v %s", e, b)
+			}
+			_, e = Open(testContext(t), Options{Root: root})
+			if stage == "after_rename" || stage == "after_directory_sync" {
+				if e != nil {
+					t.Fatal(e)
+				}
+			} else if !errors.Is(e, ErrRepair) {
+				t.Fatal(e)
+			}
+			if _, e = Initialize(testContext(t), Options{Root: root}); !errors.Is(e, ErrRepair) {
+				t.Fatal("silent bootstrap recovery", e)
+			}
+		})
+	}
+}
+func TestLimitsAndReadOnlyLookup(t *testing.T) {
+	for _, l := range []Limits{{Records: 10001}, {Records: -1}, {Bytes: (8 << 20) + 1}, {Bytes: 1023}, {Retention: MinRetention - 1}, {Retention: 366 * 86400}} {
+		if _, e := newStore(Options{Limits: l}); !errors.Is(e, ErrInvalid) {
+			t.Fatal(l, e)
+		}
+	}
+	s, c := fixture(t, Limits{})
+	a := admission("R")
+	mustAdmit(t, s, a)
+	paths := []string{"namespace", "journal.json", "lock"}
+	before := map[string][]byte{}
+	for _, p := range paths {
+		b, e := os.ReadFile(filepath.Join(s.root, p))
+		if e != nil {
+			t.Fatal(e)
+		}
+		before[p] = b
+	}
+	s = reopen(t, s, c)
+	if _, e := s.Lookup(testContext(t), a.Key, a.Digest); e != nil {
+		t.Fatal(e)
+	}
+	for _, p := range paths {
+		b, e := os.ReadFile(filepath.Join(s.root, p))
+		if e != nil || !bytes.Equal(b, before[p]) {
+			t.Fatal("lookup wrote state", p, e)
+		}
+	}
+}

--- a/internal/agentnotify/journal/json.go
+++ b/internal/agentnotify/journal/json.go
@@ -1,0 +1,141 @@
+package journal
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"unicode/utf8"
+)
+
+// Check duplicate names, depth, UTF-8 and surrogate escapes before typed decode.
+// The input has already been bounded by file size and LimitReader.
+func strictJSON(b []byte) error {
+	if !utf8.Valid(b) {
+		return ErrRepair
+	}
+	// encoding/json replaces isolated UTF-16 surrogates; disallow that ambiguity.
+	for i := 0; i < len(b); i++ {
+		if b[i] != '"' {
+			continue
+		}
+		i++
+		for i < len(b) && b[i] != '"' {
+			if b[i] == '\\' {
+				i++
+				if i >= len(b) {
+					return ErrRepair
+				}
+				if b[i] == 'u' {
+					if i+4 >= len(b) {
+						return ErrRepair
+					}
+					var v uint16
+					for j := 1; j <= 4; j++ {
+						n, ok := nibble(b[i+j])
+						if !ok {
+							return ErrRepair
+						}
+						v = v*16 + uint16(n)
+					}
+					i += 4
+					if v >= 0xd800 && v <= 0xdbff {
+						if i+6 >= len(b) || b[i+1] != '\\' || b[i+2] != 'u' {
+							return ErrRepair
+						}
+						var w uint16
+						for j := 3; j <= 6; j++ {
+							n, ok := nibble(b[i+j])
+							if !ok {
+								return ErrRepair
+							}
+							w = w*16 + uint16(n)
+						}
+						if w < 0xdc00 || w > 0xdfff {
+							return ErrRepair
+						}
+						i += 6
+					} else if v >= 0xdc00 && v <= 0xdfff {
+						return ErrRepair
+					}
+				}
+			}
+			i++
+		}
+	}
+	d := json.NewDecoder(bytes.NewReader(b))
+	d.UseNumber()
+	if e := jsonValue(d, 0); e != nil {
+		return e
+	}
+	if _, e := d.Token(); e != io.EOF {
+		return ErrRepair
+	}
+	return nil
+}
+func nibble(b byte) (byte, bool) {
+	switch {
+	case b >= '0' && b <= '9':
+		return b - '0', true
+	case b >= 'a' && b <= 'f':
+		return b - 'a' + 10, true
+	case b >= 'A' && b <= 'F':
+		return b - 'A' + 10, true
+	}
+	return 0, false
+}
+func jsonValue(d *json.Decoder, depth int) error {
+	if depth > 16 {
+		return ErrRepair
+	}
+	t, e := d.Token()
+	if e != nil {
+		return e
+	}
+	delim, ok := t.(json.Delim)
+	if !ok {
+		return nil
+	}
+	switch delim {
+	case '{':
+		seen := map[string]bool{}
+		for d.More() {
+			k, e := d.Token()
+			if e != nil {
+				return e
+			}
+			s, ok := k.(string)
+			if !ok || seen[s] {
+				return ErrRepair
+			}
+			if len(seen) >= 10000 {
+				return ErrRepair
+			}
+			seen[s] = true
+			if e = jsonValue(d, depth+1); e != nil {
+				return e
+			}
+		}
+	case '[':
+		count := 0
+		for d.More() {
+			count++
+			if count > 10000 {
+				return ErrRepair
+			}
+			if e = jsonValue(d, depth+1); e != nil {
+				return e
+			}
+		}
+	default:
+		return ErrRepair
+	}
+	end, e := d.Token()
+	if e != nil {
+		return e
+	}
+	if (delim == '{' && end != json.Delim('}')) || (delim == '[' && end != json.Delim(']')) {
+		return fmt.Errorf("invalid JSON container")
+	}
+	return nil
+}

--- a/internal/agentnotify/journal/storage_unix.go
+++ b/internal/agentnotify/journal/storage_unix.go
@@ -1,0 +1,363 @@
+//go:build linux || darwin
+
+package journal
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+// Open every component physically. A trusted root must already exist, be owned
+// by this user and mode 0700. Ancestors may be owned by root or this user, and
+// writable ancestors are refused except trusted-owner sticky directories (/tmp).
+// All subsequent operations are relative to the pinned directory descriptor.
+func openRoot(path string) (*os.File, error) {
+	if !filepath.IsAbs(path) || filepath.Clean(path) != path || path == "/" {
+		return nil, ErrInvalid
+	}
+	fd, e := unix.Open("/", unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC, 0)
+	if e != nil {
+		return nil, e
+	}
+	parts := strings.Split(strings.TrimPrefix(path, "/"), "/")
+	for i, p := range parts {
+		next, e := unix.Openat(fd, p, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0)
+		unix.Close(fd)
+		if e != nil {
+			return nil, wrap(e)
+		}
+		fd = next
+		var st unix.Stat_t
+		if e = unix.Fstat(fd, &st); e != nil {
+			unix.Close(fd)
+			return nil, e
+		}
+		last := i == len(parts)-1
+		uid := uint32(os.Geteuid())
+		safeOwner := st.Uid == uid || st.Uid == 0
+		unsafeWrite := st.Mode&0022 != 0 && !(safeOwner && st.Mode&unix.S_ISVTX != 0)
+		if !safeOwner || unsafeWrite || (last && (st.Uid != uid || st.Mode&0777 != 0700)) {
+			unix.Close(fd)
+			return nil, ErrRepair
+		}
+	}
+	return os.NewFile(uintptr(fd), path), nil
+}
+func openFile(dir *os.File, name string, flags int) (*os.File, error) {
+	fd, e := unix.Openat(int(dir.Fd()), name, flags|unix.O_NOFOLLOW|unix.O_CLOEXEC|unix.O_NONBLOCK, 0600)
+	if e != nil {
+		return nil, e
+	}
+	var st unix.Stat_t
+	if e = unix.Fstat(fd, &st); e != nil {
+		unix.Close(fd)
+		return nil, e
+	}
+	if st.Mode&unix.S_IFMT != unix.S_IFREG || st.Uid != uint32(os.Geteuid()) || st.Nlink != 1 || st.Mode&0777 != 0600 {
+		unix.Close(fd)
+		return nil, ErrRepair
+	}
+	return os.NewFile(uintptr(fd), name), nil
+}
+func lock(ctx context.Context, dir *os.File, create bool) (*os.File, error) {
+	if _, ok := ctx.Deadline(); !ok {
+		return nil, ErrInvalid
+	}
+	if e := ctx.Err(); e != nil {
+		return nil, e
+	}
+	flags := unix.O_RDWR
+	if create {
+		flags |= unix.O_CREAT
+	}
+	f, e := openFile(dir, "lock", flags)
+	if e != nil {
+		return nil, wrap(e)
+	}
+	for {
+		if e = ctx.Err(); e != nil {
+			f.Close()
+			return nil, e
+		}
+		e = unix.Flock(int(f.Fd()), unix.LOCK_EX|unix.LOCK_NB)
+		if e == nil {
+			break
+		}
+		if e != unix.EAGAIN && e != unix.EWOULDBLOCK {
+			f.Close()
+			return nil, e
+		}
+		timer := time.NewTimer(5 * time.Millisecond)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			f.Close()
+			return nil, ctx.Err()
+		case <-timer.C:
+		}
+	}
+	// Never accept a detached/replaced lock inode.
+	var a, b unix.Stat_t
+	e = unix.Fstat(int(f.Fd()), &a)
+	if e == nil {
+		e = unix.Fstatat(int(dir.Fd()), "lock", &b, unix.AT_SYMLINK_NOFOLLOW)
+	}
+	if e != nil || a.Ino != b.Ino || a.Dev != b.Dev || a.Nlink != 1 {
+		f.Close()
+		return nil, ErrRepair
+	}
+	return f, nil // close releases kernel flock, including process death
+}
+func readBounded(dir *os.File, name string, max int) ([]byte, error) {
+	f, e := openFile(dir, name, unix.O_RDONLY)
+	if e != nil {
+		return nil, wrap(e)
+	}
+	defer f.Close()
+	st, e := f.Stat()
+	if e != nil {
+		return nil, e
+	}
+	if st.Size() > int64(max) {
+		return nil, ErrRepair
+	}
+	b, e := io.ReadAll(io.LimitReader(f, int64(max)+1))
+	if e != nil {
+		return nil, e
+	}
+	if len(b) > max {
+		return nil, ErrRepair
+	}
+	return b, nil
+}
+func (s *Store) read(dir *os.File) (*disk, error) {
+	ns, e := readBounded(dir, "namespace", 65)
+	if e != nil {
+		return nil, e
+	}
+	if len(ns) != 65 || ns[64] != '\n' || !isHex(string(ns[:64])) {
+		return nil, ErrRepair
+	}
+	b, e := readBounded(dir, "journal.json", s.limits.Bytes)
+	if e != nil {
+		return nil, e
+	}
+	if e = strictJSON(b); e != nil {
+		return nil, wrap(e)
+	}
+	var d disk
+	dec := json.NewDecoder(bytes.NewReader(b))
+	dec.DisallowUnknownFields()
+	if e = dec.Decode(&d); e != nil {
+		return nil, wrap(e)
+	}
+	canonical, e := json.Marshal(d)
+	if e != nil {
+		return nil, wrap(e)
+	}
+	var compact bytes.Buffer
+	if e = json.Compact(&compact, b); e != nil || !bytes.Equal(compact.Bytes(), canonical) {
+		return nil, ErrRepair
+	}
+	if d.Namespace != string(ns[:64]) || (s.namespace != "" && s.namespace != d.Namespace) {
+		return nil, ErrRepair
+	}
+	if e = d.validate(s); e != nil {
+		return nil, e
+	}
+	return &d, nil
+}
+func (s *Store) transaction(ctx context.Context, fn func(*disk) (bool, error)) error {
+	dir, e := openRoot(s.root)
+	if e != nil {
+		return e
+	}
+	defer dir.Close()
+	l, e := lock(ctx, dir, false)
+	if e != nil {
+		return e
+	}
+	defer l.Close()
+	d, e := s.read(dir)
+	if e != nil {
+		return e
+	}
+	if e = ctx.Err(); e != nil {
+		return e
+	}
+	changed, e := fn(d)
+	if e != nil {
+		return e
+	}
+	if !changed {
+		return nil
+	}
+	if e = ctx.Err(); e != nil {
+		return e
+	}
+	return s.write(ctx, dir, d)
+}
+func (s *Store) fail(stage string) error {
+	if s.fault != nil {
+		return s.fault(stage)
+	}
+	return nil
+}
+func (s *Store) write(ctx context.Context, dir *os.File, d *disk) error {
+	if e := d.validate(s); e != nil {
+		return e
+	}
+	// Inputs and record count are bounded before encoding. Check encoded size
+	// before opening the same-filesystem temporary file.
+	records := d.Records
+	d.Records = map[string]Record{}
+	header, e := json.Marshal(d)
+	d.Records = records
+	if e != nil {
+		return e
+	}
+	size := len(header)
+	for key, r := range records {
+		entry, err := json.Marshal(r)
+		if err != nil {
+			return err
+		}
+		size += len(key) + 3 + len(entry) + 1
+		if size > s.limits.Bytes {
+			return ErrFull
+		}
+	}
+	b, e := json.Marshal(d)
+	if e != nil {
+		return e
+	}
+	if len(b) > s.limits.Bytes {
+		return ErrFull
+	}
+	if e = s.fail("before_temp"); e != nil {
+		return e
+	}
+	// One fixed, validated orphan slot bounds disk use after repeated crashes.
+	old, e := openFile(dir, "snapshot.tmp", unix.O_RDONLY)
+	if e == nil {
+		old.Close()
+		if e = unix.Unlinkat(int(dir.Fd()), "snapshot.tmp", 0); e != nil {
+			return e
+		}
+	} else if !errors.Is(e, unix.ENOENT) {
+		return e
+	}
+	f, e := openFile(dir, "snapshot.tmp", unix.O_WRONLY|unix.O_CREAT|unix.O_EXCL)
+	if e != nil {
+		return e
+	}
+	defer f.Close()
+	defer unix.Unlinkat(int(dir.Fd()), "snapshot.tmp", 0)
+	half := len(b) / 2
+	if _, e = f.Write(b[:half]); e != nil {
+		return e
+	}
+	if e = s.fail("partial_write"); e != nil {
+		return e
+	}
+	if _, e = f.Write(b[half:]); e != nil {
+		return e
+	}
+	if e = s.fail("before_file_sync"); e != nil {
+		return e
+	}
+	if e = f.Sync(); e != nil {
+		return e
+	}
+	if e = s.fail("after_file_sync"); e != nil {
+		return e
+	}
+	if e = f.Close(); e != nil {
+		return e
+	}
+	if e = ctx.Err(); e != nil {
+		return e
+	}
+	if e = s.fail("before_rename"); e != nil {
+		return e
+	}
+	if e = unix.Renameat(int(dir.Fd()), "snapshot.tmp", int(dir.Fd()), "journal.json"); e != nil {
+		return e
+	}
+	if e = s.fail("after_rename"); e != nil {
+		return e
+	}
+	if e = dir.Sync(); e != nil {
+		return e
+	}
+	return s.fail("after_directory_sync")
+}
+func (s *Store) bootstrap(ctx context.Context) error {
+	dir, e := openRoot(s.root)
+	if e != nil {
+		return e
+	}
+	defer dir.Close()
+	// Refuse existing or interrupted state before allowing lock creation.
+	// In particular, Initialize must not recreate a lost expected lock inode.
+	for _, name := range []string{"namespace", "journal.json", "snapshot.tmp"} {
+		var st unix.Stat_t
+		err := unix.Fstatat(int(dir.Fd()), name, &st, unix.AT_SYMLINK_NOFOLLOW)
+		if err == nil {
+			return ErrRepair
+		}
+		if !errors.Is(err, unix.ENOENT) {
+			return wrap(err)
+		}
+	}
+	l, e := lock(ctx, dir, true)
+	if e != nil {
+		return e
+	}
+	defer l.Close()
+	names, e := dir.Readdirnames(-1)
+	if e != nil {
+		return e
+	}
+	for _, n := range names {
+		if n != "lock" {
+			return ErrRepair
+		}
+	}
+	ns, e := token()
+	if e != nil {
+		return e
+	}
+	f, e := openFile(dir, "namespace", unix.O_WRONLY|unix.O_CREAT|unix.O_EXCL)
+	if e != nil {
+		return e
+	}
+	defer f.Close()
+	if _, e = f.WriteString(ns + "\n"); e != nil {
+		return e
+	}
+	if e = f.Sync(); e != nil {
+		return e
+	}
+	if e = dir.Sync(); e != nil {
+		return e
+	}
+	if e = s.fail("after_namespace_sync"); e != nil {
+		return e
+	}
+	s.namespace = ns
+	d := &disk{Version: 1, Namespace: ns, Limits: s.limits, Records: map[string]Record{}, Events: []event{}}
+	if _, e = s.advance(d); e != nil {
+		return e
+	}
+	return s.write(ctx, dir, d)
+}

--- a/internal/agentnotify/journal/storage_unix.go
+++ b/internal/agentnotify/journal/storage_unix.go
@@ -31,22 +31,22 @@ func openRoot(path string) (*os.File, error) {
 	parts := strings.Split(strings.TrimPrefix(path, "/"), "/")
 	for i, p := range parts {
 		next, e := unix.Openat(fd, p, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0)
-		unix.Close(fd)
+		_ = unix.Close(fd)
 		if e != nil {
 			return nil, wrap(e)
 		}
 		fd = next
 		var st unix.Stat_t
 		if e = unix.Fstat(fd, &st); e != nil {
-			unix.Close(fd)
+			_ = unix.Close(fd)
 			return nil, e
 		}
 		last := i == len(parts)-1
 		uid := uint32(os.Geteuid())
 		safeOwner := st.Uid == uid || st.Uid == 0
-		unsafeWrite := st.Mode&0022 != 0 && !(safeOwner && st.Mode&unix.S_ISVTX != 0)
+		unsafeWrite := st.Mode&0022 != 0 && (!safeOwner || st.Mode&unix.S_ISVTX == 0)
 		if !safeOwner || unsafeWrite || (last && (st.Uid != uid || st.Mode&0777 != 0700)) {
-			unix.Close(fd)
+			_ = unix.Close(fd)
 			return nil, ErrRepair
 		}
 	}
@@ -59,11 +59,11 @@ func openFile(dir *os.File, name string, flags int) (*os.File, error) {
 	}
 	var st unix.Stat_t
 	if e = unix.Fstat(fd, &st); e != nil {
-		unix.Close(fd)
+		_ = unix.Close(fd)
 		return nil, e
 	}
 	if st.Mode&unix.S_IFMT != unix.S_IFREG || st.Uid != uint32(os.Geteuid()) || st.Nlink != 1 || st.Mode&0777 != 0600 {
-		unix.Close(fd)
+		_ = unix.Close(fd)
 		return nil, ErrRepair
 	}
 	return os.NewFile(uintptr(fd), name), nil
@@ -85,7 +85,7 @@ func lock(ctx context.Context, dir *os.File, create bool) (*os.File, error) {
 	}
 	for {
 		if e = ctx.Err(); e != nil {
-			f.Close()
+			_ = f.Close()
 			return nil, e
 		}
 		e = unix.Flock(int(f.Fd()), unix.LOCK_EX|unix.LOCK_NB)
@@ -93,14 +93,14 @@ func lock(ctx context.Context, dir *os.File, create bool) (*os.File, error) {
 			break
 		}
 		if e != unix.EAGAIN && e != unix.EWOULDBLOCK {
-			f.Close()
+			_ = f.Close()
 			return nil, e
 		}
 		timer := time.NewTimer(5 * time.Millisecond)
 		select {
 		case <-ctx.Done():
 			timer.Stop()
-			f.Close()
+			_ = f.Close()
 			return nil, ctx.Err()
 		case <-timer.C:
 		}
@@ -112,7 +112,7 @@ func lock(ctx context.Context, dir *os.File, create bool) (*os.File, error) {
 		e = unix.Fstatat(int(dir.Fd()), "lock", &b, unix.AT_SYMLINK_NOFOLLOW)
 	}
 	if e != nil || a.Ino != b.Ino || a.Dev != b.Dev || a.Nlink != 1 {
-		f.Close()
+		_ = f.Close()
 		return nil, ErrRepair
 	}
 	return f, nil // close releases kernel flock, including process death
@@ -122,7 +122,7 @@ func readBounded(dir *os.File, name string, max int) ([]byte, error) {
 	if e != nil {
 		return nil, wrap(e)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	st, e := f.Stat()
 	if e != nil {
 		return nil, e
@@ -181,12 +181,12 @@ func (s *Store) transaction(ctx context.Context, fn func(*disk) (bool, error)) e
 	if e != nil {
 		return e
 	}
-	defer dir.Close()
+	defer func() { _ = dir.Close() }()
 	l, e := lock(ctx, dir, false)
 	if e != nil {
 		return e
 	}
-	defer l.Close()
+	defer func() { _ = l.Close() }()
 	d, e := s.read(dir)
 	if e != nil {
 		return e
@@ -249,7 +249,7 @@ func (s *Store) write(ctx context.Context, dir *os.File, d *disk) error {
 	// One fixed, validated orphan slot bounds disk use after repeated crashes.
 	old, e := openFile(dir, "snapshot.tmp", unix.O_RDONLY)
 	if e == nil {
-		old.Close()
+		_ = old.Close()
 		if e = unix.Unlinkat(int(dir.Fd()), "snapshot.tmp", 0); e != nil {
 			return e
 		}
@@ -260,8 +260,8 @@ func (s *Store) write(ctx context.Context, dir *os.File, d *disk) error {
 	if e != nil {
 		return e
 	}
-	defer f.Close()
-	defer unix.Unlinkat(int(dir.Fd()), "snapshot.tmp", 0)
+	defer func() { _ = f.Close() }()
+	defer func() { _ = unix.Unlinkat(int(dir.Fd()), "snapshot.tmp", 0) }()
 	half := len(b) / 2
 	if _, e = f.Write(b[:half]); e != nil {
 		return e
@@ -306,7 +306,7 @@ func (s *Store) bootstrap(ctx context.Context) error {
 	if e != nil {
 		return e
 	}
-	defer dir.Close()
+	defer func() { _ = dir.Close() }()
 	// Refuse existing or interrupted state before allowing lock creation.
 	// In particular, Initialize must not recreate a lost expected lock inode.
 	for _, name := range []string{"namespace", "journal.json", "snapshot.tmp"} {
@@ -323,7 +323,7 @@ func (s *Store) bootstrap(ctx context.Context) error {
 	if e != nil {
 		return e
 	}
-	defer l.Close()
+	defer func() { _ = l.Close() }()
 	names, e := dir.Readdirnames(-1)
 	if e != nil {
 		return e
@@ -341,7 +341,7 @@ func (s *Store) bootstrap(ctx context.Context) error {
 	if e != nil {
 		return e
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	if _, e = f.WriteString(ns + "\n"); e != nil {
 		return e
 	}

--- a/internal/agentnotify/journal/storage_unsupported.go
+++ b/internal/agentnotify/journal/storage_unsupported.go
@@ -1,0 +1,8 @@
+//go:build !linux && !darwin
+
+package journal
+
+import "context"
+
+func (s *Store) bootstrap(context.Context) error                              { return ErrUnavailable }
+func (s *Store) transaction(context.Context, func(*disk) (bool, error)) error { return ErrUnavailable }

--- a/internal/agentnotify/journal/storage_unsupported_test.go
+++ b/internal/agentnotify/journal/storage_unsupported_test.go
@@ -1,0 +1,21 @@
+//go:build !linux && !darwin
+
+package journal
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestUnsupportedExplicitUnavailable(t *testing.T) {
+	if _, e := Open(context.Background(), Options{Root: t.TempDir()}); !errors.Is(e, ErrUnavailable) {
+		t.Fatal(e)
+	}
+	if _, e := Initialize(context.Background(), Options{Root: t.TempDir()}); !errors.Is(e, ErrUnavailable) {
+		t.Fatal(e)
+	}
+	if (PlatformClock{}).Sample().Available {
+		t.Fatal("unsupported clock")
+	}
+}


### PR DESCRIPTION
Adds the durable admission journal for agent-triggered notifications. Requests are scoped by source, session and key kind; an admission is persisted before delivery, and ambiguous outcomes remain replayable without granting another effect.

The package provides bounded snapshots, permanent kernel locking, conservative seven-day retention, atomic rate limits, attempt-token finalization and read-only lookup. Service/CLI wiring is the next integration step.

Stacked on #153 (`feat/agent-notify-native-protocol`). This is the journal portion of phase 4, prepared independently under the plan's parallel-work allowance. The 2,075 added lines keep the persistence invariant and its process/crash tests together; 1,007 lines are tests.

Validation:
- Independent source review: no actionable findings; source hashes verified before and after review.
- Linux focused tests, vet and race tests passed; Windows unsupported-platform path compiles.
- macOS package tests passed, including real child-process crash/concurrency fixtures; the Darwin kernel clock qualification passed separately.
- These checks cover journal behavior. Native delivery, installed Desktop E2E and release qualification remain separate gates.
