### PR TITLE
feat(native): add durable Codex thread click actions

### DIFF
--- a/swift-notifier/PROTOCOL.md
+++ b/swift-notifier/PROTOCOL.md
@@ -1,14 +1,13 @@
-# Native protocol v1 (PR1, inactive by default)
+# Native protocol v1 (PR1 + PR3, inactive by default)
 
-This is the native foundation only. No installer, hook or feature enablement is
-changed. New actions support only `none`; legacy CLI and persisted ClickAction
-activate/execute/combined data continue to use their existing decoder. PR3 must
-add its typed action and capability together; it must not repurpose legacy shell
-actions or claim Codex navigation in PR1.
+This is the native delivery/action lane. No installer, hook or feature enablement
+is changed. Structured actions support `none` and `desktop_thread_v1`; legacy CLI
+and persisted ClickAction activate/execute/combined data retain their existing
+codec and execution meaning. Structured input cannot manufacture shell actions.
 
 `--capabilities-json` must be the entire argv. It emits one JSON object plus LF,
 without creating NSApplication, UNUserNotificationCenter, a delegate, permission
-probe, sound or callback executor. It declares versions `[1]`, actions `["none"]`,
+probe, sound or callback executor. It declares versions `[1]`, actions `["none", "desktop_thread_v1"]`,
 receipt support and backend `macos.usernotifications`; this is protocol support,
 not authorization or a claim that a banner will appear. Future caller must verify
 the offline managed artifact fingerprint/protocol floor first, then run a private
@@ -41,7 +40,7 @@ invalid oversized/unowned files are left to the caller, never submitted.
 Required request keys: schemaVersion (integer 1), correlationID (directory UUID),
 nonce (filename UUID), bootID (`kern.bootsessionuuid`), notAfter (seconds from
 `mach_continuous_time` converted with mach_timebase_info), title, body, category
-(`info|attention|progress`), action (`none`), silent (boolean). Optional subtitle
+(`info|attention|progress`), action (`"none"` or the typed object below), silent (boolean). Optional subtitle
 is a single-line string or null. No unknown or duplicate keys, invalid UTF-8 or
 unpaired surrogate escapes. UTF-8 limits: title/subtitle 256 bytes, body 4096;
 Unicode control scalars (general category Cc, including NUL/ESC) are rejected
@@ -75,7 +74,7 @@ layer and not emitted by native.
 | --- | --- | --- |
 | malformed_request | rejected | JSON, fields, limits or correlation invalid |
 | unsupported_version | rejected | unsupported schema |
-| unsupported_action | rejected | action unavailable (including PR3 target) |
+| unsupported_action | rejected | action kind unavailable |
 | invalid_file | rejected | unsafe/missing/bounded file read failed |
 | expired | rejected | boot/deadline invalid or elapsed before handoff |
 | activation_required | rejected | permission undetermined; setup needed |
@@ -87,7 +86,7 @@ layer and not emitted by native.
 
 The caller's future spool/admission owner must impose total byte/count limits,
 retain attempts while LaunchServices may still launch, clean its expired orphans
-with a bounded scan on notify/status/setup, and remove directories only after
+with a bounded scan on notify/setup, and remove directories only after
 terminal receipt plus sender exit, or original deadline under its ownership
 protocol. PR1 creates no spool or request files and implements no journal,
 installer, global cleanup scan or daemon. This per-attempt native reader neither
@@ -102,3 +101,131 @@ not copied from inaccessible historical spike artifacts. Run the complete Swift
 suite on macOS. Linux source review cannot qualify AppKit/UN or macOS filesystem
 APIs. Native permission, delayed LaunchServices, sleep, atomic receipt, old
 artifact rejection and installed UI behavior remain macOS integration gates.
+
+## Desktop action contract
+
+`Tests/Fixtures/desktop-thread-v1.actions.json` and `$defs.desktop_thread_v1` in
+`native-v1.schema.json` are shared adapter fixtures. The action object contains
+exactly `type="desktop_thread_v1"`, `schemaVersion=1`, `threadID`,
+`routeKind="codex_thread"`, `bundleID="com.openai.codex"`, `teamID`,
+`applicationPath`, and `correlationID`. The action correlation must match the
+request correlation and the eventual UN notification identifier. Unknown fields,
+versions, duplicate keys and malformed Unicode fail closed.
+
+Thread ID is opaque, nonempty, at most 256 UTF-8 bytes, single line, without Cc
+controls; `.` and `..` are rejected. Cf scalars remain exact bytes. The encoder
+percent-encodes every byte except RFC3986 unreserved bytes into one path segment
+of `codex://threads/<segment>`; slash, percent, query and fragment characters
+cannot alter route structure. No raw URL, shell or alternate scheme is accepted.
+
+The trusted future Go adapter constructs this object from per-call metadata and
+explicit operator routing configuration; it must never expose these fields in
+the model tool schema. A private request file does not authenticate a same-UID
+caller. Startup environment, cwd, parent guessing and credentials are not target
+sources. The complete action JSON is serialized into UN userInfo under
+`desktop_thread_v1` before add. No request/cache/workspace path is needed by a
+later click; `applicationPath` refers only to the selected installed application.
+
+Setup must obtain an explicit canonical application location and expected signing
+team from an operator or trusted distribution source. Team IDs are ten uppercase
+ASCII letters/digits, with no universal team constant. On every click the selected
+existing directory must retain its canonical location, bundle ID and valid Apple
+Developer ID signature for that team across all architectures. Ad-hoc/unsigned
+builds and other distribution types are unsupported until qualified. A missing,
+moved or mismatched selected application fails closed with a bounded reason. This
+implementation checks at most 16 registered candidates on macOS 12+ only to
+classify a missing configured location as missing, moved or ambiguous; it never
+opens a replacement candidate. Older systems report missing. Setup must refresh
+moved locations. Multiple installed copies do not cause first-candidate selection.
+
+The opener exclusively uses `NSWorkspace.open(_:withApplicationAt:configuration:
+completionHandler:)`, with activation enabled. It neither invokes a shell nor
+uses the default URL handler. `open_requested` means the explicit application
+open completed positively, not that the visible chat was verified. Profile,
+account, exact window/Space, sign-out and archived/deleted chat detection are
+unavailable. Prior default-open exit 0/logs did not switch visible chat; its root
+cause remains unknown. Prior explicit-app observations are not this patch's
+native qualification.
+
+Callback acceptance and completion run on the main queue. A process-wide owner
+counts all in-flight callbacks, invalidates idle watchdog generations on accept,
+and completes each callback once on completion or its separate ten-second
+deadline. An idle-only watchdog expires ten seconds after the last callback
+finishes and all owned children are reaped; stale timers cannot terminate active
+callbacks or abandon owned children. Only default click and
+registered `OPEN` navigate; dismiss and unknown buttons complete without action.
+Late completion cannot decrement the counter twice. No unconditional startup or
+half-second callback termination remains. Callback timeout does not prove that
+an already issued OS open was cancelled and never permits retry.
+
+
+### Callback work ownership and diagnostics (review fixes)
+
+Configured-location discovery, registered-candidate lookup, canonicalization and
+Security verification run off the main queue. One process-wide admission gate
+allows at most two outstanding preflights, including scheduled work and pending
+result delivery; a full gate completes the new callback as `open_unknown` without
+queueing a job. A timeout invalidates a lock-protected token immediately, completes
+the callback, and cannot release a slot still occupied by an uncancellable system
+call. Workers check that token before subsequent discovery/verification steps and
+after blocking calls. Results return to the main queue and recheck the original
+deadline before issuing an open. No worker reads the lifecycle dictionary or waits
+for the main queue. Security itself has no cancellation/deadline API; a permanently
+blocked call can occupy a slot for the remaining process lifetime.
+
+Legacy `/bin/sh -c <unchanged command>` uses `posix_spawn` with
+`POSIX_SPAWN_SETPGROUP` and pgroup zero, establishing its own process group before
+exec. Deadline cleanup sends TERM only to that owned group, then KILL after 250 ms.
+Normal leader exit is observed with Darwin `waitid(WEXITED | WNOHANG |
+WNOWAIT)`, without consuming its status. While this unreaped leader reserves the
+PGID, a `sysctl(KERN_PROC_PGRP)` snapshot must contain only that zombie leader
+to prove ordinary same-group work drained. Other members, even zombies, retain
+ownership conservatively. Failed, truncated or oversized snapshots
+are unknown and retain ownership until another poll or deadline cleanup. A live
+helper may finish normally within the original callback deadline; a command with
+no helper can reap on its first exit observation, without waiting ten seconds.
+On timeout the direct child remains unreaped until the final group signal,
+preventing PID reuse during escalation. Only proven normal group drain or completed
+TERM/KILL escalation permits nonblocking `waitpid` to reap the direct child; idle
+exit remains inhibited until this barrier completes, even though the notification
+completion has already fired. No fixed kernel-reap latency is promised. Ordinary
+same-group shell descendants receive cleanup signals; commands deliberately
+creating a different session/group are outside group ownership. Successful command
+completion still precedes combined activation. Deliberate `setsid`/process-group
+escape is explicitly unsupported; no cached bare PID is signalled after reap.
+The single main-queue owner must remain the only consumer of this child's wait
+status. Forced notifier death remains outside this ownership guarantee.
+
+Legacy activation retains its running-application-first strategy, followed by
+bundle-ID lookup/open when no running target exists or activation fails. Both
+running-app discovery and LaunchServices lookup use off-main work admitted through
+the same two-slot gate as typed preflight. A held call keeps its slot through main
+result delivery, even after timeout. The original callback token/activity guard is
+carried through command completion, discovery and fallback; main rechecks it before
+every activation/open. Timeout and a second typed callback remain independent of
+a held legacy lookup. Native asynchronous opens cannot
+be cancelled; timeout remains unknown and never implies a visible target.
+
+Each callback emits two bounded JSON lines to stderr: `callback_received` and one
+`callback_terminal` with a fixed `outcome`. Both contain `correlationID`, the
+validated typed action UUID matching the notification identifier. Legacy, missing,
+or malformed target data instead receives a fresh event UUID shared by its two
+lines. Valid typed dismissals retain correlation while taking no action. No body,
+thread ID, path, shell text or raw userInfo is logged. Late/double completions do
+not emit another terminal event. These events report callback-stage evidence;
+production does not emit visible-target confirmation.
+
+`CallbackWorkTests` exercises the production `CallbackHandler`, executors and
+lifecycle using held discovery/Security and owned-child spies. A syscall seam also
+exercises the production child owner's signal/escalation/reap ordering without OS
+effects, including failed spawn and cancellation before spawn. The harmless real
+child/reap test is macOS-only qualification, explicitly enabled with
+`NOTIFIER_TEST_OWNED_CHILD=1`; ordinary unit tests do not launch children or apps.
+
+`LegacyFinalTests` adds production-owner leader-exits-first drain/timeout fixtures,
+no-helper immediate completion, guarded running-first/fallback delivery, and a held
+legacy lookup alongside a typed callback with zero late legacy opens. The actual
+Darwin leader-exits-first natural-drain and deadline-cleanup fixture is opt-in via
+`NOTIFIER_TEST_LEADER_EXITS_FIRST=1`; it runs only disposable `/bin/sleep` groups,
+without app UI. Darwin syscall compilation/runtime qualification must be performed
+on macOS; Linux source inspection does not establish those results.

--- a/swift-notifier/Sources/terminal-notifier-modern/Action/ActionExecutor.swift
+++ b/swift-notifier/Sources/terminal-notifier-modern/Action/ActionExecutor.swift
@@ -2,76 +2,127 @@ import AppKit
 import Foundation
 
 protocol ActionExecuting {
-    func execute(_ action: ClickAction)
+    func execute(_ action: ClickAction, isActive: @escaping () -> Bool, completion: @escaping () -> Void)
+    func execute(_ action: ClickAction, work: CallbackWork, completion: @escaping () -> Void)
+}
+
+extension ActionExecuting {
+    func execute(_ action: ClickAction, work: CallbackWork, completion: @escaping () -> Void) {
+        execute(action, isActive: { work.token.isActive }, completion: completion)
+    }
 }
 
 final class ActionExecutor: ActionExecuting {
+    // Only discovery runs on a worker; the returned activation and opener run on
+    // main, behind the original callback's activity check. Fixtures substitute
+    // these platform calls without replacing the activation control flow.
+    struct ActivationSystem {
+        let running: (String) -> (() -> Bool)?
+        let lookup: (String) -> URL?
+        let open: (URL, @escaping () -> Void) -> Void
+        static let live = ActivationSystem(running: { bundleID in
+            guard let app = NSRunningApplication.runningApplications(withBundleIdentifier: bundleID).first else { return nil }
+            return {
+                if #available(macOS 14.0, *) {
+                    return app.activate(from: NSRunningApplication.current, options: [.activateIgnoringOtherApps])
+                }
+                return app.activate(options: [.activateIgnoringOtherApps])
+            }
+        }, lookup: { NSWorkspace.shared.urlForApplication(withBundleIdentifier: $0) }, open: { url, done in
+            let configuration = NSWorkspace.OpenConfiguration()
+            configuration.activates = true
+            NSWorkspace.shared.openApplication(at: url, configuration: configuration) { _, _ in
+                DispatchQueue.main.async { done() }
+            }
+        })
+    }
+    typealias Worker = (@escaping () -> Void) -> Void
+    private let activationSystem: ActivationSystem
+    private let discoveryWork: Worker
+    private let deliverResult: Worker
+    private let admission: PreflightAdmission
+    private let makeCommand: (String) -> OwnedCommand
+    private let activation: ((String, @escaping () -> Void) -> Void)?
+    init(makeCommand: @escaping (String) -> OwnedCommand = { SpawnedCommand($0) },
+         activation: ((String, @escaping () -> Void) -> Void)? = nil,
+         activationSystem: ActivationSystem = .live,
+         discoveryWork: @escaping Worker = { DispatchQueue.global(qos: .utility).async(execute: $0) },
+         deliverResult: @escaping Worker = { DispatchQueue.main.async(execute: $0) },
+         admission: PreflightAdmission = .shared) {
+        self.makeCommand = makeCommand; self.activation = activation
+        self.activationSystem = activationSystem; self.discoveryWork = discoveryWork
+        self.deliverResult = deliverResult; self.admission = admission
+    }
+    func execute(_ action: ClickAction, work: CallbackWork, completion: @escaping () -> Void) {
+        execute(action, isActive: { work.token.isActive }, work: work, completion: completion)
+    }
 
