### PR TITLE
feat(notify): support configurable journal admission rates

### DIFF
--- a/internal/agentnotify/journal/journal.go
+++ b/internal/agentnotify/journal/journal.go
@@ -108,7 +108,37 @@ type Receipt struct {
 	KeyKind    KeyKind  `json:"key_kind"`
 	Decision   Snapshot `json:"decision"`
 }
+
+// MaxRate is the existing maximum record/JSON-array budget. Rate capacity does
+// not reserve storage: the independent record, byte and retention limits apply.
+const MaxRate = 10000
+
+// RatePolicy is a trusted configuration snapshot, never model payload. Windows
+// are fixed at 60 seconds (session/runtime) and 2 seconds (runtime burst).
+// The whole-zero value selects defaults; individual zero values never disable
+// a limiter. Enablement and configuration generation fencing belong to callers.
+type RatePolicy struct {
+	SessionPerMinute int
+	RuntimePerMinute int
+	Burst            int
+}
+
+// Normalize validates a snapshot and resolves the backward-compatible default.
+// Session and burst limits cannot exceed the enclosing runtime minute limit.
+func (p RatePolicy) Normalize() (RatePolicy, error) {
+	if p == (RatePolicy{}) {
+		return RatePolicy{6, 30, 3}, nil
+	}
+	if p.SessionPerMinute < 1 || p.RuntimePerMinute < 1 || p.Burst < 1 ||
+		p.SessionPerMinute > MaxRate || p.RuntimePerMinute > MaxRate || p.Burst > MaxRate ||
+		p.SessionPerMinute > p.RuntimePerMinute || p.Burst > p.RuntimePerMinute {
+		return p, ErrInvalid
+	}
+	return p, nil
+}
+
 type Admission struct {
+	Rates      RatePolicy
 	Key        Key
 	Digest     Digest
 	TrackingID string
@@ -285,7 +315,7 @@ func lookup(d *disk, k Key, digest Digest) (Result, error) {
 	return result(k.scoped(d.Namespace), r, false), nil
 }
 func (s *Store) Admit(ctx context.Context, a Admission) (out Result, err error) {
-	if !a.Key.valid() || !validText(a.TrackingID, 256, true) || !validSnapshot(a.Decision) {
+	if !a.Key.valid() {
 		return out, ErrInvalid
 	}
 	err = s.transaction(ctx, func(d *disk) (bool, error) {
@@ -293,6 +323,11 @@ func (s *Store) Admit(ctx context.Context, a Admission) (out Result, err error) 
 		out, e = lookup(d, a.Key, a.Digest)
 		if e != nil || out.Found {
 			return false, e
+		}
+		// Replay precedes all mutable admission policy/decision validation.
+		rates, e := a.Rates.Normalize()
+		if e != nil || !validText(a.TrackingID, 256, true) || !validSnapshot(a.Decision) {
+			return false, ErrInvalid
 		}
 		proven, e := s.advance(d)
 		if e != nil {
@@ -324,7 +359,7 @@ func (s *Store) Admit(ctx context.Context, a Admission) (out Result, err error) 
 				}
 			}
 		}
-		if len(events) >= 30 || perSession >= 6 || burst >= 3 {
+		if len(events) >= rates.RuntimePerMinute || perSession >= rates.SessionPerMinute || burst >= rates.Burst {
 			return false, ErrRate
 		}
 		d.Events = append(events, event{now, session})
@@ -398,7 +433,7 @@ func validSnapshot(s Snapshot) bool {
 	return true
 }
 func (d *disk) validate(s *Store) error {
-	if d.Version != 1 || !isHex(d.Namespace) || d.Limits != s.limits || d.Records == nil || d.Events == nil || len(d.Records) > d.Limits.Records || len(d.Events) > 30 || !validText(d.Clock.Boot, 256, false) || (d.Clock.Boot == "" && d.Clock.Seconds != 0) {
+	if d.Version != 1 || !isHex(d.Namespace) || d.Limits != s.limits || d.Records == nil || d.Events == nil || len(d.Records) > d.Limits.Records || len(d.Events) > d.Limits.Records || !validText(d.Clock.Boot, 256, false) || (d.Clock.Boot == "" && d.Clock.Seconds != 0) {
 		return ErrRepair
 	}
 	for _, v := range d.Events {
@@ -458,20 +493,9 @@ func (d *disk) validate(s *Store) error {
 			return ErrRepair
 		}
 	}
-	for i, v := range d.Events {
-		session, burst := 0, 0
-		for _, previous := range d.Events[:i+1] {
-			if v.At-previous.At < 60 && v.Session == previous.Session {
-				session++
-			}
-			if v.At-previous.At < 2 {
-				burst++
-			}
-		}
-		if session > 6 || burst > 3 {
-			return ErrRepair
-		}
-	}
+	// Policy is mutable and is not persisted in the v1 representation. Validate
+	// structural budgets and the exact live event/record multiset above, never
+	// today's quotas against yesterday's admissions. This is O(records+events).
 	return nil
 }
 func wrap(e error) error {

--- a/internal/agentnotify/journal/journal_test.go
+++ b/internal/agentnotify/journal/journal_test.go
@@ -436,6 +436,9 @@ func TestJournalProcess(t *testing.T) {
 		t.Fatal(e)
 	}
 	a := admission(os.Getenv("JOURNAL_KEY"))
+	if raw := os.Getenv("JOURNAL_RATES"); raw != "" {
+		requireNoError(t, json.Unmarshal([]byte(raw), &a.Rates))
+	}
 	if os.Getenv("JOURNAL_DIGEST") == "other" {
 		a.Digest = sha256.Sum256([]byte("conflict"))
 	}
@@ -891,7 +894,8 @@ func TestActualBootstrapCrashBoundaries(t *testing.T) {
 			if e = os.Chmod(root, 0700); e != nil {
 				t.Fatal(e)
 			}
-			s, _ := newStore(Options{Root: root})
+			s, e := newStore(Options{Root: root})
+			requireNoError(t, e)
 			b, e := child(s, "R", "bootstrap", stage, "").CombinedOutput()
 			var exit *exec.ExitError
 			if !errors.As(e, &exit) || exit.ExitCode() != 71 {

--- a/internal/agentnotify/journal/rates_test.go
+++ b/internal/agentnotify/journal/rates_test.go
@@ -1,0 +1,215 @@
+//go:build linux || darwin
+
+package journal
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRatePolicyBounds(t *testing.T) {
+	for _, p := range []RatePolicy{{1, 1, 1}, {MaxRate, MaxRate, MaxRate}, {2, 4, 3}, {12, 60, 8}, {}} {
+		if _, e := p.Normalize(); e != nil {
+			t.Fatal(p, e)
+		}
+	}
+	for _, p := range []RatePolicy{{0, 1, 1}, {1, 0, 1}, {1, 1, 0}, {-1, 1, 1}, {1, -1, 1}, {1, 1, -1}, {2, 1, 1}, {1, 1, 2}, {MaxRate + 1, MaxRate, 1}, {1, MaxRate + 1, 1}, {1, MaxRate, MaxRate + 1}} {
+		t.Run(fmt.Sprint(p), func(t *testing.T) {
+			s, _ := fixture(t, Limits{})
+			a := admission("R")
+			a.Rates = p
+			before, e := os.ReadFile(filepath.Join(s.root, "journal.json"))
+			requireNoError(t, e)
+			r, e := s.Admit(testContext(t), a)
+			if !errors.Is(e, ErrInvalid) || r.Fresh {
+				t.Fatal(r, e)
+			}
+			after, e := os.ReadFile(filepath.Join(s.root, "journal.json"))
+			requireNoError(t, e)
+			if !bytes.Equal(before, after) {
+				t.Fatal("invalid policy wrote state")
+			}
+			a.Rates = RatePolicy{}
+			mustAdmit(t, s, a)
+		})
+	}
+}
+
+func TestConfiguredWindows(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		p        RatePolicy
+		n        int
+		step     uint64
+		sessions bool
+	}{
+		{"lower-session", RatePolicy{2, 10, 10}, 2, 3, false},
+		{"higher-session", RatePolicy{8, 40, 10}, 8, 3, false},
+		{"lower-runtime", RatePolicy{2, 4, 4}, 4, 3, true},
+		{"higher-runtime", RatePolicy{40, 40, 40}, 40, 0, true},
+		{"lower-burst", RatePolicy{6, 30, 1}, 1, 0, false},
+		{"higher-burst", RatePolicy{10, 40, 5}, 5, 0, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s, c := fixture(t, Limits{})
+			for i := 0; i <= tc.n; i++ {
+				a := admission(fmt.Sprint(i))
+				a.Rates = tc.p
+				if tc.sessions {
+					a.Key.Session = fmt.Sprint(i)
+				}
+				if i < tc.n {
+					mustAdmit(t, s, a)
+				} else if r, e := s.Admit(testContext(t), a); !errors.Is(e, ErrRate) || r.Fresh {
+					t.Fatal(r, e)
+				}
+				c.x.Seconds += tc.step
+			}
+			s = reopen(t, s, c)
+			c.x.Seconds += 61
+			a := admission("recovered")
+			a.Rates = tc.p
+			mustAdmit(t, s, a)
+		})
+	}
+}
+
+func TestPolicyChangeReplayAndFrozenCounters(t *testing.T) {
+	s, c := fixture(t, Limits{})
+	a := admission("original")
+	a.Rates = RatePolicy{8, 40, 8}
+	first := mustAdmit(t, s, a)
+	for i := 0; i < 6; i++ {
+		b := admission(fmt.Sprint(i))
+		b.Rates = a.Rates
+		mustAdmit(t, s, b)
+	}
+	s = reopen(t, s, c)
+	for _, p := range []RatePolicy{{}, {1, 1, 1}, {-1, 0, 0}} {
+		a.Rates = p
+		a.Decision.Policy = "disabled"
+		a.Decision.Target.ID = strings.Repeat("x", 1025)
+		a.TrackingID = ""
+		r, e := s.Admit(testContext(t), a)
+		requireNoError(t, e)
+		x, e := json.Marshal(first.Record)
+		requireNoError(t, e)
+		y, e := json.Marshal(r.Record)
+		requireNoError(t, e)
+		if r.Fresh || r.ScopedKey != first.ScopedKey || !bytes.Equal(x, y) {
+			t.Fatal("replay changed")
+		}
+		r, e = s.Lookup(testContext(t), a.Key, a.Digest)
+		if e != nil || !r.Found {
+			t.Fatal(r, e)
+		}
+	}
+	b := admission("next")
+	if _, e := s.Admit(testContext(t), b); !errors.Is(e, ErrRate) {
+		t.Fatal(e)
+	}
+	b.Rates = RatePolicy{8, 40, 8}
+	mustAdmit(t, s, b)
+	for _, sample := range []Sample{{"boot-A", 1, true}, {"boot-B", 999999, true}, {}, {"boot-C", 9999999, true}} {
+		c.x = sample
+		requireNoError(t, s.Collect(testContext(t)))
+		s = reopen(t, s, c)
+		b := admission("frozen")
+		b.Rates = RatePolicy{8, 40, 8}
+		if _, e := s.Admit(testContext(t), b); !errors.Is(e, ErrRate) {
+			t.Fatal(sample, e)
+		}
+	}
+}
+
+func TestConfiguredActualProcessQuota(t *testing.T) {
+	for _, quota := range []int{1, 5} {
+		t.Run(fmt.Sprint(quota), func(t *testing.T) {
+			s, _ := fixture(t, Limits{})
+			p := RatePolicy{quota, quota, quota}
+			for i := 0; i < quota-1; i++ {
+				a := admission(fmt.Sprint(i))
+				a.Rates = p
+				mustAdmit(t, s, a)
+			}
+			encoded, e := json.Marshal(p)
+			requireNoError(t, e)
+			cmds := []*exec.Cmd{child(s, "A", "", "", ""), child(s, "B", "", "", "")}
+			var out [2]bytes.Buffer
+			for i, cmd := range cmds {
+				cmd.Env = append(cmd.Env, "JOURNAL_RATES="+string(encoded), "JOURNAL_GATE=go")
+				cmd.Stdout = &out[i]
+				cmd.Stderr = &out[i]
+				requireNoError(t, cmd.Start())
+				t.Cleanup(func() {
+					if cmd.ProcessState == nil {
+						_ = cmd.Process.Kill()
+						_ = cmd.Wait()
+					}
+				})
+			}
+			ctx := testContext(t)
+			for {
+				ready, e := filepath.Glob(filepath.Join(s.root, "ready-*"))
+				requireNoError(t, e)
+				if len(ready) == 2 {
+					break
+				}
+				select {
+				case <-ctx.Done():
+					t.Fatal(ctx.Err())
+				case <-time.After(time.Millisecond):
+				}
+			}
+			requireNoError(t, os.WriteFile(filepath.Join(s.root, "go"), []byte("go"), 0600))
+			for i, cmd := range cmds {
+				if e := cmd.Wait(); e != nil {
+					t.Fatalf("%v: %s", e, out[i].String())
+				}
+			}
+			all := out[0].String() + out[1].String()
+			if strings.Count(all, "FRESH") != 1 || strings.Count(all, "RATE") != 1 || effects(t, s) != 1 {
+				t.Fatal(all)
+			}
+		})
+	}
+}
+
+// Exercise the maximum structural budget without 10,000 fsync transactions.
+// All entries originate from a valid admission template; identities are unique.
+func TestExpandedRateIntegrityBudget(t *testing.T) {
+	s, _ := fixture(t, Limits{})
+	a := admission("R")
+	a.Rates = RatePolicy{MaxRate, MaxRate, MaxRate}
+	mustAdmit(t, s, a)
+	requireNoError(t, s.transaction(testContext(t), func(d *disk) (bool, error) {
+		template := d.Records[a.Key.scoped(d.Namespace)]
+		d.Records = map[string]Record{}
+		d.Events = []event{}
+		for i := 0; i < MaxRate; i++ {
+			r := template
+			r.Attempt = hash("attempt", fmt.Sprint(i))
+			d.Records[hash("key", fmt.Sprint(i))] = r
+			d.Events = append(d.Events, event{r.Created, r.Session})
+		}
+		requireNoError(t, d.validate(s))
+		d.Events[0].Session = hash("wrong")
+		if !errors.Is(d.validate(s), ErrRepair) {
+			t.Fatal("mismatched events accepted")
+		}
+		d.Events[0].Session = template.Session
+		d.Events = append(d.Events, event{template.Created, template.Session})
+		if !errors.Is(d.validate(s), ErrRepair) {
+			t.Fatal("oversized events accepted")
+		}
+		return false, nil
+	}))
+}


### PR DESCRIPTION
Explicit notifications need configurable limits shared across processes. Add a validated per-admission policy with the existing 6/session/minute, 30/runtime/minute and burst 3 defaults. Changes preserve accrued counters, stable request identity and replay; storage validation supports bounded expanded histories without quadratic rate scans.

Stacked on #156. This adds the journal contract; configuration activation and the compatible admission-writer floor are subsequent integration work. Old writers cannot safely enforce custom rates, despite unchanged disk JSON shape.

Validation: independent source review found no actionable issues; focused Linux package/race/vet passed with actual unprivileged process fixtures; macOS journal tests passed, including configured limits and contention. No native notifications or installed-feature completion is claimed.