-    func execute(_ action: ClickAction) {
+
+    func execute(_ action: ClickAction, isActive: @escaping () -> Bool, completion: @escaping () -> Void) {
+        execute(action, isActive: isActive, work: nil, completion: completion)
+    }
+    private func execute(_ action: ClickAction, isActive: @escaping () -> Bool,
+                         work: CallbackWork?, completion: @escaping () -> Void) {
+        guard isActive() else { completion(); return }
         switch action {
         case .activate(let bundleID):
-            activateApp(bundleID: bundleID)
+            activateApp(bundleID: bundleID, token: work?.token, isActive: isActive, completion: completion)
         case .execute(let command):
-            executeCommand(command)
+            executeCommand(command, work: work, completion: completion)
         case .executeAndActivate(let command, let bundleID):
-            executeCommand(command)
-            activateApp(bundleID: bundleID)
+            executeCommand(command, work: work) { [self] in
+                guard isActive() else { completion(); return }
+                activateApp(bundleID: bundleID, token: work?.token, isActive: isActive, completion: completion)
+            }
         case .none:
-            break
+            completion()
         }
     }
 
-    private func activateApp(bundleID: String) {
-        // Try NSRunningApplication.activate() first — it brings the app to
-        // front without creating a new window (unlike NSWorkspace.openApplication
-        // which causes Terminal.app to open a new window).
-        let runningApps = NSRunningApplication.runningApplications(
-            withBundleIdentifier: bundleID
-        )
-        if let app = runningApps.first {
-            var activated = false
-            if #available(macOS 14.0, *) {
-                activated = app.activate(from: NSRunningApplication.current, options: [.activateIgnoringOtherApps])
-            } else {
-                activated = app.activate(options: [.activateIgnoringOtherApps])
-            }
-            if activated {
-                return
-            }
-            // activate() failed (e.g. target is in fullscreen on another Space) —
-            // fall through to openApplication which is stronger but may create a new window
-        }
-
-        guard let url = NSWorkspace.shared.urlForApplication(
-            withBundleIdentifier: bundleID
-        ) else {
-            fputs("Warning: application not found for bundle ID: \(bundleID)\n", stderr)
-            return
-        }
-
-        let configuration = NSWorkspace.OpenConfiguration()
-        configuration.activates = true
-
-        NSWorkspace.shared.openApplication(
-            at: url,
-            configuration: configuration
-        ) { _, error in
-            if let error = error {
-                fputs("Warning: failed to activate application: \(error.localizedDescription)\n", stderr)
+    private func activateApp(bundleID: String, token: CallbackToken?,
+                             isActive: @escaping () -> Bool, completion: @escaping () -> Void) {
+        guard isActive() else { completion(); return }
+        if let activation = activation { activation(bundleID, completion); return }
+        guard admission.acquire() else { completion(); return }
+        discoveryWork { [self] in
+            let running = token?.isActive == false ? nil : activationSystem.running(bundleID)
+            deliverResult { [self] in
+                admission.release()
+                guard isActive() else { completion(); return }
+                // Preserve legacy running-first selection and its no-new-window
+                // activation. A failed activation keeps the same guarded fallback.
+                if let running = running {
+                    guard isActive() else { completion(); return }
+                    if running() { completion(); return }
+                }
+                lookupAndOpen(bundleID: bundleID, token: token, isActive: isActive, completion: completion)
             }
         }
     }
 
-    private func executeCommand(_ command: String) {
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/bin/sh")
-        process.arguments = ["-c", command]
+    private func lookupAndOpen(bundleID: String, token: CallbackToken?,
+                               isActive: @escaping () -> Bool, completion: @escaping () -> Void) {
+        guard isActive(), admission.acquire() else { completion(); return }
+        discoveryWork { [self] in
+            let url = token?.isActive == false ? nil : activationSystem.lookup(bundleID)
+            deliverResult { [self] in
+                // A stuck lookup holds its slot even after callback timeout.
+                admission.release()
+                guard isActive(), let url = url else { completion(); return }
+                activationSystem.open(url, completion)
+            }
+        }
+    }
 
-        do {
-            try process.run()
-            process.waitUntilExit()
-        } catch {
-            fputs("Warning: failed to execute command: \(error.localizedDescription)\n", stderr)
+    private func executeCommand(_ command: String, work: CallbackWork?, completion: @escaping () -> Void) {
+        let child = makeCommand(command)
+        let drained = work?.own(cancel: { child.cancel() }) ?? {}
+        var finished = false
+        child.start {
+            guard !finished else { return }
+            finished = true
+            drained()
+            completion()
         }
     }
 }

--- a/swift-notifier/Sources/terminal-notifier-modern/Action/CallbackHandler.swift
+++ b/swift-notifier/Sources/terminal-notifier-modern/Action/CallbackHandler.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+// The delegates and fixtures use this same production routing/ownership boundary.
+final class CallbackHandler {
+    private let lifecycle: CallbackLifecycle
+    private let desktop: DesktopThreadExecutor
+    private let legacy: ActionExecuting
+    init(lifecycle: CallbackLifecycle, desktop: DesktopThreadExecutor = DesktopThreadExecutor(),
+         legacy: ActionExecuting = ActionExecutor()) {
+        self.lifecycle = lifecycle; self.desktop = desktop; self.legacy = legacy
+    }
+    func receive(identifier: String, defaultIdentifier: String, notificationID: String,
+                 userInfo: [AnyHashable: Any], completion: @escaping () -> Void) {
+        let route = CallbackRoute.decode(identifier: identifier, defaultIdentifier: defaultIdentifier,
+                                         notificationID: notificationID, userInfo: userInfo)
+        // Decode a target independently of click selection so a valid dismissed
+        // notification is still attributable; malformed input never supplies IDs.
+        let validated = CallbackRoute.decode(identifier: defaultIdentifier, defaultIdentifier: defaultIdentifier,
+                                             notificationID: notificationID, userInfo: userInfo)
+        lifecycle.acceptOwned(correlation: validated.correlation, completion: completion) { [self] done, work in
+            switch route {
+            case .desktop(let action): desktop.execute(action, token: work.token, completion: done)
+            case .legacy(let action): legacy.execute(action, work: work) { done(.legacy_completed) }
+            case .malformed: done(.malformed_action)
+            case .ignored: done(.ignored)
+            }
+        }
+    }
+}

--- a/swift-notifier/Sources/terminal-notifier-modern/Action/CallbackLifecycle.swift
+++ b/swift-notifier/Sources/terminal-notifier-modern/Action/CallbackLifecycle.swift
@@ -1,0 +1,124 @@
+import Foundation
+
+enum CallbackOutcome: String {
+    case ignored, malformed_action, legacy_completed, open_requested, open_failed
+    case application_missing, application_moved, application_ambiguous, identity_mismatch, open_unknown
+}
+
+// Workers only inspect this token, never the main-queue lifecycle dictionary.
+final class CallbackToken {
+    private let lock = NSLock()
+    private var cancelled = false
+    private let deadline: Double
+    private let now: () -> Double
+    init(deadline: Double = .infinity,
+         now: @escaping () -> Double = { ProcessInfo.processInfo.systemUptime }) {
+        self.deadline = deadline; self.now = now
+    }
+    var isActive: Bool {
+        lock.lock(); defer { lock.unlock() }
+        return !cancelled && now() < deadline
+    }
+    func cancel() { lock.lock(); cancelled = true; lock.unlock() }
+}
+
+struct CallbackDiagnostic: Codable {
+    let event: String
+    let correlationID: UUID
+    let outcome: String?
+    var json: String {
+        // Only fixed event/outcome enums and a UUID enter this encoder.
+        String(decoding: try! JSONEncoder().encode(self), as: UTF8.self)
+    }
+}
+
+// Main-queue contract: acquire ownership before starting a child; release only
+// after reaping. Callback completion and owned-work drain are separate barriers.
+final class CallbackWork {
+    let token: CallbackToken
+    private let acquire: (@escaping () -> Void) -> (() -> Void)
+    init(token: CallbackToken, acquire: @escaping (@escaping () -> Void) -> (() -> Void)) {
+        self.token = token; self.acquire = acquire
+    }
+    func own(cancel: @escaping () -> Void) -> () -> Void { acquire(cancel) }
+}
+
+final class CallbackLifecycle {
+    typealias Schedule = (Double, @escaping () -> Void) -> Void
+    private let schedule: Schedule
+    private let exit: () -> Void
+    private let diagnostic: (String) -> Void
+    private let now: () -> Double
+    private struct Pending {
+        let token: CallbackToken
+        let correlation: UUID
+        let completion: () -> Void
+    }
+    private struct Owned { let callback: UUID; let cancel: () -> Void }
+    private var owned: [UUID: Owned] = [:]
+    private var generation = 0
+    private var callbacks: [UUID: Pending] = [:]
+    private(set) var stopped = false
+    var inFlight: Int { callbacks.count }
+    var ownedCount: Int { owned.count }
+    init(schedule: @escaping Schedule, exit: @escaping () -> Void,
+         diagnostic: @escaping (String) -> Void = { _ in },
+         now: @escaping () -> Double = { ProcessInfo.processInfo.systemUptime }) {
+        self.schedule = schedule; self.exit = exit; self.diagnostic = diagnostic; self.now = now
+    }
+    func start() { armIdle() }
+    func accept(completion: @escaping () -> Void,
+                operation: (@escaping (CallbackOutcome) -> Void, @escaping () -> Bool) -> Void) {
+        acceptOwned(completion: completion) { done, work in
+            operation(done, { work.token.isActive })
+        }
+    }
+    func acceptOwned(correlation: UUID = UUID(), completion: @escaping () -> Void,
+                     operation: (@escaping (CallbackOutcome) -> Void, CallbackWork) -> Void) {
+        diagnostic(CallbackDiagnostic(event: "callback_received", correlationID: correlation, outcome: nil).json)
+        guard !stopped else {
+            diagnostic(CallbackDiagnostic(event: "callback_terminal", correlationID: correlation,
+                                          outcome: CallbackOutcome.ignored.rawValue).json)
+            completion(); return
+        }
+        generation += 1
+        let id = UUID()
+        let token = CallbackToken(deadline: now() + 10, now: now)
+        callbacks[id] = Pending(token: token, correlation: correlation, completion: completion)
+        schedule(10) { [weak self] in self?.finish(id, outcome: .open_unknown) }
+        let work = CallbackWork(token: token) { [self] cancel in
+            let child = UUID()
+            owned[child] = Owned(callback: id, cancel: cancel)
+            generation += 1
+            if !token.isActive { cancel() }
+            return { [self] in
+                guard owned.removeValue(forKey: child) != nil else { return }
+                armIdle()
+            }
+        }
+        operation({ [weak self] outcome in self?.finish(id, outcome: outcome) }, work)
+    }
+    private func finish(_ id: UUID, outcome: CallbackOutcome) {
+        guard let pending = callbacks.removeValue(forKey: id) else { return }
+        let result = pending.token.isActive ? outcome : .open_unknown
+        pending.token.cancel()
+        // Snapshot permits a synchronous cancellation/reap seam to release ownership.
+        let cancellations = owned.values.filter { $0.callback == id }.map { $0.cancel }
+        cancellations.forEach { $0() }
+        diagnostic(CallbackDiagnostic(event: "callback_terminal", correlationID: pending.correlation,
+                                      outcome: result.rawValue).json)
+        pending.completion()
+        armIdle()
+    }
+    private func armIdle() {
+        guard callbacks.isEmpty, owned.isEmpty, !stopped else { return }
+        generation += 1
+        let expected = generation
+        schedule(10) { [weak self] in
+            guard let self = self, self.generation == expected,
+                  self.callbacks.isEmpty, self.owned.isEmpty, !self.stopped else { return }
+            self.stopped = true
+            self.exit()
+        }
+    }
+}

--- a/swift-notifier/Sources/terminal-notifier-modern/Action/CallbackRouter.swift
+++ b/swift-notifier/Sources/terminal-notifier-modern/Action/CallbackRouter.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+// Response selection is independent of UNNotificationResponse construction so
+// fixtures exercise the same dispatch boundary used by the application delegate.
+enum CallbackRoute {
+    case desktop(DesktopThreadAction)
+    case legacy(ClickAction)
+    case ignored
+    case malformed
+
+    // Only a decoded typed action, including its match to the notification ID,
+    // supplies trusted correlation. Legacy/malformed/dismiss input gets an event UUID.
+    var correlation: UUID {
+        if case .desktop(let action) = self,
+           let id = UUID(uuidString: action.correlationID) { return id }
+        return UUID()
+    }
+
+    static func decode(identifier: String, defaultIdentifier: String,
+                       notificationID: String, userInfo: [AnyHashable: Any]) -> CallbackRoute {
+        guard identifier == "OPEN" || identifier == defaultIdentifier else { return .ignored }
+        // A present but invalid typed action must never fall through to legacy.
+        if let value = userInfo["desktop_thread_v1"] {
+            guard let json = value as? String,
+                  let action = try? DesktopThreadAction.decode(Data(json.utf8)),
+                  action.correlationID == notificationID else { return .malformed }
+            return .desktop(action)
+        }
+        if let value = userInfo["action"] {
+            guard let json = value as? String, let action = ClickAction.fromJSON(json) else { return .malformed }
+            return .legacy(action)
+        }
+        return .ignored
+    }
+}

--- a/swift-notifier/Sources/terminal-notifier-modern/Action/DesktopThreadAction.swift
+++ b/swift-notifier/Sources/terminal-notifier-modern/Action/DesktopThreadAction.swift
@@ -1,0 +1,71 @@
+import Foundation
+
+// Trusted local adapter data, never model tool arguments. Identity is pinned by
+// setup, and reverified at click time; location is not an authority by itself.
+struct DesktopThreadAction: Codable, Equatable {
+    let type: String
+    let schemaVersion: Int
+    let threadID: String
+    let routeKind: String
+    let bundleID: String
+    let teamID: String
+    let applicationPath: String
+    let correlationID: String
+
+    func validate() throws {
+        guard type == "desktop_thread_v1", schemaVersion == 1,
+              routeKind == "codex_thread", bundleID == "com.openai.codex",
+              !threadID.isEmpty, threadID != ".", threadID != "..",
+              teamID.utf8.count == 10,
+              teamID.utf8.allSatisfy({ (65...90).contains($0) || (48...57).contains($0) }),
+              UUID(uuidString: correlationID) != nil,
+              applicationPath.hasPrefix("/"), applicationPath.hasSuffix(".app"),
+              URL(fileURLWithPath: applicationPath).standardizedFileURL.path == applicationPath
+        else { throw NativeReason.malformed_request }
+        try NativeCodec.text(threadID, limit: 256)
+        try NativeCodec.text(applicationPath, limit: 4096)
+    }
+
+    var url: URL {
+        // Encode UTF-8 bytes, allowing only unreserved characters in one segment.
+        let segment = threadID.utf8.map { byte -> String in
+            if (65...90).contains(byte) || (97...122).contains(byte) ||
+                (48...57).contains(byte) || [45, 46, 95, 126].contains(byte) {
+                return String(UnicodeScalar(byte))
+            }
+            return String(format: "%%%02X", byte)
+        }.joined()
+        return URL(string: "codex://threads/" + segment)!
+    }
+
+    static func decode(_ data: Data) throws -> DesktopThreadAction {
+        let object = try StrictJSON.object(data)
+        guard Set(object.keys) == Set(["type", "schemaVersion", "threadID", "routeKind",
+            "bundleID", "teamID", "applicationPath", "correlationID"]) else {
+            throw NativeReason.malformed_request
+        }
+        let action = try JSONDecoder().decode(Self.self, from: data)
+        try action.validate()
+        return action
+    }
+}
+
+enum NativeAction: Codable, Equatable {
+    case none
+    case desktopThread(DesktopThreadAction)
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if let string = try? container.decode(String.self), string == "none" { self = .none; return }
+        let action = try container.decode(DesktopThreadAction.self)
+        try action.validate()
+        self = .desktopThread(action)
+    }
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .none: try container.encode("none")
+        case .desktopThread(let action): try action.validate(); try container.encode(action)
+        }
+    }
+}

--- a/swift-notifier/Sources/terminal-notifier-modern/Action/DesktopThreadExecutor.swift
+++ b/swift-notifier/Sources/terminal-notifier-modern/Action/DesktopThreadExecutor.swift
@@ -1,0 +1,127 @@
+import AppKit
+import Security
+
+typealias DesktopOpenResult = CallbackOutcome
+protocol ApplicationDiscovering {
+    func selectedApplication(path: String) -> URL?
+    func registeredApplications(bundleID: String) -> [URL]
+}
+protocol ApplicationVerifying { func verify(_ url: URL, bundleID: String, teamID: String) -> Bool }
+protocol DesktopURLOpening { func open(_ url: URL, application: URL, completion: @escaping (Bool) -> Void) }
+
+struct ConfiguredApplicationDiscovery: ApplicationDiscovering {
+    func registeredApplications(bundleID: String) -> [URL] {
+        if #available(macOS 12.0, *) {
+            return NSWorkspace.shared.urlsForApplications(withBundleIdentifier: bundleID)
+        }
+        return [] // Older supported systems require the configured location.
+    }
+    func selectedApplication(path: String) -> URL? {
+        let url = URL(fileURLWithPath: path)
+        var directory: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: path, isDirectory: &directory), directory.boolValue else { return nil }
+        return url.resolvingSymlinksInPath().standardizedFileURL
+    }
+}
+struct SignedApplicationVerifier: ApplicationVerifying {
+    func verify(_ url: URL, bundleID: String, teamID: String) -> Bool {
+        guard bundleID == "com.openai.codex", Bundle(url: url)?.bundleIdentifier == bundleID else { return false }
+        // Apple-anchored Developer ID distribution; expected team comes from explicit
+        // operator configuration. Ad-hoc, unsigned and other teams fail closed.
+        let expression = "anchor apple generic and identifier \"com.openai.codex\" and certificate leaf[subject.OU] = \"\(teamID)\" and certificate leaf[field.1.2.840.113635.100.6.1.13] exists"
+        var requirement: SecRequirement?
+        var code: SecStaticCode?
+        guard SecRequirementCreateWithString(expression as CFString, [], &requirement) == errSecSuccess,
+              SecStaticCodeCreateWithPath(url as CFURL, [], &code) == errSecSuccess,
+              let code = code, let requirement = requirement else { return false }
+        return SecStaticCodeCheckValidity(code, SecCSFlags(rawValue: kSecCSCheckAllArchitectures | kSecCSStrictValidate), requirement) == errSecSuccess
+    }
+}
+struct WorkspaceDesktopOpener: DesktopURLOpening {
+    func open(_ url: URL, application: URL, completion: @escaping (Bool) -> Void) {
+        let configuration = NSWorkspace.OpenConfiguration()
+        configuration.activates = true
+        NSWorkspace.shared.open([url], withApplicationAt: application, configuration: configuration) { app, error in
+            DispatchQueue.main.async { completion(error == nil && app != nil) }
+        }
+    }
+}
+// A refused admission schedules no job. Slots include queued/running work and
+// are released only when the underlying synchronous preflight returns.
+final class PreflightAdmission {
+    static let shared = PreflightAdmission(limit: 2)
+    private let lock = NSLock()
+    private let limit: Int
+    private var count = 0
+    init(limit: Int) { precondition(limit > 0); self.limit = limit }
+    func acquire() -> Bool {
+        lock.lock(); defer { lock.unlock() }
+        guard count < limit else { return false }
+        count += 1; return true
+    }
+    func release() { lock.lock(); count -= 1; lock.unlock() }
+}
+
+final class DesktopThreadExecutor {
+    private let discovery: ApplicationDiscovering
+    private let verifier: ApplicationVerifying
+    private let opener: DesktopURLOpening
+    typealias Work = (@escaping () -> Void) -> Void
+    private let verificationWork: Work
+    private let deliverResult: Work
+    private let admission: PreflightAdmission
+    init(discovery: ApplicationDiscovering = ConfiguredApplicationDiscovery(),
+         verifier: ApplicationVerifying = SignedApplicationVerifier(),
+         opener: DesktopURLOpening = WorkspaceDesktopOpener(),
+         verificationWork: @escaping Work = { work in DispatchQueue.global(qos: .utility).async(execute: work) },
+         deliverResult: @escaping Work = { work in DispatchQueue.main.async(execute: work) },
+         admission: PreflightAdmission = .shared) {
+        self.discovery = discovery; self.verifier = verifier; self.opener = opener
+        self.verificationWork = verificationWork; self.deliverResult = deliverResult
+        self.admission = admission
+    }
+    func execute(_ action: DesktopThreadAction, token: CallbackToken = CallbackToken(),
+                 isActive: @escaping () -> Bool = { true }, completion: @escaping (DesktopOpenResult) -> Void) {
+        guard token.isActive && isActive() else { completion(.open_unknown); return }
+        do { try action.validate() }
+        catch { completion(.malformed_action); return }
+        guard admission.acquire() else { completion(.open_unknown); return }
+        verificationWork { [self] in
+            let result = preflight(action, token: token)
+            deliverResult { [self] in
+                admission.release()
+                // isActive is a compatibility seam, called only on the callback queue.
+                guard token.isActive && isActive() else { completion(.open_unknown); return }
+                switch result {
+                case .success(let app):
+                    opener.open(action.url, application: app) { completion($0 ? .open_requested : .open_failed) }
+                case .failure(let outcome): completion(outcome)
+                }
+            }
+        }
+    }
+    private enum PreflightResult { case success(URL), failure(CallbackOutcome) }
+    private func preflight(_ action: DesktopThreadAction, token: CallbackToken) -> PreflightResult {
+        guard token.isActive else { return .failure(.open_unknown) }
+        let app = discovery.selectedApplication(path: action.applicationPath)
+        guard token.isActive else { return .failure(.open_unknown) }
+        if let app = app {
+            guard app.path == action.applicationPath else { return .failure(.application_moved) }
+            let valid = verifier.verify(app, bundleID: action.bundleID, teamID: action.teamID)
+            guard token.isActive else { return .failure(.open_unknown) }
+            return valid ? .success(app) : .failure(.identity_mismatch)
+        }
+        let registered = discovery.registeredApplications(bundleID: action.bundleID)
+        guard token.isActive else { return .failure(.open_unknown) }
+        guard registered.count <= 16 else { return .failure(.application_ambiguous) }
+        var paths = Set<String>()
+        for url in registered {
+            guard token.isActive else { return .failure(.open_unknown) }
+            let valid = verifier.verify(url, bundleID: action.bundleID, teamID: action.teamID)
+            guard token.isActive else { return .failure(.open_unknown) }
+            if valid { paths.insert(url.resolvingSymlinksInPath().standardizedFileURL.path) }
+        }
+        return .failure(paths.count > 1 ? .application_ambiguous :
+            (paths.isEmpty ? .application_missing : .application_moved))
+    }
+}

--- a/swift-notifier/Sources/terminal-notifier-modern/Action/OwnedCommand.swift
+++ b/swift-notifier/Sources/terminal-notifier-modern/Action/OwnedCommand.swift
@@ -1,0 +1,144 @@
+import Foundation
+import Darwin
+
+protocol OwnedCommand: AnyObject {
+    // Completion means spawn failed or the owned child was reaped, not timeout.
+    func start(completion: @escaping () -> Void)
+    func cancel()
+}
+
+// All methods/timers are main-queue confined. POSIX_SPAWN_SETPGROUP establishes
+// ownership atomically in the child before exec; no parent-side setpgid race.
+final class SpawnedCommand: OwnedCommand {
+    // Small syscall seam: fixtures exercise this owner's real escalation/reap
+    // control flow without spawning or signalling anything.
+    struct System {
+        let spawn: (String) -> pid_t?
+        let signalGroup: (pid_t, Int32) -> Void
+        let reap: (pid_t) -> Bool
+        let leaderExited: (pid_t) -> Bool
+        let groupDrained: (pid_t) -> Bool
+
+        init(spawn: @escaping (String) -> pid_t?,
+             signalGroup: @escaping (pid_t, Int32) -> Void,
+             reap: @escaping (pid_t) -> Bool,
+             leaderExited: @escaping (pid_t) -> Bool,
+             groupDrained: @escaping (pid_t) -> Bool) {
+            self.spawn = spawn; self.signalGroup = signalGroup; self.reap = reap
+            self.leaderExited = leaderExited; self.groupDrained = groupDrained
+        }
+        static let live = System(spawn: { (command: String) -> pid_t? in
+            var attributes: posix_spawnattr_t?
+            guard posix_spawnattr_init(&attributes) == 0 else { return nil }
+            defer { posix_spawnattr_destroy(&attributes) }
+            guard posix_spawnattr_setflags(&attributes, Int16(POSIX_SPAWN_SETPGROUP)) == 0,
+                  posix_spawnattr_setpgroup(&attributes, 0) == 0 else { return nil }
+            let arguments = ["/bin/sh", "-c", command].map { value in value.withCString { strdup($0) } }
+            defer { arguments.forEach { free($0) } }
+            guard arguments.allSatisfy({ $0 != nil }) else { return nil }
+            // Foundation exposes the inherited environment without relying on the
+            // private CRT _NSGetEnviron symbol, unavailable to Swift here.
+            let environment = ProcessInfo.processInfo.environment.map { entry in "\(entry.key)=\(entry.value)".withCString { strdup($0) } }
+            defer { environment.forEach { free($0) } }
+            guard environment.allSatisfy({ $0 != nil }) else { return nil }
+            var envp = environment + [nil]
+            var argv = arguments + [nil]
+            var pid: pid_t = 0
+            let result = argv.withUnsafeMutableBufferPointer { buffer in
+                envp.withUnsafeMutableBufferPointer { environmentBuffer in
+                    posix_spawn(&pid, "/bin/sh", nil, &attributes, buffer.baseAddress!, environmentBuffer.baseAddress!)
+                }
+            }
+            return result == 0 ? pid : nil
+        }, signalGroup: { pid, signal in
+            _ = kill(-pid, signal)
+        }, reap: { pid in
+            var status: Int32 = 0
+            let result = waitpid(pid, &status, WNOHANG)
+            return result == pid || (result == -1 && errno == ECHILD)
+        }, leaderExited: { pid in
+            var info = siginfo_t()
+            // WNOWAIT reserves the leader PID (and hence our PGID) until drain.
+            return waitid(P_PID, id_t(pid), &info, WEXITED | WNOHANG | WNOWAIT) == 0
+                && info.si_pid == pid
+        }, groupDrained: { pid in
+            // A zombie leader alone makes kill(-pgid, 0) useless for this test.
+            // Require a kernel snapshot containing only our zombie leader. Other
+            // members (even zombies) conservatively retain ownership. Any error,
+            // truncation or oversized group is unknown, never evidence of drain.
+            var mib: [Int32] = [CTL_KERN, KERN_PROC, KERN_PROC_PGRP, pid]
+            var bytes = 0
+            guard sysctl(&mib, 4, nil, &bytes, nil, 0) == 0 else { return false }
+            let stride = MemoryLayout<kinfo_proc>.stride
+            let capacity = bytes / stride + 16
+            guard capacity <= 4096 else { return false }
+            var entries = [kinfo_proc](repeating: kinfo_proc(), count: capacity)
+            bytes = capacity * stride
+            let result = entries.withUnsafeMutableBytes { buffer in
+                sysctl(&mib, 4, buffer.baseAddress, &bytes, nil, 0)
+            }
+            guard result == 0, bytes < capacity * stride, bytes % stride == 0 else { return false }
+            let snapshot = entries.prefix(bytes / stride)
+            // Require the reserved leader to be visible; an empty/filtered result
+            // must not accidentally prove that an owned group has drained.
+            guard snapshot.count == 1, let leader = snapshot.first else { return false }
+            return leader.kp_proc.p_pid == pid && Int32(leader.kp_proc.p_stat) == SZOMB
+        })
+    }
+    private let command: String
+    private let system: System
+    private let schedule: CallbackLifecycle.Schedule
+    private var pid: pid_t = 0
+    var processID: pid_t { pid }
+    private var completion: (() -> Void)?
+    private var cancelled = false
+    private var escalating = false
+    private var started = false
+    init(_ command: String, system: System = .live, schedule: @escaping CallbackLifecycle.Schedule = { delay, work in
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: work)
+    }) { self.command = command; self.system = system; self.schedule = schedule }
+
+    func start(completion: @escaping () -> Void) {
+        precondition(!started)
+        started = true
+        guard !cancelled else { completion(); return }
+        self.completion = completion
+        guard let spawned = system.spawn(command), spawned > 0 else { finish(); return }
+        pid = spawned
+        poll()
+    }
+    func cancel() {
+        guard !cancelled else { return }
+        cancelled = true
+        guard pid > 0 else { return }
+        escalating = true
+        system.signalGroup(pid, SIGTERM)
+        // Keep the leader unreaped until the final group signal: its reserved PID
+        // prevents a recycled PID/group from being signalled by the delayed timer.
+        schedule(0.25) { [self] in
+            guard pid > 0 else { return }
+            system.signalGroup(pid, SIGKILL)
+            escalating = false
+            poll()
+        }
+    }
+    private func poll() {
+        guard pid > 0, !escalating else { return }
+        // Normal exit is only observed, never consumed while helpers may run.
+        // They retain the original callback deadline and may finish successfully.
+        // After bounded cancellation the last group signal has already happened.
+        if (cancelled || (system.leaderExited(pid) && system.groupDrained(pid))) && system.reap(pid) {
+            pid = 0
+            finish()
+        } else {
+            // No blocking wait on the callback queue. If the kernel cannot yet
+            // reap a killed child, ownership continues to inhibit idle exit.
+            schedule(0.05) { [self] in poll() }
+        }
+    }
+    private func finish() {
+        let done = completion
+        completion = nil
+        done?()
+    }
+}

--- a/swift-notifier/Sources/terminal-notifier-modern/App/AppDelegate.swift
+++ b/swift-notifier/Sources/terminal-notifier-modern/App/AppDelegate.swift
@@ -3,6 +3,7 @@ import UserNotifications
 
 final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDelegate {
 
+    let lifecycle = ProcessCallbackLifecycle.shared
     private let actionExecutor: ActionExecuting
 
     init(actionExecutor: ActionExecuting = ActionExecutor()) {
@@ -19,28 +20,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         didReceive response: UNNotificationResponse,
         withCompletionHandler completionHandler: @escaping () -> Void
     ) {
-        switch response.actionIdentifier {
-        case "DISMISS", UNNotificationDismissActionIdentifier:
-            break
-        case "OPEN", UNNotificationDefaultActionIdentifier:
-            let userInfo = response.notification.request.content.userInfo
-            if let actionJSON = userInfo["action"] as? String,
-               let action = ClickAction.fromJSON(actionJSON) {
-                actionExecutor.execute(action)
-            }
-        default:
-            let userInfo = response.notification.request.content.userInfo
-            if let actionJSON = userInfo["action"] as? String,
-               let action = ClickAction.fromJSON(actionJSON) {
-                actionExecutor.execute(action)
-            }
+        let handle = { [self] in
+            CallbackHandler(lifecycle: lifecycle, legacy: actionExecutor).receive(
+                identifier: response.actionIdentifier,
+                defaultIdentifier: UNNotificationDefaultActionIdentifier,
+                notificationID: response.notification.request.identifier,
+                userInfo: response.notification.request.content.userInfo,
+                completion: completionHandler)
         }
-
-        completionHandler()
-
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-            NSApplication.shared.terminate(nil)
-        }
+        if Thread.isMainThread { handle() }
+        else { DispatchQueue.main.async(execute: handle) }
     }
 
     func userNotificationCenter(

--- a/swift-notifier/Sources/terminal-notifier-modern/App/ProcessCallbackLifecycle.swift
+++ b/swift-notifier/Sources/terminal-notifier-modern/App/ProcessCallbackLifecycle.swift
@@ -1,0 +1,10 @@
+import AppKit
+
+// Both current and legacy notification delegates share this single process owner.
+enum ProcessCallbackLifecycle {
+    static let shared = CallbackLifecycle(schedule: { delay, work in
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: work)
+    }, exit: { NSApplication.shared.terminate(nil) }, diagnostic: {
+        fputs("\($0)\n", stderr)
+    })
+}

--- a/swift-notifier/Sources/terminal-notifier-modern/Notification/NSNotificationService.swift
+++ b/swift-notifier/Sources/terminal-notifier-modern/Notification/NSNotificationService.swift
@@ -48,14 +48,16 @@ final class NSNotificationDelegate: NSObject, NSUserNotificationCenterDelegate {
         _ center: NSUserNotificationCenter,
         didActivate notification: NSUserNotification
     ) {
-        if let actionJSON = notification.userInfo?["action"] as? String,
-           let action = ClickAction.fromJSON(actionJSON) {
-            actionExecutor.execute(action)
+        let handle = { [self] in
+            let clicked = notification.activationType == .contentsClicked ||
+                          notification.activationType == .actionButtonClicked
+            CallbackHandler(lifecycle: ProcessCallbackLifecycle.shared, legacy: actionExecutor).receive(
+                identifier: clicked ? "OPEN" : "DISMISS", defaultIdentifier: "OPEN",
+                notificationID: notification.identifier ?? "", userInfo: notification.userInfo ?? [:],
+                completion: {})
         }
-
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-            NSApplication.shared.terminate(nil)
-        }
+        if Thread.isMainThread { handle() }
+        else { DispatchQueue.main.async(execute: handle) }
     }
 
     func userNotificationCenter(

--- a/swift-notifier/Sources/terminal-notifier-modern/Protocol/NativeProtocol.swift
+++ b/swift-notifier/Sources/terminal-notifier-modern/Protocol/NativeProtocol.swift
@@ -1,8 +1,5 @@
 import Foundation
 
-// Separate from legacy ClickAction: new send cannot manufacture shell actions.
-// PR3 can add a versioned typed action without changing the legacy decoder.
-enum NativeAction: String, Codable { case none }
 enum NativeStatus: String, Codable { case rejected, suppressed, submitted, unknown }
 enum NativeReason: String, Codable, Error {
     case malformed_request, unsupported_version, unsupported_action, invalid_file
@@ -56,7 +53,7 @@ struct NativeCapabilities: Codable, Equatable {
     init() {
         schemaVersion = 1
         protocolVersions = [1]
-        actionKinds = ["none"]
+        actionKinds = ["none", "desktop_thread_v1"]
         receiptSupport = true
         backend = "macos.usernotifications"
         explicitFeatureEnabledByDefault = false
@@ -88,7 +85,10 @@ enum NativeCodec {
               CFGetTypeID(version) != CFBooleanGetTypeID(), version.doubleValue == 1 else {
             throw NativeReason.unsupported_version
         }
-        guard object["action"] as? String == "none" else { throw NativeReason.unsupported_action }
+        if object["action"] as? String != "none" {
+            guard let action = object["action"] as? [String: Any] else { throw NativeReason.unsupported_action }
+            _ = try DesktopThreadAction.decode(JSONSerialization.data(withJSONObject: action))
+        }
         let request: NativeRequest
         do { request = try JSONDecoder().decode(NativeRequest.self, from: data) }
         catch { throw NativeReason.malformed_request }
@@ -96,6 +96,9 @@ enum NativeCodec {
               UUID(uuidString: request.nonce) != nil,
               !request.bootID.isEmpty, request.bootID.utf8.count <= 256,
               request.notAfter.isFinite, request.notAfter > 0 else { throw NativeReason.malformed_request }
+        if case .desktopThread(let action) = request.action {
+            guard action.correlationID == request.correlationID else { throw NativeReason.malformed_request }
+        }
         try text(request.title, limit: 256)
         try text(request.body, limit: 4096, multiline: true)
         if let subtitle = request.subtitle { try text(subtitle, limit: 256) }
@@ -135,7 +138,7 @@ import CoreFoundation
 
 // Foundation decoders may accept duplicate keys. Walk the bounded JSON syntax
 // before decoding, comparing decoded keys (including escaped spellings).
-private struct StrictJSON {
+struct StrictJSON {
     var bytes: [UInt8]
     var i = 0
     static func object(_ data: Data) throws -> [String: Any] {

--- a/swift-notifier/Sources/terminal-notifier-modern/Protocol/StructuredRuntime.swift
+++ b/swift-notifier/Sources/terminal-notifier-modern/Protocol/StructuredRuntime.swift
@@ -31,15 +31,32 @@ private final class StructuredUNBackend: NativeBackend {
         }
     }
     func add(_ request: NativeRequest, completion: @escaping (Bool) -> Void) {
+        let content: UNMutableNotificationContent
+        do { content = try StructuredNotificationContent.make(request) }
+        catch { completion(false); return }
+        if case .desktopThread = request.action { NotificationCategory.register() }
+        center.add(UNNotificationRequest(identifier: request.correlationID, content: content, trigger: nil)) { error in
+            DispatchQueue.main.async { completion(error == nil) }
+        }
+    }
+}
+
+enum StructuredNotificationContent {
+    static func make(_ request: NativeRequest) throws -> UNMutableNotificationContent {
         let content = UNMutableNotificationContent()
         content.title = request.title
         content.body = request.body
         content.subtitle = request.subtitle ?? ""
         content.sound = request.silent ? nil : .default
-        // PR1 supports no navigation. No legacy action, shell, category or route.
-        center.add(UNNotificationRequest(identifier: request.correlationID, content: content, trigger: nil)) { error in
-            DispatchQueue.main.async { completion(error == nil) }
+        if case .desktopThread(let action) = request.action {
+            try action.validate()
+            guard action.correlationID == request.correlationID else { throw NativeReason.malformed_request }
+            guard let data = try? JSONEncoder().encode(action),
+                  let json = String(data: data, encoding: .utf8) else { throw NativeReason.malformed_request }
+            content.userInfo = ["desktop_thread_v1": json]
+            content.categoryIdentifier = NotificationCategory.categoryIdentifier
         }
+        return content
     }
 }
 

--- a/swift-notifier/Sources/terminal-notifier-modern/main.swift
+++ b/swift-notifier/Sources/terminal-notifier-modern/main.swift
@@ -132,9 +132,7 @@ func runCallbackMode() {
     app.delegate = appDelegate
     UNUserNotificationCenter.current().delegate = appDelegate
 
-    DispatchQueue.main.asyncAfter(deadline: .now() + 10) {
-        NSApplication.shared.terminate(nil)
-    }
+    appDelegate.lifecycle.start()
 
     withExtendedLifetime(appDelegate) {
         app.run()

--- a/swift-notifier/Tests/Fixtures/desktop-thread-v1.actions.json
+++ b/swift-notifier/Tests/Fixtures/desktop-thread-v1.actions.json
@@ -1,0 +1,130 @@
+{
+  "valid": [
+    {
+      "action": {
+        "type": "desktop_thread_v1",
+        "schemaVersion": 1,
+        "threadID": "thread/other?#%👩‍💻",
+        "routeKind": "codex_thread",
+        "bundleID": "com.openai.codex",
+        "teamID": "TESTTEAM01",
+        "applicationPath": "/disposable/Codex.app",
+        "correlationID": "00000000-0000-4000-8000-000000000001"
+      },
+      "uri": "codex://threads/thread%2Fother%3F%23%25%F0%9F%91%A9%E2%80%8D%F0%9F%92%BB"
+    }
+  ],
+  "invalid": [
+    {
+      "type": "desktop_thread_v1",
+      "schemaVersion": 2,
+      "threadID": "thread/other?#%👩‍💻",
+      "routeKind": "codex_thread",
+      "bundleID": "com.openai.codex",
+      "teamID": "TESTTEAM01",
+      "applicationPath": "/disposable/Codex.app",
+      "correlationID": "00000000-0000-4000-8000-000000000001"
+    },
+    {
+      "type": "desktop_thread_v1",
+      "schemaVersion": true,
+      "threadID": "thread/other?#%👩‍💻",
+      "routeKind": "codex_thread",
+      "bundleID": "com.openai.codex",
+      "teamID": "TESTTEAM01",
+      "applicationPath": "/disposable/Codex.app",
+      "correlationID": "00000000-0000-4000-8000-000000000001"
+    },
+    {
+      "type": "execute",
+      "schemaVersion": 1,
+      "threadID": "thread/other?#%👩‍💻",
+      "routeKind": "codex_thread",
+      "bundleID": "com.openai.codex",
+      "teamID": "TESTTEAM01",
+      "applicationPath": "/disposable/Codex.app",
+      "correlationID": "00000000-0000-4000-8000-000000000001"
+    },
+    {
+      "type": "desktop_thread_v1",
+      "schemaVersion": 1,
+      "threadID": "thread/other?#%👩‍💻",
+      "routeKind": "codex_thread",
+      "bundleID": "com.openai.codex",
+      "teamID": "TESTTEAM01",
+      "applicationPath": "/disposable/Codex.app",
+      "correlationID": "00000000-0000-4000-8000-000000000001",
+      "url": "https://example.com"
+    },
+    {
+      "type": "desktop_thread_v1",
+      "schemaVersion": 1,
+      "threadID": "..",
+      "routeKind": "codex_thread",
+      "bundleID": "com.openai.codex",
+      "teamID": "TESTTEAM01",
+      "applicationPath": "/disposable/Codex.app",
+      "correlationID": "00000000-0000-4000-8000-000000000001"
+    },
+    {
+      "type": "desktop_thread_v1",
+      "schemaVersion": 1,
+      "threadID": "bad",
+      "routeKind": "codex_thread",
+      "bundleID": "com.openai.codex",
+      "teamID": "TESTTEAM01",
+      "applicationPath": "/disposable/Codex.app",
+      "correlationID": "00000000-0000-4000-8000-000000000001"
+    },
+    {
+      "type": "desktop_thread_v1",
+      "schemaVersion": 1,
+      "threadID": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+      "routeKind": "codex_thread",
+      "bundleID": "com.openai.codex",
+      "teamID": "TESTTEAM01",
+      "applicationPath": "/disposable/Codex.app",
+      "correlationID": "00000000-0000-4000-8000-000000000001"
+    },
+    {
+      "type": "desktop_thread_v1",
+      "schemaVersion": 1,
+      "threadID": "thread/other?#%👩‍💻",
+      "routeKind": "codex_thread",
+      "bundleID": "com.openai.codex",
+      "teamID": "evil",
+      "applicationPath": "/disposable/Codex.app",
+      "correlationID": "00000000-0000-4000-8000-000000000001"
+    },
+    {
+      "type": "desktop_thread_v1",
+      "schemaVersion": 1,
+      "threadID": "thread/other?#%👩‍💻",
+      "routeKind": "codex_thread",
+      "bundleID": "com.other.app",
+      "teamID": "TESTTEAM01",
+      "applicationPath": "/disposable/Codex.app",
+      "correlationID": "00000000-0000-4000-8000-000000000001"
+    },
+    {
+      "type": "desktop_thread_v1",
+      "schemaVersion": 1,
+      "threadID": "thread/other?#%👩‍💻",
+      "routeKind": "codex_thread",
+      "bundleID": "com.openai.codex",
+      "teamID": "TESTTEAM01",
+      "applicationPath": "/a/../Codex.app",
+      "correlationID": "00000000-0000-4000-8000-000000000001"
+    },
+    {
+      "type": "desktop_thread_v1",
+      "schemaVersion": 1,
+      "threadID": "thread/other?#%👩‍💻",
+      "routeKind": "codex_thread",
+      "bundleID": "com.openai.codex",
+      "teamID": "TESTTEAM01",
+      "applicationPath": "/disposable/Codex.app",
+      "correlationID": "bad"
+    }
+  ]
+}

--- a/swift-notifier/Tests/Fixtures/native-v1.capabilities.json
+++ b/swift-notifier/Tests/Fixtures/native-v1.capabilities.json
@@ -4,7 +4,8 @@
     1
   ],
   "actionKinds": [
-    "none"
+    "none",
+    "desktop_thread_v1"
   ],
   "receiptSupport": true,
   "backend": "macos.usernotifications",

--- a/swift-notifier/Tests/Fixtures/native-v1.schema.json
+++ b/swift-notifier/Tests/Fixtures/native-v1.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "title": "Native PR1 protocol",
+  "title": "Native protocol v1 with PR3 desktop action",
   "description": "Choose a $defs schema. Runtime also checks UTF-8 byte limits, duplicates, controls, boot deadline and filename correlation. Entire wire request <=16384 bytes.",
   "$defs": {
     "request": {
@@ -64,7 +64,14 @@
           ]
         },
         "action": {
-          "const": "none"
+          "oneOf": [
+            {
+              "const": "none"
+            },
+            {
+              "$ref": "#/$defs/desktop_thread_v1"
+            }
+          ]
         },
         "silent": {
           "type": "boolean"
@@ -193,7 +200,8 @@
         },
         "actionKinds": {
           "const": [
-            "none"
+            "none",
+            "desktop_thread_v1"
           ]
         },
         "receiptSupport": {
@@ -204,6 +212,53 @@
         },
         "explicitFeatureEnabledByDefault": {
           "const": false
+        }
+      }
+    },
+    "desktop_thread_v1": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "type",
+        "schemaVersion",
+        "threadID",
+        "routeKind",
+        "bundleID",
+        "teamID",
+        "applicationPath",
+        "correlationID"
+      ],
+      "properties": {
+        "type": {
+          "const": "desktop_thread_v1"
+        },
+        "schemaVersion": {
+          "const": 1
+        },
+        "threadID": {
+          "type": "string",
+          "minLength": 1,
+          "description": "1..256 UTF-8 bytes; single line; no Cc controls; not . or ..; encoded as a single URI path segment without normalization."
+        },
+        "routeKind": {
+          "const": "codex_thread"
+        },
+        "bundleID": {
+          "const": "com.openai.codex"
+        },
+        "teamID": {
+          "type": "string",
+          "pattern": "^[A-Z0-9]{10}$"
+        },
+        "applicationPath": {
+          "type": "string",
+          "pattern": "^/.*\\.app$",
+          "description": "Canonical configured location; <=4096 UTF-8 bytes; no Cc or line separators."
+        },
+        "correlationID": {
+          "type": "string",
+          "format": "uuid",
+          "description": "Must equal enclosing request correlationID / notification identifier."
         }
       }
     }

--- a/swift-notifier/Tests/terminal-notifier-modernTests/CallbackLifecycleTests.swift
+++ b/swift-notifier/Tests/terminal-notifier-modernTests/CallbackLifecycleTests.swift
@@ -1,0 +1,82 @@
+import XCTest
+@testable import terminal_notifier_modern
+
+final class CallbackLifecycleTests: XCTestCase {
+    func testNearIdleTwoClicksAndLateDoubleCompletion() {
+        var timers: [() -> Void] = []
+        var exits = 0
+        var completions = 0
+        var diagnostics: [String] = []
+        var ends: [(CallbackOutcome) -> Void] = []
+        let owner = CallbackLifecycle(schedule: { _, work in timers.append(work) }, exit: { exits += 1 },
+            diagnostic: { diagnostics.append($0) })
+        owner.start()
+        for _ in 0..<2 {
+            owner.accept(completion: { completions += 1 }, operation: { done, _ in ends.append(done) })
+        }
+        timers[0]() // original idle watchdog must not kill either callback
+        XCTAssertEqual(exits, 0)
+        XCTAssertEqual(owner.inFlight, 2)
+        ends[0](.open_requested); ends[0](.open_requested)
+        XCTAssertEqual(completions, 1)
+        XCTAssertEqual(owner.inFlight, 1)
+        timers[2]() // second callback deadline
+        XCTAssertEqual(completions, 2)
+        XCTAssertEqual(owner.inFlight, 0)
+        ends[1](.open_failed); timers[1]() // late completion and first deadline
+        XCTAssertEqual(completions, 2)
+        timers.last?()
+        XCTAssertEqual(exits, 1)
+        XCTAssertEqual(diagnostics.compactMap { try? JSONDecoder().decode(CallbackDiagnostic.self, from: Data($0.utf8)) }.compactMap { $0.outcome }, ["open_requested", "open_unknown"])
+        XCTAssertEqual(diagnostics.count, 4)
+    }
+    func testNewClickInvalidatesDrainIdleTimer() {
+        var timers: [() -> Void] = []
+        var exits = 0
+        let owner = CallbackLifecycle(schedule: { _, work in timers.append(work) }, exit: { exits += 1 })
+        owner.start()
+        owner.accept(completion: {}, operation: { done, _ in done(.ignored) })
+        let stale = timers.last!
+        var finish: ((CallbackOutcome) -> Void)?
+        owner.accept(completion: {}, operation: { done, _ in finish = done })
+        stale()
+        XCTAssertEqual(exits, 0)
+        finish?(.open_requested)
+        timers.last?()
+        XCTAssertEqual(exits, 1)
+    }
+    func testDeadlineInvalidatesPendingContinuationAndStoppedOwnerDoesNotStartWork() {
+        var timers: [() -> Void] = []
+        var active: (() -> Bool)?
+        var completions = 0
+        let owner = CallbackLifecycle(schedule: { delay, work in
+            XCTAssertEqual(delay, 10)
+            timers.append(work)
+        }, exit: {})
+        owner.accept(completion: { completions += 1 }) { _, isActive in active = isActive }
+        XCTAssertEqual(active?(), true)
+        timers[0]()
+        XCTAssertEqual(active?(), false)
+        XCTAssertEqual(completions, 1)
+        timers.last?()
+        owner.accept(completion: { completions += 1 }) { _, _ in XCTFail("started after exit") }
+        XCTAssertEqual(completions, 2)
+    }
+
+    func testElapsedDeadlineWinsEvenBeforeTimerDelivery() {
+        var time = 100.0
+        var finish: ((CallbackOutcome) -> Void)?
+        var active: (() -> Bool)?
+        var diagnostics: [String] = []
+        let owner = CallbackLifecycle(schedule: { _, _ in }, exit: {},
+            diagnostic: { diagnostics.append($0) }, now: { time })
+        owner.accept(completion: {}) { done, isActive in finish = done; active = isActive }
+        time = 110
+        XCTAssertEqual(active?(), false)
+        finish?(.open_requested)
+        XCTAssertEqual(diagnostics.compactMap { try? JSONDecoder().decode(CallbackDiagnostic.self, from: Data($0.utf8)) }.compactMap { $0.outcome }, ["open_unknown"])
+        XCTAssertEqual(diagnostics.count, 2)
+        XCTAssertEqual(owner.inFlight, 0)
+    }
+
+}

--- a/swift-notifier/Tests/terminal-notifier-modernTests/CallbackWorkTests.swift
+++ b/swift-notifier/Tests/terminal-notifier-modernTests/CallbackWorkTests.swift
@@ -1,0 +1,327 @@
+import XCTest
+import Darwin
+@testable import terminal_notifier_modern
+
+final class CallbackWorkTests: XCTestCase {
+    private func action(_ n: Int = 1) -> DesktopThreadAction {
+        DesktopThreadAction(type: "desktop_thread_v1", schemaVersion: 1, threadID: "private-thread",
+            routeKind: "codex_thread", bundleID: "com.openai.codex", teamID: "TESTTEAM01",
+            applicationPath: "/disposable/Codex.app",
+            correlationID: String(format: "00000000-0000-4000-8000-%012d", n))
+    }
+    private func receive(_ handler: CallbackHandler, _ action: DesktopThreadAction,
+                         completion: @escaping () -> Void = {}) throws {
+        handler.receive(identifier: "OPEN", defaultIdentifier: "default", notificationID: action.correlationID,
+            userInfo: ["desktop_thread_v1": String(decoding: try JSONEncoder().encode(action), as: UTF8.self)],
+            completion: completion)
+    }
+    private struct Discovery: ApplicationDiscovering {
+        var selected: URL? = URL(fileURLWithPath: "/disposable/Codex.app")
+        var candidates: [URL] = []
+        var check: () -> Void = {}
+        func selectedApplication(path: String) -> URL? { check(); return selected }
+        func registeredApplications(bundleID: String) -> [URL] { check(); return candidates }
+    }
+    private struct Verifier: ApplicationVerifying {
+        var check: () -> Bool = { true }
+        func verify(_ url: URL, bundleID: String, teamID: String) -> Bool { check() }
+    }
+    private final class Opener: DesktopURLOpening {
+        var completions: [(Bool) -> Void] = []
+        func open(_ url: URL, application: URL, completion: @escaping (Bool) -> Void) {
+            XCTAssertTrue(Thread.isMainThread)
+            completions.append(completion)
+        }
+    }
+    func testHeldSecurityKeepsSlotsAfterTimeoutAndOtherCallbacksProgress() throws {
+        let entered = expectation(description: "two blocked checks")
+        entered.expectedFulfillmentCount = 2
+        let returned = expectation(description: "late results")
+        returned.expectedFulfillmentCount = 2
+        let gate = DispatchSemaphore(value: 0)
+        defer { gate.signal(); gate.signal() }
+        var timers: [() -> Void] = []
+        var completions = 0
+        var events: [String] = []
+        let owner = CallbackLifecycle(schedule: { _, work in timers.append(work) }, exit: {},
+                                      diagnostic: { events.append($0) })
+        let opener = Opener()
+        let executor = DesktopThreadExecutor(
+            discovery: Discovery(selected: nil, candidates: (0..<16).map { URL(fileURLWithPath: "/disposable/\($0).app") },
+                                 check: { XCTAssertFalse(Thread.isMainThread) }),
+            verifier: Verifier(check: {
+                XCTAssertFalse(Thread.isMainThread)
+                entered.fulfill()
+                // The safety timeout only prevents a broken fixture stranding a worker.
+                XCTAssertEqual(gate.wait(timeout: .now() + 5), .success)
+                return true
+            }), opener: opener,
+            deliverResult: { work in DispatchQueue.main.async { work(); returned.fulfill() } },
+            admission: PreflightAdmission(limit: 2))
+        let handler = CallbackHandler(lifecycle: owner, desktop: executor)
+        try receive(handler, action(1)) { completions += 1 }
+        try receive(handler, action(2)) { completions += 1 }
+        wait(for: [entered], timeout: 2)
+        // Acceptance and timeout run on the real main queue while Security is held.
+        timers[0](); timers[1]()
+        XCTAssertEqual(completions, 2)
+        for n in 3...24 { try receive(handler, action(n)) { completions += 1 } }
+        XCTAssertEqual(completions, 24) // no queued work behind occupied slots
+        XCTAssertEqual(opener.completions.count, 0)
+        gate.signal(); gate.signal()
+        wait(for: [returned], timeout: 2)
+        XCTAssertEqual(completions, 24)
+        XCTAssertEqual(opener.completions.count, 0)
+        XCTAssertEqual(events.count, 48)
+        // No further candidate checks after cancellation; overfulfilment of entered fails.
+    }
+    func testMainQueueDeadlineFiresWhileVerifierRemainsHeld() throws {
+        let entered = expectation(description: "held verifier")
+        let timedOut = expectation(description: "main queue deadline callback")
+        let returned = expectation(description: "late verification result")
+        let gate = DispatchSemaphore(value: 0)
+        defer { gate.signal() }
+        var completions = 0
+        let owner = CallbackLifecycle(schedule: { delay, work in
+            XCTAssertEqual(delay, 10)
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.05, execute: work)
+        }, exit: {})
+        let opener = Opener()
+        let executor = DesktopThreadExecutor(discovery: Discovery(), verifier: Verifier(check: {
+            entered.fulfill()
+            XCTAssertEqual(gate.wait(timeout: .now() + 5), .success)
+            return true
+        }), opener: opener,
+        deliverResult: { work in DispatchQueue.main.async { work(); returned.fulfill() } },
+        admission: PreflightAdmission(limit: 1))
+        let handler = CallbackHandler(lifecycle: owner, desktop: executor)
+        try receive(handler, action()) { completions += 1; timedOut.fulfill() }
+        wait(for: [entered], timeout: 2)
+        handler.receive(identifier: "DISMISS", defaultIdentifier: "default", notificationID: "untrusted",
+                        userInfo: [:]) { completions += 1 }
+        wait(for: [timedOut], timeout: 2)
+        XCTAssertEqual(completions, 2)
+        gate.signal()
+        wait(for: [returned], timeout: 2)
+        XCTAssertEqual(completions, 2)
+        XCTAssertTrue(opener.completions.isEmpty)
+    }
+
+    func testBlockedDiscoveryAlsoLeavesCallbackQueueResponsive() throws {
+        let entered = expectation(description: "discovery held")
+        let returned = expectation(description: "discovery returned")
+        let gate = DispatchSemaphore(value: 0)
+        defer { gate.signal() }
+        var timers: [() -> Void] = []
+        var completions = 0
+        let owner = CallbackLifecycle(schedule: { _, work in timers.append(work) }, exit: {})
+        let opener = Opener()
+        let executor = DesktopThreadExecutor(discovery: Discovery(check: {
+            XCTAssertFalse(Thread.isMainThread); entered.fulfill()
+            XCTAssertEqual(gate.wait(timeout: .now() + 5), .success)
+        }), verifier: Verifier(check: { XCTFail("verified after timeout"); return true }), opener: opener,
+        deliverResult: { work in DispatchQueue.main.async { work(); returned.fulfill() } },
+        admission: PreflightAdmission(limit: 1))
+        let handler = CallbackHandler(lifecycle: owner, desktop: executor)
+        try receive(handler, action()) { completions += 1 }
+        wait(for: [entered], timeout: 2)
+        timers[0]()
+        handler.receive(identifier: "DISMISS", defaultIdentifier: "default", notificationID: "untrusted",
+                        userInfo: [:]) { completions += 1 }
+        XCTAssertEqual(completions, 2)
+        gate.signal()
+        wait(for: [returned], timeout: 2)
+        XCTAssertTrue(opener.completions.isEmpty)
+    }
+    func testAdmissionIncludesScheduledJobsAndReleasesOnlyWhenWorkReturns() throws {
+        var jobs: [() -> Void] = []
+        var completions = 0
+        let token = CallbackToken()
+        let executor = DesktopThreadExecutor(discovery: Discovery(), verifier: Verifier(check: { false }),
+            opener: Opener(), verificationWork: { jobs.append($0) }, deliverResult: { $0() },
+            admission: PreflightAdmission(limit: 1))
+        executor.execute(action(), token: token) { _ in completions += 1 }
+        token.cancel()
+        for _ in 0..<20 { executor.execute(action()) { result in
+            XCTAssertEqual(result, .open_unknown); completions += 1
+        } }
+        XCTAssertEqual(jobs.count, 1)
+        jobs[0]()
+        executor.execute(action()) { _ in completions += 1 }
+        XCTAssertEqual(jobs.count, 2)
+        jobs[1]()
+        XCTAssertEqual(completions, 22)
+    }
+    func testReversedCompletionRetainsCorrelationAndEmitsOneTerminal() throws {
+        var lines: [String] = []
+        let owner = CallbackLifecycle(schedule: { _, _ in }, exit: {}, diagnostic: { lines.append($0) })
+        let opener = Opener()
+        let executor = DesktopThreadExecutor(discovery: Discovery(), verifier: Verifier(), opener: opener,
+            verificationWork: { $0() }, deliverResult: { $0() }, admission: PreflightAdmission(limit: 2))
+        let handler = CallbackHandler(lifecycle: owner, desktop: executor)
+        try receive(handler, action(1)); try receive(handler, action(2))
+        opener.completions[1](false); opener.completions[0](true)
+        opener.completions[1](true); opener.completions[0](false)
+        let events = try lines.map { try JSONDecoder().decode(CallbackDiagnostic.self, from: Data($0.utf8)) }
+        XCTAssertEqual(events.map { $0.event }, ["callback_received", "callback_received", "callback_terminal", "callback_terminal"])
+        XCTAssertEqual(events.map { $0.correlationID }, [1, 2, 2, 1].map { UUID(uuidString: action($0).correlationID)! })
+        XCTAssertEqual(events.compactMap { $0.outcome }, ["open_failed", "open_requested"])
+        XCTAssertTrue(lines.allSatisfy { $0.utf8.count < 200 && !$0.contains("private-thread") && !$0.contains("disposable") })
+    }
+    func testMalformedCorrelationIsGeneratedAndNeverLogsInput() throws {
+        var lines: [String] = []
+        let owner = CallbackLifecycle(schedule: { _, _ in }, exit: {}, diagnostic: { lines.append($0) })
+        let handler = CallbackHandler(lifecycle: owner)
+        let untrusted = "private-body-shell-path"
+        handler.receive(identifier: "OPEN", defaultIdentifier: "default", notificationID: untrusted,
+            userInfo: ["desktop_thread_v1": untrusted, "action": untrusted], completion: {})
+        let events = try lines.map { try JSONDecoder().decode(CallbackDiagnostic.self, from: Data($0.utf8)) }
+        XCTAssertEqual(events.count, 2)
+        XCTAssertEqual(events[0].correlationID, events[1].correlationID)
+        XCTAssertEqual(events[1].outcome, "malformed_action")
+        XCTAssertFalse(lines.joined().contains(untrusted))
+    }
+
+    private final class Child: OwnedCommand {
+        var started = 0
+        var cancelled = 0
+        var end: (() -> Void)?
+        func start(completion: @escaping () -> Void) { started += 1; end = completion }
+        func cancel() { cancelled += 1 }
+    }
+    func testLegacyTimeoutOwnsDrainWhileSecondCallbackCompletes() throws {
+        var timers: [() -> Void] = []
+        var exits = 0
+        var completions = 0
+        var activations: [String] = []
+        var lines: [String] = []
+        let owner = CallbackLifecycle(schedule: { _, work in timers.append(work) }, exit: { exits += 1 },
+                                      diagnostic: { lines.append($0) })
+        let a = Child(), b = Child()
+        var children = [a, b]
+        let executor = ActionExecutor(makeCommand: { command in
+            XCTAssertEqual(command, "literal shell command")
+            return children.removeFirst()
+        }, activation: { bundle, done in activations.append(bundle); done() })
+        let handler = CallbackHandler(lifecycle: owner, legacy: executor)
+        owner.start()
+        let command = ClickAction.executeAndActivate(command: "literal shell command", bundleID: "test.bundle")
+        for _ in 0..<2 {
+            handler.receive(identifier: "OPEN", defaultIdentifier: "default", notificationID: "legacy",
+                            userInfo: ["action": command.toJSON()!]) { completions += 1 }
+        }
+        timers[0]() // stale startup idle
+        timers[1]() // timeout A
+        XCTAssertEqual(a.cancelled, 1)
+        XCTAssertEqual(b.cancelled, 0)
+        XCTAssertEqual(completions, 1)
+        XCTAssertEqual(owner.ownedCount, 2)
+        b.end?(); b.end?()
+        XCTAssertEqual(activations, ["test.bundle"])
+        XCTAssertEqual(completions, 2)
+        XCTAssertEqual(owner.inFlight, 0)
+        XCTAssertEqual(owner.ownedCount, 1)
+        timers.forEach { $0() }
+        XCTAssertEqual(exits, 0) // expired callback alone cannot permit parent exit
+        a.end?(); a.end?()
+        XCTAssertEqual(owner.ownedCount, 0)
+        XCTAssertEqual(completions, 2)
+        XCTAssertEqual(activations.count, 1)
+        timers.last?()
+        XCTAssertEqual(exits, 1)
+        XCTAssertEqual(lines.count, 4)
+    }
+
+    func testProductionChildOwnerEscalatesBeforeReapAndSignalsOnlyOwnedGroup() {
+        var scheduled: [(Double, () -> Void)] = []
+        var signals: [(pid_t, Int32)] = []
+        var reapCalls = 0
+        var readyToReap = false
+        var completions = 0
+        let system = SpawnedCommand.System(spawn: { command in
+            XCTAssertEqual(command, "unchanged shell payload")
+            return 1234
+        }, signalGroup: { pid, signal in signals.append((pid, signal)) }, reap: { pid in
+            XCTAssertEqual(pid, 1234)
+            reapCalls += 1
+            return readyToReap
+        }, leaderExited: { _ in true }, groupDrained: { _ in true })
+        let child = SpawnedCommand("unchanged shell payload", system: system,
+                                   schedule: { scheduled.append(($0, $1)) })
+        child.start { completions += 1 }
+        XCTAssertEqual(reapCalls, 1)
+        XCTAssertEqual(scheduled.map { $0.0 }, [0.05])
+        child.cancel(); child.cancel()
+        XCTAssertEqual(signals.map { $0.0 }, [1234])
+        XCTAssertEqual(signals.map { $0.1 }, [SIGTERM])
+        XCTAssertEqual(scheduled.map { $0.0 }, [0.05, 0.25])
+        scheduled[0].1() // old poll must not reap/release the PID during escalation
+        XCTAssertEqual(reapCalls, 1)
+        XCTAssertEqual(completions, 0)
+        XCTAssertEqual(child.processID, 1234)
+        scheduled[1].1()
+        XCTAssertEqual(signals.map { $0.0 }, [1234, 1234])
+        XCTAssertEqual(signals.map { $0.1 }, [SIGTERM, SIGKILL])
+        XCTAssertEqual(reapCalls, 2)
+        XCTAssertEqual(completions, 0) // KILL alone does not mean reaped
+        readyToReap = true
+        scheduled[2].1()
+        XCTAssertEqual(child.processID, 0)
+        XCTAssertEqual(completions, 1)
+        scheduled[0].1(); scheduled[1].1(); scheduled[2].1(); child.cancel()
+        XCTAssertEqual(completions, 1)
+        XCTAssertEqual(signals.count, 2) // no stale signal after PID release
+    }
+
+    func testProductionChildOwnerHandlesSpawnFailureAndCancelBeforeStart() {
+        for cancelled in [false, true] {
+            var spawns = 0
+            var completions = 0
+            let system = SpawnedCommand.System(spawn: { _ in spawns += 1; return nil },
+                signalGroup: { _, _ in XCTFail("no owned group to signal") },
+                reap: { _ in XCTFail("no owned child to reap"); return false },
+                leaderExited: { _ in XCTFail("no child to observe"); return false },
+                groupDrained: { _ in XCTFail("no group to inspect"); return false })
+            let child = SpawnedCommand("literal", system: system,
+                                       schedule: { _, _ in XCTFail("unexpected timer") })
+            if cancelled { child.cancel() }
+            child.start { completions += 1 }
+            child.cancel()
+            XCTAssertEqual(spawns, cancelled ? 0 : 1)
+            XCTAssertEqual(completions, 1)
+            XCTAssertEqual(child.processID, 0)
+        }
+    }
+
+    // Explicit macOS qualification only; ordinary unit runs have no child effects.
+    func testMacOwnedHarmlessChildTimeoutReapsBeforeIdleExit() throws {
+        guard ProcessInfo.processInfo.environment["NOTIFIER_TEST_OWNED_CHILD"] == "1" else {
+            throw XCTSkip("Coordinator macOS opt-in: NOTIFIER_TEST_OWNED_CHILD=1")
+        }
+        var timers: [() -> Void] = []
+        let exited = expectation(description: "idle after reap")
+        var completed = 0
+        let child = SpawnedCommand("trap '' TERM; while :; do /bin/sleep 1; done")
+        defer { child.cancel() }
+        let owner = CallbackLifecycle(schedule: { _, work in timers.append(work) }, exit: { exited.fulfill() })
+        let handler = CallbackHandler(lifecycle: owner, legacy: ActionExecutor(makeCommand: { _ in child }))
+        handler.receive(identifier: "OPEN", defaultIdentifier: "default", notificationID: "legacy",
+                        userInfo: ["action": ClickAction.execute(command: "fixture").toJSON()!]) { completed += 1 }
+        let pid = child.processID
+        XCTAssertGreaterThan(pid, 0)
+        timers[0]()
+        XCTAssertEqual(completed, 1)
+        XCTAssertEqual(owner.ownedCount, 1)
+        let drained = expectation(description: "kernel child reaped")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+            XCTAssertEqual(owner.ownedCount, 0)
+            var status: Int32 = 0
+            XCTAssertEqual(waitpid(pid, &status, WNOHANG), -1)
+            XCTAssertEqual(errno, ECHILD)
+            XCTAssertEqual(completed, 1)
+            timers.last?()
+            drained.fulfill()
+        }
+        wait(for: [drained, exited], timeout: 3)
+    }
+}

--- a/swift-notifier/Tests/terminal-notifier-modernTests/DesktopThreadActionTests.swift
+++ b/swift-notifier/Tests/terminal-notifier-modernTests/DesktopThreadActionTests.swift
@@ -1,0 +1,193 @@
+import XCTest
+import UserNotifications
+@testable import terminal_notifier_modern
+
+final class DesktopThreadActionTests: XCTestCase {
+    func action(thread: String = "thread/other?#%👩‍💻") -> DesktopThreadAction {
+        DesktopThreadAction(type: "desktop_thread_v1", schemaVersion: 1,
+            threadID: thread, routeKind: "codex_thread", bundleID: "com.openai.codex",
+            teamID: "TESTTEAM01", applicationPath: "/disposable/Codex.app",
+            correlationID: "00000000-0000-4000-8000-000000000001")
+    }
+    func testRouteIsOneEncodedSegmentAndLiteralBytesSurvive() throws {
+        let target = action()
+        let decoded = try DesktopThreadAction.decode(JSONEncoder().encode(target))
+        XCTAssertEqual(Array(decoded.threadID.utf8), Array(target.threadID.utf8))
+        XCTAssertEqual(decoded.url.absoluteString,
+            "codex://threads/thread%2Fother%3F%23%25%F0%9F%91%A9%E2%80%8D%F0%9F%92%BB")
+        XCTAssertNil(URLComponents(url: decoded.url, resolvingAgainstBaseURL: false)?.query)
+        XCTAssertNil(URLComponents(url: decoded.url, resolvingAgainstBaseURL: false)?.fragment)
+        for thread in ["", ".", "..", "bad\0", String(repeating: "x", count: 257)] {
+            XCTAssertThrowsError(try action(thread: thread).validate())
+        }
+    }
+    func testStrictActionFieldsAndVersions() throws {
+        let data = try JSONEncoder().encode(action())
+        let original = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        for (key, value) in [("schemaVersion", 2), ("schemaVersion", true), ("url", "https://example.com"),
+                             ("routeKind", "shell"), ("teamID", "\" or true"), ("applicationPath", "/a/../Codex.app")] as [(String, Any)] {
+            var object = original; object[key] = value
+            XCTAssertThrowsError(try DesktopThreadAction.decode(JSONSerialization.data(withJSONObject: object)))
+        }
+    }
+    func testSharedActionFixtures() throws {
+        let root = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+            .deletingLastPathComponent().appendingPathComponent("Fixtures")
+        let data = try Data(contentsOf: root.appendingPathComponent("desktop-thread-v1.actions.json"))
+        let fixtures = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        for entry in try XCTUnwrap(fixtures["valid"] as? [[String: Any]]) {
+            let action = try DesktopThreadAction.decode(JSONSerialization.data(withJSONObject: entry["action"]!))
+            XCTAssertEqual(action.url.absoluteString, entry["uri"] as? String)
+        }
+        for entry in try XCTUnwrap(fixtures["invalid"] as? [[String: Any]]) {
+            XCTAssertThrowsError(try DesktopThreadAction.decode(JSONSerialization.data(withJSONObject: entry)))
+        }
+    }
+    func testCallbackSelectionAndTypedPayloadNeverFallsBack() throws {
+        let target = action()
+        let json = String(decoding: try JSONEncoder().encode(target), as: UTF8.self)
+        for button in ["OPEN", "default"] {
+            guard case .desktop(let decoded) = CallbackRoute.decode(identifier: button,
+                defaultIdentifier: "default", notificationID: target.correlationID,
+                userInfo: ["desktop_thread_v1": json]) else { return XCTFail("expected desktop") }
+            XCTAssertEqual(decoded, target)
+        }
+        for button in ["DISMISS", "unknown"] {
+            guard case .ignored = CallbackRoute.decode(identifier: button, defaultIdentifier: "default",
+                notificationID: target.correlationID, userInfo: ["desktop_thread_v1": json]) else {
+                return XCTFail("unexpected navigation")
+            }
+        }
+        for value in [42, "{}", json] as [Any] {
+            guard case .malformed = CallbackRoute.decode(identifier: "OPEN", defaultIdentifier: "default",
+                notificationID: "wrong", userInfo: ["desktop_thread_v1": value,
+                    "action": ClickAction.execute(command: "never run").toJSON()!]) else {
+                return XCTFail("typed payload fell through")
+            }
+        }
+    }
+    func testStructuredContentContainsCompleteDurableTarget() throws {
+        let target = action()
+        let request = NativeRequest(schemaVersion: 1, correlationID: target.correlationID,
+            nonce: "00000000-0000-4000-8000-000000000002", bootID: "boot", notAfter: 110,
+            title: "--help", body: "[important]👩‍💻", subtitle: nil, category: .info,
+            action: .desktopThread(target), silent: true)
+        let decoded = try NativeCodec.decodeRequest(JSONEncoder().encode(request))
+        let content = try StructuredNotificationContent.make(decoded)
+        XCTAssertEqual(content.title, "--help")
+        XCTAssertEqual(content.body, "[important]👩‍💻")
+        XCTAssertEqual(content.categoryIdentifier, NotificationCategory.categoryIdentifier)
+        let json = try XCTUnwrap(content.userInfo["desktop_thread_v1"] as? String)
+        XCTAssertEqual(try DesktopThreadAction.decode(Data(json.utf8)), target)
+        XCTAssertEqual(content.userInfo.count, 1)
+        XCTAssertNil(content.sound)
+        var object = try XCTUnwrap(JSONSerialization.jsonObject(with: JSONEncoder().encode(request)) as? [String: Any])
+        object["correlationID"] = "00000000-0000-4000-8000-000000000003"
+        XCTAssertThrowsError(try NativeCodec.decodeRequest(JSONSerialization.data(withJSONObject: object)))
+    }
+    struct Discovery: ApplicationDiscovering {
+        let url: URL?
+        var registered: [URL] = []
+        func registeredApplications(bundleID: String) -> [URL] { registered }
+        func selectedApplication(path: String) -> URL? { url }
+    }
+    struct Verifier: ApplicationVerifying {
+        let valid: Bool
+        func verify(_ url: URL, bundleID: String, teamID: String) -> Bool { valid }
+    }
+    final class Opener: DesktopURLOpening {
+        var calls = 0
+        var completion: ((Bool) -> Void)?
+        func open(_ url: URL, application: URL, completion: @escaping (Bool) -> Void) {
+            calls += 1; self.completion = completion
+        }
+    }
+    func testDeadlineDuringVerificationPreventsOpen() {
+        let opener = Opener()
+        let executor = DesktopThreadExecutor(discovery: Discovery(url: URL(fileURLWithPath: "/disposable/Codex.app")),
+            verifier: Verifier(valid: true), opener: opener, verificationWork: { $0() }, deliverResult: { $0() })
+        var checks = 0
+        var result: DesktopOpenResult?
+        executor.execute(action(), isActive: { checks += 1; return checks == 1 }) { result = $0 }
+        XCTAssertEqual(result, .open_unknown)
+        XCTAssertEqual(opener.calls, 0)
+    }
+    func testMissingSelectedLocationNeverPicksRegisteredCandidate() {
+        for count in [1, 2, 17] {
+            let opener = Opener()
+            let urls = (0..<count).map { URL(fileURLWithPath: "/disposable/\($0)/Codex.app") }
+            let executor = DesktopThreadExecutor(discovery: Discovery(url: nil, registered: urls),
+                verifier: Verifier(valid: true), opener: opener, verificationWork: { $0() }, deliverResult: { $0() })
+            var result: DesktopOpenResult?
+            executor.execute(action()) { result = $0 }
+            XCTAssertEqual(result, count == 1 ? .application_moved : .application_ambiguous)
+            XCTAssertEqual(opener.calls, 0)
+        }
+    }
+    func testDiscoveryVerificationAndDelayedOpen() {
+        for (path, valid, expected) in [(nil, true, DesktopOpenResult.application_missing),
+                                      ("/other/Codex.app", true, .application_moved),
+                                      ("/disposable/Codex.app", false, .identity_mismatch),
+                                      ("/disposable/Codex.app", true, .open_failed),
+                                      ("/disposable/Codex.app", true, .open_requested)] as [(String?, Bool, DesktopOpenResult)] {
+            let opener = Opener()
+            let executor = DesktopThreadExecutor(discovery: Discovery(url: path.map { URL(fileURLWithPath: $0) }),
+                verifier: Verifier(valid: valid), opener: opener, verificationWork: { $0() }, deliverResult: { $0() })
+            var result: DesktopOpenResult?
+            executor.execute(action()) { result = $0 }
+            if expected == .open_failed || expected == .open_requested {
+                XCTAssertNil(result)
+                XCTAssertEqual(opener.calls, 1)
+                opener.completion?(expected == .open_requested)
+            } else { XCTAssertEqual(opener.calls, 0) }
+            XCTAssertEqual(result, expected)
+        }
+    }
+    func testPendingVerificationDoesNotBlockDeadlineOrOpenLate() {
+        var jobs: [() -> Void] = []
+        var timers: [() -> Void] = []
+        var completions = 0
+        var time = 0.0
+        let lifecycle = CallbackLifecycle(schedule: { _, job in timers.append(job) },
+            exit: {}, now: { time })
+        let opener = Opener()
+        let executor = DesktopThreadExecutor(
+            discovery: Discovery(url: URL(fileURLWithPath: "/disposable/Codex.app")),
+            verifier: Verifier(valid: true), opener: opener,
+            verificationWork: { jobs.append($0) }, deliverResult: { $0() })
+        lifecycle.accept(completion: { completions += 1 }) { done, active in
+            executor.execute(action(), isActive: active, completion: done)
+        }
+        XCTAssertEqual(jobs.count, 1)
+        XCTAssertEqual(completions, 0)
+        time = 11
+        timers[0]()
+        XCTAssertEqual(completions, 1)
+        XCTAssertEqual(lifecycle.inFlight, 0)
+        jobs[0]()
+        XCTAssertEqual(opener.calls, 0)
+        XCTAssertEqual(completions, 1)
+    }
+
+    struct BackgroundVerifier: ApplicationVerifying {
+        func verify(_ url: URL, bundleID: String, teamID: String) -> Bool {
+            XCTAssertFalse(Thread.isMainThread)
+            return false
+        }
+    }
+    func testProductionSchedulerVerifiesOffMainAndReturnsToMain() {
+        let done = expectation(description: "verification returns")
+        let opener = Opener()
+        let executor = DesktopThreadExecutor(
+            discovery: Discovery(url: URL(fileURLWithPath: "/disposable/Codex.app")),
+            verifier: BackgroundVerifier(), opener: opener)
+        executor.execute(action()) { result in
+            XCTAssertTrue(Thread.isMainThread)
+            XCTAssertEqual(result, .identity_mismatch)
+            XCTAssertEqual(opener.calls, 0)
+            done.fulfill()
+        }
+        wait(for: [done], timeout: 2)
+    }
+
+}

--- a/swift-notifier/Tests/terminal-notifier-modernTests/LegacyFinalTests.swift
+++ b/swift-notifier/Tests/terminal-notifier-modernTests/LegacyFinalTests.swift
@@ -1,0 +1,301 @@
+import XCTest
+import Darwin
+@testable import terminal_notifier_modern
+
+final class LegacyFinalTests: XCTestCase {
+    private struct Discovery: ApplicationDiscovering {
+        func selectedApplication(path: String) -> URL? { URL(fileURLWithPath: path) }
+        func registeredApplications(bundleID: String) -> [URL] { [] }
+    }
+    private struct Verifier: ApplicationVerifying {
+        func verify(_ url: URL, bundleID: String, teamID: String) -> Bool { true }
+    }
+    private final class HeldOpener: DesktopURLOpening {
+        var calls = 0
+        func open(_ url: URL, application: URL, completion: @escaping (Bool) -> Void) {
+            calls += 1 // keep typed callback pending until its own deadline
+        }
+    }
+
+    func testLeaderExitRetainsOwnershipUntilHelperDrainsThenActivates() {
+        var polls: [() -> Void] = []
+        var timers: [() -> Void] = []
+        var drained = false
+        var reaps = 0
+        var activations = 0
+        var completed = 0
+        var exits = 0
+        let child = SpawnedCommand("unchanged", system: .init(spawn: { _ in 1234 },
+            signalGroup: { _, _ in XCTFail("successful helper must not be killed") },
+            reap: { _ in reaps += 1; return true }, leaderExited: { _ in true },
+            groupDrained: { _ in drained }), schedule: { _, work in polls.append(work) })
+        let owner = CallbackLifecycle(schedule: { _, work in timers.append(work) }, exit: { exits += 1 })
+        owner.start()
+        let executor = ActionExecutor(makeCommand: { _ in child }, activationSystem: .init(
+            running: { _ in { activations += 1; return true } },
+            lookup: { _ in XCTFail("running target succeeded"); return nil },
+            open: { _, _ in XCTFail("unexpected open") }), discoveryWork: { $0() }, deliverResult: { $0() })
+        owner.acceptOwned(completion: { completed += 1 }) { done, work in
+            executor.execute(.executeAndActivate(command: "unchanged", bundleID: "test.bundle"), work: work) { done(.legacy_completed) }
+        }
+        polls.removeFirst()()
+        timers[0]() // stale startup idle cannot exit with a leader-exits-first helper
+        XCTAssertEqual(exits, 0)
+        XCTAssertEqual(child.processID, 1234)
+        XCTAssertEqual(owner.ownedCount, 1)
+        XCTAssertEqual(reaps, 0)
+        XCTAssertEqual(completed, 0)
+        XCTAssertEqual(activations, 0)
+        drained = true
+        polls.removeFirst()()
+        XCTAssertEqual(reaps, 1)
+        XCTAssertEqual(child.processID, 0)
+        XCTAssertEqual(owner.ownedCount, 0)
+        XCTAssertEqual(completed, 1)
+        XCTAssertEqual(activations, 1)
+        child.cancel() // no signalling cached PID after reap
+        timers.last?()
+        XCTAssertEqual(exits, 1)
+    }
+
+    func testNoHelperReapsImmediatelyWithoutDeadlineDelay() {
+        var completed = 0
+        let child = SpawnedCommand("exit 0", system: .init(spawn: { _ in 1234 },
+            signalGroup: { _, _ in XCTFail("unexpected signal") }, reap: { _ in true },
+            leaderExited: { _ in true }, groupDrained: { _ in true }),
+            schedule: { _, _ in XCTFail("no ten-second wait for an exited foreground command") })
+        child.start { completed += 1 }
+        XCTAssertEqual(completed, 1)
+        XCTAssertEqual(child.processID, 0)
+    }
+
+    func testLeaderExitWithUndrainedOrUnknownGroupUsesOwnedDeadlineCleanup() {
+        var polls: [(Double, () -> Void)] = []
+        var timers: [() -> Void] = []
+        var events: [String] = []
+        var completed = 0
+        let child = SpawnedCommand("helper & exit 0", system: .init(spawn: { _ in 1234 },
+            signalGroup: { pid, signal in XCTAssertEqual(pid, 1234); events.append("signal:\(signal)") },
+            reap: { _ in events.append("reap"); return true }, leaderExited: { _ in true },
+            groupDrained: { _ in false }), schedule: { polls.append(($0, $1)) })
+        let owner = CallbackLifecycle(schedule: { _, work in timers.append(work) }, exit: {})
+        let executor = ActionExecutor(makeCommand: { _ in child }, activation: { _, _ in XCTFail("late activation") })
+        owner.acceptOwned(completion: { completed += 1 }) { done, work in
+            executor.execute(.executeAndActivate(command: "helper & exit 0", bundleID: "test.bundle"), work: work) { done(.legacy_completed) }
+        }
+        XCTAssertTrue(events.isEmpty)
+        timers[0]()
+        XCTAssertEqual(completed, 1)
+        XCTAssertEqual(owner.ownedCount, 1)
+        polls[0].1()
+        XCTAssertEqual(events, ["signal:\(SIGTERM)"])
+        XCTAssertEqual(polls[1].0, 0.25)
+        polls[1].1()
+        XCTAssertEqual(events, ["signal:\(SIGTERM)", "signal:\(SIGKILL)", "reap"])
+        XCTAssertEqual(owner.ownedCount, 0)
+        XCTAssertEqual(completed, 1)
+        polls.forEach { $0.1() }; child.cancel()
+        XCTAssertEqual(events.count, 3)
+    }
+
+    func testHeldLegacyLookupKeepsSharedSlotWhileTwoCallbacksTimeOutAndNeverOpensLate() {
+        let entered = expectation(description: "legacy lookup held off main")
+        let returned = expectation(description: "legacy lookup delivered")
+        let deadlines = expectation(description: "both callbacks complete on main")
+        deadlines.expectedFulfillmentCount = 2
+        let gate = DispatchSemaphore(value: 0)
+        defer { gate.signal() }
+        let admission = PreflightAdmission(limit: 2)
+        var opens = 0
+        var completed = 0
+        var deliveries = 0
+        let executor = ActionExecutor(activationSystem: .init(running: { _ in
+            XCTAssertFalse(Thread.isMainThread); return nil
+        }, lookup: { _ in
+            XCTAssertFalse(Thread.isMainThread)
+            entered.fulfill()
+            XCTAssertEqual(gate.wait(timeout: .now() + 5), .success)
+            return URL(fileURLWithPath: "/disposable/Test.app")
+        }, open: { _, done in opens += 1; done() }), deliverResult: { work in
+            DispatchQueue.main.async {
+                work(); deliveries += 1
+                if deliveries == 2 { returned.fulfill() }
+            }
+        }, admission: admission)
+        let owner = CallbackLifecycle(schedule: { _, work in
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5, execute: work)
+        }, exit: {})
+        let typedOpener = HeldOpener()
+        let typed = DesktopThreadExecutor(discovery: Discovery(), verifier: Verifier(), opener: typedOpener,
+            verificationWork: { $0() }, deliverResult: { $0() }, admission: admission)
+        let handler = CallbackHandler(lifecycle: owner, desktop: typed, legacy: executor)
+        handler.receive(identifier: "OPEN", defaultIdentifier: "default", notificationID: "legacy",
+            userInfo: ["action": ClickAction.activate(bundleID: "test.bundle").toJSON()!]) {
+                XCTAssertTrue(Thread.isMainThread); completed += 1; deadlines.fulfill()
+            }
+        wait(for: [entered], timeout: 2)
+        // The typed path shares admission and keeps its opener pending. Its own
+        // main-queue deadline must finish independently of the legacy lookup.
+        let action = DesktopThreadAction(type: "desktop_thread_v1", schemaVersion: 1, threadID: "fixture",
+            routeKind: "codex_thread", bundleID: "com.openai.codex", teamID: "TESTTEAM01",
+            applicationPath: "/disposable/Codex.app", correlationID: "00000000-0000-4000-8000-000000000001")
+        handler.receive(identifier: "OPEN", defaultIdentifier: "default", notificationID: action.correlationID,
+            userInfo: ["desktop_thread_v1": String(decoding: try! JSONEncoder().encode(action), as: UTF8.self)]) {
+                completed += 1; deadlines.fulfill()
+            }
+        XCTAssertEqual(typedOpener.calls, 1)
+        wait(for: [deadlines], timeout: 2)
+        XCTAssertEqual(completed, 2)
+        XCTAssertTrue(admission.acquire()) // the typed preflight has returned
+        XCTAssertFalse(admission.acquire()) // timeout did not free legacy slot
+        admission.release()
+        XCTAssertEqual(opens, 0)
+        gate.signal()
+        wait(for: [returned], timeout: 2)
+        XCTAssertEqual(completed, 2)
+        XCTAssertEqual(opens, 0)
+        XCTAssertTrue(admission.acquire()); admission.release()
+    }
+
+    func testLegacyFallbackRechecksOriginalDeadlineAndPreservesRunningFirstStrategy() {
+        for expires in [false, true] {
+            var now = 0.0
+            let token = CallbackToken(deadline: 10, now: { now })
+            let work = CallbackWork(token: token, acquire: { _ in {} })
+            var events: [String] = []
+            let executor = ActionExecutor(activationSystem: .init(running: { _ in
+                events.append("running")
+                return { events.append("activate"); if expires { now = 10 }; return false }
+            }, lookup: { _ in events.append("lookup"); return URL(fileURLWithPath: "/disposable/Test.app") },
+            open: { _, done in events.append("open"); done() }), discoveryWork: { $0() }, deliverResult: { $0() })
+            executor.execute(.activate(bundleID: "test.bundle"), work: work) { events.append("done") }
+            XCTAssertEqual(events, expires ? ["running", "activate", "done"] : ["running", "activate", "lookup", "open", "done"])
+        }
+    }
+
+    func testLegacyPendingDeliveryChecksDeadlineBeforeActivateAndOpen() {
+        for hasRunning in [false, true] {
+            var delivery: [() -> Void] = []
+            var now = 0.0
+            let token = CallbackToken(deadline: 10, now: { now })
+            let work = CallbackWork(token: token, acquire: { _ in {} })
+            var effects = 0
+            var completed = 0
+            let executor = ActionExecutor(activationSystem: .init(running: { _ in
+                if hasRunning { return { effects += 1; return true } }; return nil
+            }, lookup: { _ in URL(fileURLWithPath: "/disposable/Test.app") },
+            open: { _, done in effects += 1; done() }), discoveryWork: { $0() },
+            deliverResult: { delivery.append($0) })
+            executor.execute(.activate(bundleID: "test.bundle"), work: work) { completed += 1 }
+            if !hasRunning { delivery.removeFirst()() } // enqueue lookup result
+            now = 10 // original deadline, without relying on the main timer firing
+            delivery.removeFirst()()
+            XCTAssertEqual(effects, 0)
+            XCTAssertEqual(completed, 1)
+        }
+    }
+
+    func testLegacyAdmissionCountsQueuedAndPendingDeliveryAndSkipsExpiredDiscovery() {
+        let admission = PreflightAdmission(limit: 1)
+        var jobs: [() -> Void] = []
+        var deliveries: [() -> Void] = []
+        var completed = 0
+        let token = CallbackToken()
+        let work = CallbackWork(token: token, acquire: { _ in {} })
+        let executor = ActionExecutor(activationSystem: .init(
+            running: { _ in XCTFail("expired job must not start discovery"); return nil },
+            lookup: { _ in XCTFail("expired fallback"); return nil },
+            open: { _, _ in XCTFail("expired open") }), discoveryWork: { jobs.append($0) },
+            deliverResult: { deliveries.append($0) }, admission: admission)
+        executor.execute(.activate(bundleID: "test.bundle"), work: work) { completed += 1 }
+        token.cancel()
+        for _ in 0..<20 {
+            executor.execute(.activate(bundleID: "test.bundle"), isActive: { true }) { completed += 1 }
+        }
+        XCTAssertEqual(jobs.count, 1)
+        XCTAssertEqual(completed, 20)
+        jobs.removeFirst()()
+        XCTAssertFalse(admission.acquire()) // returned work still awaits main delivery
+        deliveries.removeFirst()()
+        XCTAssertEqual(completed, 21)
+        XCTAssertTrue(admission.acquire()); admission.release()
+    }
+
+    func testUnobservedLeaderExitNeverInspectsGroupOrConsumesStatus() {
+        var scheduled = 0
+        let child = SpawnedCommand("running", system: .init(spawn: { _ in 1234 },
+            signalGroup: { _, _ in XCTFail("unexpected signal") },
+            reap: { _ in XCTFail("must observe exit first"); return false },
+            leaderExited: { _ in false },
+            groupDrained: { _ in XCTFail("leader still running or observation failed"); return true }),
+            schedule: { _, _ in scheduled += 1 })
+        child.start { XCTFail("premature release") }
+        XCTAssertEqual(child.processID, 1234)
+        XCTAssertEqual(scheduled, 1)
+    }
+
+    private func groupSnapshot(_ pid: pid_t) -> [kinfo_proc]? {
+        var mib: [Int32] = [CTL_KERN, KERN_PROC, KERN_PROC_PGRP, pid]
+        var entries = [kinfo_proc](repeating: kinfo_proc(), count: 64)
+        var bytes = entries.count * MemoryLayout<kinfo_proc>.stride
+        let result = entries.withUnsafeMutableBytes {
+            sysctl(&mib, 4, $0.baseAddress, &bytes, nil, 0)
+        }
+        guard result == 0, bytes < 64 * MemoryLayout<kinfo_proc>.stride,
+              bytes % MemoryLayout<kinfo_proc>.stride == 0 else { return nil }
+        return Array(entries.prefix(bytes / MemoryLayout<kinfo_proc>.stride))
+    }
+
+    // Coordinator-only: no UI, no apps, only disposable same-group /bin/sleep.
+    func testMacLeaderExitsFirstNaturalDrainAndDeadlineCleanup() throws {
+        guard ProcessInfo.processInfo.environment["NOTIFIER_TEST_LEADER_EXITS_FIRST"] == "1" else {
+            throw XCTSkip("Coordinator macOS opt-in: NOTIFIER_TEST_LEADER_EXITS_FIRST=1")
+        }
+        for natural in [true, false] {
+            let done = expectation(description: "leader and group drained")
+            var sawLiveHelper = false
+            var signals: [Int32] = []
+            var child: SpawnedCommand!
+            let live = SpawnedCommand.System.live
+            let system = SpawnedCommand.System(spawn: live.spawn, signalGroup: { pid, signal in
+                // Non-consuming observation still works immediately before every
+                // signal: the leader's identity has never been released.
+                XCTAssertTrue(live.leaderExited(pid))
+                signals.append(signal); live.signalGroup(pid, signal)
+            }, reap: live.reap, leaderExited: live.leaderExited, groupDrained: { pid in
+                let drained = live.groupDrained(pid)
+                if !drained && !sawLiveHelper {
+                    let members = self.groupSnapshot(pid)
+                    XCTAssertNotNil(members)
+                    XCTAssertTrue(members?.contains(where: {
+                        $0.kp_proc.p_pid != pid && Int32($0.kp_proc.p_stat) != SZOMB
+                    }) == true)
+                    sawLiveHelper = true
+                    XCTAssertEqual(child.processID, pid)
+                    if !natural { DispatchQueue.main.async { child.cancel() } }
+                }
+                return drained
+            })
+            child = SpawnedCommand(natural ? "/bin/sleep 1 & exit 0" : "/bin/sleep 30 & exit 0", system: system)
+            child.start { done.fulfill() }
+            let pid = child.processID
+            defer { child.cancel() }
+            wait(for: [done], timeout: 5)
+            XCTAssertTrue(sawLiveHelper)
+            XCTAssertEqual(child.processID, 0)
+            XCTAssertEqual(signals, natural ? [] : [SIGTERM, SIGKILL])
+            var status: Int32 = 0
+            XCTAssertEqual(waitpid(pid, &status, WNOHANG), -1)
+            XCTAssertEqual(errno, ECHILD)
+            let groupGone = expectation(description: "no live same-group helper")
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+                // Read-only inspection after reap; never signal this cached PGID.
+                let members = self.groupSnapshot(pid)
+                XCTAssertNotNil(members)
+                XCTAssertTrue(members?.allSatisfy { Int32($0.kp_proc.p_stat) == SZOMB } == true)
+                groupGone.fulfill()
+            }
+            wait(for: [groupGone], timeout: 2)
+        }
+    }
+}

--- a/swift-notifier/Tests/terminal-notifier-modernTests/NativeProtocolTests.swift
+++ b/swift-notifier/Tests/terminal-notifier-modernTests/NativeProtocolTests.swift
@@ -80,7 +80,7 @@ final class NativeProtocolTests: XCTestCase {
         XCTAssertNoThrow(try NativeCodec.decodeCapabilities(data))
         XCTAssertThrowsError(try NativeCodec.decodeCapabilities(Data("{}".utf8)))
         let object = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
-        XCTAssertEqual(object["actionKinds"] as? [String], ["none"])
+        XCTAssertEqual(object["actionKinds"] as? [String], ["none", "desktop_thread_v1"])
         XCTAssertEqual(object["explicitFeatureEnabledByDefault"] as? Bool, false)
     }
     func testRepositoryWireFixtures() throws {


### PR DESCRIPTION
Adds a self-contained `desktop_thread_v1` click action that opens the supplied Codex thread through an explicitly selected, signature-checked application. The action is stored in notification userInfo, so callback execution does not depend on the sender process or a temporary request file.

The callback lifecycle tracks completion separately from owned child-process cleanup. Bounded background discovery keeps deadlines responsive; expired work cannot issue a new open. Legacy actions retain their codecs and successful command-before-activation order, including the case where a shell exits before its ordinary background helper.

Stacked on #153 (`feat/agent-notify-native-protocol`). This is the native portion of phase 3. Installer activation and the Go/MCP consumer are subsequent integration work.

Validation:
- macOS Swift suite: 82 tests, 2 opt-in tests skipped, zero failures.
- Both opt-in real child-process tests passed separately, covering timeout/reaping and leader-exits-first natural completion/cancellation.
- Independent source review and follow-up review verified the exact patch; all reported findings are resolved in this scope.
- Installed notification clicks, cold start and queued upgrade/rollback remain product qualification gates. An accepted open request is not visible-target confirmation.
