### PR TITLE
feat(notify): add explicit notification service and durable outcomes

### DIFF
--- a/internal/agentnotify/journal/journal.go
+++ b/internal/agentnotify/journal/journal.go
@@ -100,13 +100,14 @@ type Snapshot struct {
 	Navigation Navigation `json:"navigation"`
 }
 type Receipt struct {
-	Status     string   `json:"status"`
-	Reason     string   `json:"reason"`
-	Backend    string   `json:"backend"`
-	RequestID  *string  `json:"request_id"`
-	TrackingID string   `json:"tracking_id"`
-	KeyKind    KeyKind  `json:"key_kind"`
-	Decision   Snapshot `json:"decision"`
+	Status            string      `json:"status"`
+	Reason            string      `json:"reason"`
+	Backend           string      `json:"backend"`
+	RequestID         *string     `json:"request_id"`
+	TrackingID        string      `json:"tracking_id"`
+	KeyKind           KeyKind     `json:"key_kind"`
+	Decision          Snapshot    `json:"decision"`
+	OutcomeNavigation *Navigation `json:"outcome_navigation,omitempty"`
 }
 
 // MaxRate is the existing maximum record/JSON-array budget. Rate capacity does
@@ -387,6 +388,22 @@ func (s *Store) Admit(ctx context.Context, a Admission) (out Result, err error) 
 // are immutable. On any error after the effect the caller reports unknown and
 // must not retry delivery. A completed token cannot be finalized twice.
 func (s *Store) Finalize(ctx context.Context, k Key, attempt, status, reason, backend string) error {
+	return s.FinalizeOutcome(ctx, k, attempt, status, reason, backend, nil)
+}
+
+// FinalizeOutcome atomically records terminal navigation separately from the
+// immutable admission. Nil preserves the legacy Finalize representation.
+// This is draft unreleased v1 state: existing records remain readable, but old
+// readers reject the optional field/new suppressed enum. Activation must fence
+// older writers and rollback paths; never reset history or change namespace.
+func (s *Store) FinalizeOutcome(ctx context.Context, k Key, attempt, status, reason, backend string, navigation *Navigation) error {
+	if navigation != nil {
+		n := *navigation
+		navigation = &n
+		if !validOutcomeNavigation(n) {
+			return ErrInvalid
+		}
+	}
 	if !k.valid() || !isHex(attempt) || !validTerminal(status) || !validText(reason, 128, true) || !validText(backend, 128, false) {
 		return ErrInvalid
 	}
@@ -396,6 +413,10 @@ func (s *Store) Finalize(ctx context.Context, k Key, attempt, status, reason, ba
 		if !ok || r.Attempt != attempt || r.State != "dispatching" {
 			return false, ErrCAS
 		}
+		if navigation != nil && !validNavigationTransition(r.Receipt.Decision.Navigation, *navigation) {
+			return false, ErrInvalid
+		}
+		r.Receipt.OutcomeNavigation = navigation
 		r.State = status
 		r.Receipt.Status = status
 		r.Receipt.Reason = reason
@@ -423,7 +444,18 @@ func (s *Store) Collect(ctx context.Context) error {
 		return true, nil
 	})
 }
-func validTerminal(s string) bool { return s == "submitted" || s == "rejected" || s == "unknown" }
+func validTerminal(s string) bool {
+	return s == "submitted" || s == "rejected" || s == "unknown" || s == "suppressed"
+}
+func validOutcomeNavigation(n Navigation) bool {
+	if !validText(n.Scope, 1024, false) || !validText(n.Reason, 1024, false) {
+		return false
+	}
+	return (n.Capability == "available" && n.Precision == "chat_id" && n.Scope != "") || ((n.Capability == "unavailable" || n.Capability == "disabled") && n.Precision == "none")
+}
+func validNavigationTransition(before, after Navigation) bool {
+	return after.Capability != "available" || (before.Capability == "available" && before.Precision == after.Precision && before.Scope == after.Scope)
+}
 func validSnapshot(s Snapshot) bool {
 	for _, v := range []string{s.Target.Kind, s.Target.ID, s.Target.Application, s.Target.Identity, s.Policy, s.Navigation.Capability, s.Navigation.Precision, s.Navigation.Scope, s.Navigation.Reason} {
 		if !validText(v, 1024, false) {
@@ -473,6 +505,9 @@ func (d *disk) validate(s *Store) error {
 		if !isHex(r.Session) || !isHex(k) || !isHex(r.Digest) || !isHex(r.Attempt) || r.Created > d.Clock.Logical || !validKind(p.KeyKind) || !validText(p.TrackingID, 256, true) || !validSnapshot(p.Decision) || !validText(p.Reason, 128, true) || !validText(p.Backend, 128, false) {
 			return ErrRepair
 		}
+		if p.OutcomeNavigation != nil && (!validOutcomeNavigation(*p.OutcomeNavigation) || !validNavigationTransition(p.Decision.Navigation, *p.OutcomeNavigation)) {
+			return ErrRepair
+		}
 		if p.KeyKind == Explicit {
 			if p.RequestID == nil || !validText(*p.RequestID, 256, true) {
 				return ErrRepair
@@ -481,7 +516,7 @@ func (d *disk) validate(s *Store) error {
 			return ErrRepair
 		}
 		if r.State == "dispatching" {
-			if p.Status != "unknown" || p.Reason != "pending_submission" || p.Backend != "" {
+			if p.Status != "unknown" || p.Reason != "pending_submission" || p.Backend != "" || p.OutcomeNavigation != nil {
 				return ErrRepair
 			}
 		} else if !validTerminal(r.State) || p.Status != r.State {

--- a/internal/agentnotify/journal/outcome_test.go
+++ b/internal/agentnotify/journal/outcome_test.go
@@ -1,0 +1,65 @@
+package journal
+
+import (
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestOutcomeSuppressionCASAndCompatibility(t *testing.T) {
+	s, c := fixture(t, Limits{})
+	a := admission("suppressed")
+	first := mustAdmit(t, s, a)
+	n := Navigation{Capability: "disabled", Precision: "none", Reason: "disabled"}
+	ctx := testContext(t)
+	if e := s.FinalizeOutcome(ctx, a.Key, strings.Repeat("a", 64), "suppressed", "disabled", "fake", &n); !errors.Is(e, ErrCAS) {
+		t.Fatal(e)
+	}
+	if e := s.FinalizeOutcome(ctx, a.Key, first.Record.Attempt, "suppressed", "disabled", "fake", &n); e != nil {
+		t.Fatal(e)
+	}
+	n.Reason = "mutated"
+	for _, finalize := range []func() error{
+		func() error { return s.Finalize(ctx, a.Key, first.Record.Attempt, "submitted", "late", "fake") },
+		func() error {
+			return s.FinalizeOutcome(ctx, a.Key, first.Record.Attempt, "unknown", "late", "fake", &n)
+		},
+	} {
+		if e := finalize(); !errors.Is(e, ErrCAS) {
+			t.Fatal(e)
+		}
+	}
+	s = reopen(t, s, c)
+	r, e := s.Lookup(ctx, a.Key, a.Digest)
+	if e != nil || r.Record.Receipt.Status != "suppressed" || r.Record.Receipt.Reason != "disabled" || r.Record.Receipt.Backend != "fake" || r.Record.Receipt.OutcomeNavigation.Reason != "disabled" || !reflect.DeepEqual(r.Record.Receipt.Decision, a.Decision) {
+		t.Fatal(r, e)
+	}
+	// Legacy v1 records omit the optional field and remain readable after reopen.
+	old := admission("legacy")
+	v := mustAdmit(t, s, old)
+	if e := s.Finalize(ctx, old.Key, v.Record.Attempt, "submitted", "accepted", "old"); e != nil {
+		t.Fatal(e)
+	}
+	s = reopen(t, s, c)
+	v, e = s.Lookup(ctx, old.Key, old.Digest)
+	if e != nil || v.Record.Receipt.OutcomeNavigation != nil || v.Record.Receipt.Status != "submitted" {
+		t.Fatal(v, e)
+	}
+}
+
+func TestOutcomeRejectsInvalidNavigation(t *testing.T) {
+	s, _ := fixture(t, Limits{})
+	a := admission("R")
+	a.Decision.Navigation = Navigation{Capability: "unavailable", Precision: "none"}
+	r := mustAdmit(t, s, a)
+	for _, n := range []Navigation{{}, {Capability: "available", Precision: "chat_id", Scope: "invented"}, {Capability: "disabled", Precision: "chat_id"}} {
+		if e := s.FinalizeOutcome(testContext(t), a.Key, r.Record.Attempt, "submitted", "accepted", "fake", &n); !errors.Is(e, ErrInvalid) {
+			t.Fatal(e)
+		}
+	}
+	v, e := s.Lookup(testContext(t), a.Key, a.Digest)
+	if e != nil || v.Record.Receipt.Reason != "pending_submission" || v.Record.Receipt.OutcomeNavigation != nil {
+		t.Fatal(v, e)
+	}
+}

--- a/internal/agentnotify/journal/outcome_test.go
+++ b/internal/agentnotify/journal/outcome_test.go
@@ -1,3 +1,5 @@
+//go:build linux || darwin
+
 package journal
 
 import (

--- a/internal/agentnotify/origin/origin.go
+++ b/internal/agentnotify/origin/origin.go
@@ -1,0 +1,147 @@
+// Package origin contains transport-supplied identity and pure routing helpers.
+// It never discovers sessions, interfaces, applications or parent chats.
+package origin
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"errors"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/777genius/agent-notifications/internal/notification"
+)
+
+type Provenance string
+
+const (
+	ClientMetadata Provenance = "client_metadata"
+	CallerAsserted Provenance = "caller_asserted"
+)
+
+type Locality string
+
+const (
+	Local           Locality = "local"
+	Remote          Locality = "remote"
+	LocalityUnknown Locality = "unknown"
+)
+
+type Interface string
+
+const (
+	Desktop          Interface = "desktop"
+	Headless         Interface = "headless"
+	InterfaceUnknown Interface = "unknown"
+)
+
+// Context is built by the transport, never decoded from model Payload.
+// Namespace is a stable source namespace, not an application/configuration ID.
+// AnonymousCaller is an explicit transport namespace, permitted only for none.
+type Context struct {
+	Provider        string
+	Namespace       string
+	SessionID       string
+	AnonymousCaller string
+	CallID          string
+	Provenance      Provenance
+	Locality        Locality
+	Interface       Interface
+	Hidden          bool
+}
+
+func Text(s string, limit int, required bool) bool {
+	if (required && s == "") || len(s) > limit || !utf8.ValidString(s) {
+		return false
+	}
+	for _, r := range s {
+		if unicode.Is(unicode.Cc, r) {
+			return false
+		}
+	}
+	return true
+}
+
+func (o Context) Validate(n notification.Navigation) error {
+	if !Text(o.Provider, 256, true) || !Text(o.Namespace, 256, true) ||
+		!Text(o.SessionID, 256, false) || !Text(o.AnonymousCaller, 256, false) || !Text(o.CallID, 256, false) {
+		return errors.New("invalid_origin")
+	}
+	if o.Provenance != ClientMetadata && o.Provenance != CallerAsserted {
+		return errors.New("invalid_origin")
+	}
+	if o.Locality != Local && o.Locality != Remote && o.Locality != LocalityUnknown {
+		return errors.New("invalid_origin")
+	}
+	if o.Interface != Desktop && o.Interface != Headless && o.Interface != InterfaceUnknown {
+		return errors.New("invalid_origin")
+	}
+	if o.SessionID == "" && (n != notification.None || o.AnonymousCaller == "") {
+		return errors.New("session_required")
+	}
+	return nil
+}
+
+// Scope separates anonymous caller namespaces from real session identities.
+// The hash avoids expanding a 256-byte ID beyond the journal's key limit.
+func (o Context) Scope() (source, session string) {
+	kind, id := "session\x00", o.SessionID
+	if id == "" {
+		kind, id = "anonymous\x00", o.AnonymousCaller
+	}
+	h := sha256.Sum256([]byte(kind + id))
+	// Length framing avoids provider/namespace delimiter collisions.
+	var length [8]byte
+	binary.BigEndian.PutUint64(length[:], uint64(len(o.Provider)))
+	sourceHash := sha256.Sum256(append(length[:], []byte(o.Provider+o.Namespace)...))
+	return hex.EncodeToString(sourceHash[:]), hex.EncodeToString(h[:])
+}
+
+type RoutePolicy struct {
+	LocalRouting        bool
+	AllowUnknownCaller  bool
+	AllowCallerAsserted bool
+	ApplicationPath     string
+	TeamID              string
+}
+type Target struct {
+	Desktop    notification.DesktopTarget
+	Navigation notification.NavigationResult
+}
+
+// ResolveCodex preserves unknown interface/provenance and routes only under
+// explicit operator policy. It does not claim profile or store compatibility.
+func ResolveCodex(o Context, p RoutePolicy) Target {
+	no := func(reason string) Target {
+		return Target{Navigation: notification.NavigationResult{Capability: "unavailable", Precision: "none", Reason: reason}}
+	}
+	if err := o.Validate(notification.Required); err != nil {
+		return no("invalid_origin")
+	}
+	if o.Provider != "codex" {
+		return no("provider_unsupported")
+	}
+	if o.Locality == Remote || o.Interface == Headless {
+		return no("local_gui_unavailable")
+	}
+	if o.Hidden {
+		return no("hidden_target")
+	}
+	if o.SessionID == "" {
+		return no("session_required")
+	}
+	if !p.LocalRouting {
+		return no("local_routing_disabled")
+	}
+	if (o.Interface == InterfaceUnknown || o.Locality == LocalityUnknown) && !p.AllowUnknownCaller {
+		return no("unknown_caller")
+	}
+	if o.Provenance == CallerAsserted && !p.AllowCallerAsserted {
+		return no("caller_asserted_disabled")
+	}
+	if !Text(p.ApplicationPath, 1024, true) || !Text(p.TeamID, 256, true) {
+		return no("application_unavailable")
+	}
+	return Target{Desktop: notification.DesktopTarget{ThreadID: o.SessionID, ApplicationPath: p.ApplicationPath, TeamID: p.TeamID}, Navigation: notification.NavigationResult{Capability: "available", Precision: "chat_id", Scope: "local_current_profile", Reason: "configured_codex_desktop"}}
+}

--- a/internal/agentnotify/origin/origin_test.go
+++ b/internal/agentnotify/origin/origin_test.go
@@ -1,0 +1,69 @@
+package origin
+
+import (
+	"github.com/777genius/agent-notifications/internal/notification"
+	"testing"
+)
+
+func TestRoutingEvidenceAndExplicitPolicy(t *testing.T) {
+	base := Context{Provider: "codex", Namespace: "local", SessionID: "exact-session", Provenance: ClientMetadata, Locality: Local, Interface: InterfaceUnknown}
+	policy := RoutePolicy{LocalRouting: true, AllowUnknownCaller: true, AllowCallerAsserted: true, ApplicationPath: "/test/Codex.app", TeamID: "team"}
+	for _, tt := range []struct {
+		name      string
+		change    func(*Context, *RoutePolicy)
+		available bool
+	}{
+		{"unknown_optin", func(*Context, *RoutePolicy) {}, true},
+		{"unknown_no_optin", func(_ *Context, p *RoutePolicy) { p.AllowUnknownCaller = false }, false},
+		{"desktop", func(o *Context, p *RoutePolicy) { o.Interface = Desktop; p.AllowUnknownCaller = false }, true},
+		{"remote", func(o *Context, _ *RoutePolicy) { o.Locality = Remote }, false},
+		{"headless", func(o *Context, _ *RoutePolicy) { o.Interface = Headless }, false},
+		{"hidden", func(o *Context, _ *RoutePolicy) { o.Hidden = true }, false},
+		{"asserted", func(o *Context, _ *RoutePolicy) { o.Provenance = CallerAsserted }, true},
+		{"asserted_denied", func(o *Context, p *RoutePolicy) { o.Provenance = CallerAsserted; p.AllowCallerAsserted = false }, false},
+		{"unknown_locality", func(o *Context, _ *RoutePolicy) { o.Locality = LocalityUnknown }, true},
+		{"no_route", func(_ *Context, p *RoutePolicy) { p.LocalRouting = false }, false},
+		{"no_session", func(o *Context, _ *RoutePolicy) { o.SessionID = "" }, false},
+		{"claude", func(o *Context, _ *RoutePolicy) { o.Provider = "claude" }, false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			o, p := base, policy
+			tt.change(&o, &p)
+			before := o
+			r := ResolveCodex(o, p)
+			if (r.Navigation.Capability == "available") != tt.available {
+				t.Fatal(r)
+			}
+			if o != before {
+				t.Fatal("invented origin")
+			}
+			if tt.available && (r.Desktop.ThreadID != o.SessionID || r.Navigation.Scope != "local_current_profile") {
+				t.Fatal(r)
+			}
+		})
+	}
+}
+func TestAnonymousAndSourceScope(t *testing.T) {
+	o := Context{Provider: "codex", Namespace: "local", AnonymousCaller: "caller-A", Provenance: CallerAsserted, Locality: Local, Interface: InterfaceUnknown}
+	if e := o.Validate(notification.None); e != nil {
+		t.Fatal(e)
+	}
+	if e := o.Validate(notification.Required); e == nil {
+		t.Fatal("fake chat")
+	}
+	a, b := o.Scope()
+	o.SessionID = o.AnonymousCaller
+	c, d := o.Scope()
+	if a != c || b == d {
+		t.Fatal("scope collision")
+	}
+	o.Provider = "codex/"
+	o.Namespace = "local"
+	a, _ = o.Scope()
+	o.Provider = "codex"
+	o.Namespace = "/local"
+	c, _ = o.Scope()
+	if a == c {
+		t.Fatal("source framing collision")
+	}
+}

--- a/internal/agentnotify/outcome_test.go
+++ b/internal/agentnotify/outcome_test.go
@@ -1,0 +1,112 @@
+package agentnotify
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/777genius/agent-notifications/internal/agentnotify/journal"
+	"github.com/777genius/agent-notifications/internal/notification"
+)
+
+func TestOutcomeNavigationValidation(t *testing.T) {
+	for _, phase := range []string{"readiness", "delivery"} {
+		for _, kind := range []string{"missing", "malformed", "upgrade", "scope_change", "required_missing"} {
+			t.Run(phase+"/"+kind, func(t *testing.T) {
+				f := setup(t, journal.Limits{})
+				p := payload("navigation")
+				p.Navigation = notification.BestEffort
+				if kind == "upgrade" {
+					f.policy.Delivery.ClickToFocus = false
+				}
+				if kind == "required_missing" {
+					p.Navigation = notification.Required
+				}
+				bad := func(r notification.Request) notification.NavigationResult {
+					switch kind {
+					case "missing":
+						return notification.NavigationResult{}
+					case "malformed":
+						return notification.NavigationResult{Capability: "unavailable", Precision: "chat_id"}
+					case "upgrade":
+						return notification.NavigationResult{Capability: "available", Precision: "chat_id", Scope: "local_current_profile"}
+					case "scope_change":
+						return notification.NavigationResult{Capability: "available", Precision: "chat_id", Scope: "invented_profile"}
+					default:
+						return notification.NavigationResult{Capability: "unavailable", Precision: "none", Reason: "application_unavailable"}
+					}
+				}
+				if phase == "readiness" {
+					f.s.deps.Readiness = readyFunc(func(_ context.Context, r notification.Request) notification.Readiness {
+						return notification.Readiness{CorrelationID: r.CorrelationID, Status: "ready", Reason: "ready", Navigation: bad(r)}
+					})
+				} else {
+					f.s.deps.Delivery = deliverFunc(func(_ context.Context, r notification.Request) notification.Receipt {
+						f.effects.Add(1)
+						return notification.Receipt{CorrelationID: r.CorrelationID, Status: "submitted", Reason: "accepted", Navigation: bad(r)}
+					})
+				}
+				a := f.notify(p, caller())
+				if phase == "readiness" {
+					if a.Status != "rejected" || f.effects.Load() != 0 {
+						t.Fatal(a)
+					}
+				} else {
+					b := f.notify(p, caller())
+					expected := "unknown"
+					if kind == "required_missing" {
+						expected = "submitted"
+					}
+					if a.Status != expected || !b.Replayed || f.effects.Load() != 1 || a.Navigation != b.Navigation {
+						t.Fatal(a, b)
+					}
+				}
+			})
+		}
+	}
+}
+
+func TestOutcomePreservesAdmittedIdentity(t *testing.T) {
+	for _, phase := range []string{"readiness", "delivery"} {
+		t.Run(phase, func(t *testing.T) {
+			f := setup(t, journal.Limits{})
+			p := payload("identity")
+			p.Navigation = notification.BestEffort
+			limited := notification.NavigationResult{Capability: "unavailable", Precision: "none", Reason: "application_unavailable"}
+			original := f.s.deps.Readiness
+			if phase == "readiness" {
+				f.s.deps.Readiness = readyFunc(func(c context.Context, r notification.Request) notification.Readiness {
+					v := original.CheckReadiness(c, r)
+					v.Navigation = limited
+					return v
+				})
+			}
+			var admitted journal.Result
+			f.s.deps.Delivery = deliverFunc(func(c context.Context, r notification.Request) notification.Receipt {
+				source, session := caller().Scope()
+				var e error
+				admitted, e = f.store.Lookup(c, journal.Key{Source: source, Session: session, Kind: journal.Explicit, Request: *p.RequestID}, digest(p))
+				if e != nil {
+					t.Fatal(e)
+				}
+				if phase == "readiness" && r.Target != (notification.DesktopTarget{}) {
+					t.Fatal("unqualified action", r.Target)
+				}
+				f.effects.Add(1)
+				return notification.Receipt{CorrelationID: r.CorrelationID, Status: "submitted", Reason: "accepted", Backend: "fake", Navigation: limited}
+			})
+			a := f.notify(p, caller())
+			f.policy = Policy{}
+			b := f.notify(p, caller())
+			source, session := caller().Scope()
+			final, e := f.store.Lookup(testContext(t), journal.Key{Source: source, Session: session, Kind: journal.Explicit, Request: *p.RequestID}, digest(p))
+			if e != nil || !reflect.DeepEqual(admitted.Record.Receipt.Decision, final.Record.Receipt.Decision) || final.Record.Receipt.Decision.Target.ID == "" || final.Record.Receipt.Decision.Target.Application == "" {
+				t.Fatal(final, e)
+			}
+			b.Replayed = false
+			if !reflect.DeepEqual(a, b) || a.Navigation != limited || f.effects.Load() != 1 {
+				t.Fatal(a, b)
+			}
+		})
+	}
+}

--- a/internal/agentnotify/outcome_test.go
+++ b/internal/agentnotify/outcome_test.go
@@ -1,3 +1,5 @@
+//go:build linux || darwin
+
 package agentnotify
 
 import (

--- a/internal/agentnotify/rates_integration_test.go
+++ b/internal/agentnotify/rates_integration_test.go
@@ -1,0 +1,56 @@
+//go:build linux || darwin
+
+package agentnotify
+
+import (
+	"context"
+	"testing"
+
+	"github.com/777genius/agent-notifications/internal/agentnotify/journal"
+	"github.com/777genius/agent-notifications/internal/notification"
+)
+
+func TestServiceConfiguredRatesPreserveAccruedQuota(t *testing.T) {
+	f := setup(t, journal.Limits{})
+	f.policy.Rates = journal.RatePolicy{SessionPerMinute: 1, RuntimePerMinute: 1, Burst: 1}
+	first := f.notify(payload("first"), caller())
+	requireStatus(t, first, "submitted")
+	limited := f.notify(payload("second"), caller())
+	if limited.Status != "suppressed" || limited.Reason != "rate_limited" || f.effects.Load() != 1 {
+		t.Fatal(limited, f.effects.Load())
+	}
+	// Raising the policy permits the second request without forgetting the first.
+	f.policy.Rates = journal.RatePolicy{SessionPerMinute: 2, RuntimePerMinute: 2, Burst: 2}
+	requireStatus(t, f.notify(payload("second"), caller()), "submitted")
+	limited = f.notify(payload("third"), caller())
+	if limited.Reason != "rate_limited" || f.effects.Load() != 2 {
+		t.Fatal(limited, f.effects.Load())
+	}
+	f.policy.Rates = journal.RatePolicy{SessionPerMinute: 1, RuntimePerMinute: 1, Burst: 1}
+	limited = f.notify(payload("third"), caller())
+	if limited.Reason != "rate_limited" || f.effects.Load() != 2 {
+		t.Fatal(limited, f.effects.Load())
+	}
+	f.advance()
+	requireStatus(t, f.notify(payload("third"), caller()), "submitted")
+}
+
+func TestServiceInvalidRatePolicyDoesNotProbeAndReplaySkipsPolicy(t *testing.T) {
+	f := setup(t, journal.Limits{})
+	first := f.notify(payload("first"), caller())
+	requireStatus(t, first, "submitted")
+	f.policy.Rates = journal.RatePolicy{SessionPerMinute: 1, Burst: 1}
+	f.s.deps.Readiness = readyFunc(func(context.Context, notification.Request) notification.Readiness {
+		t.Fatal("invalid rate policy reached native readiness")
+		return notification.Readiness{}
+	})
+	r := f.notify(payload("new"), caller())
+	if r.Status != "rejected" || r.Reason != "configuration_invalid" || f.effects.Load() != 1 {
+		t.Fatal(r, f.effects.Load())
+	}
+	loads := f.loads.Load()
+	r = f.notify(payload("first"), caller())
+	if !r.Replayed || r.TrackingID != first.TrackingID || f.loads.Load() != loads || f.effects.Load() != 1 {
+		t.Fatal(r)
+	}
+}

--- a/internal/agentnotify/service.go
+++ b/internal/agentnotify/service.go
@@ -1,0 +1,394 @@
+package agentnotify
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+	"sync"
+	"time"
+
+	"github.com/777genius/agent-notifications/internal/agentnotify/journal"
+	"github.com/777genius/agent-notifications/internal/agentnotify/origin"
+	"github.com/777genius/agent-notifications/internal/notification"
+)
+
+type Service struct {
+	deps    Dependencies
+	mu      sync.Mutex
+	closed  bool
+	active  int
+	drained chan struct{}
+}
+
+func New(d Dependencies) (*Service, error) {
+	if !validDependencies(d) {
+		return nil, ErrDependencies
+	}
+	return &Service{deps: d, drained: make(chan struct{})}, nil
+}
+
+// Close prevents new submissions and drains admitted/preflight work. It is
+// idempotent, does not cancel an accepted OS send, and never closes injected
+// resources. A future transport owns those resources once per service lifetime.
+func (s *Service) Close(ctx context.Context) error {
+	if s == nil || s.drained == nil {
+		return ErrDependencies
+	}
+	if ctx == nil {
+		return errors.New("invalid_context")
+	}
+	s.mu.Lock()
+	if !s.closed {
+		s.closed = true
+		if s.active == 0 {
+			close(s.drained)
+		}
+	}
+	done := s.drained
+	s.mu.Unlock()
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+func (s *Service) enter() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return "service_closed"
+	}
+	if s.active >= 2 {
+		return "busy"
+	}
+	s.active++
+	return ""
+}
+func (s *Service) leave() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.active--
+	if s.closed && s.active == 0 {
+		close(s.drained)
+	}
+}
+
+// remaining never manufactures a fresh transport budget. The transport MUST
+// capture this deadline before decoding/validation. Decoded fields have a 16KiB
+// budget; raw JSON framing limits belong to the transport (MCP: 64KiB).
+func (s *Service) remaining(ctx context.Context, d notification.Deadline) (time.Duration, string) {
+	if ctx == nil {
+		return 0, "invalid_context"
+	}
+	if ctx.Err() != nil {
+		return 0, "canceled"
+	}
+	now := s.deps.Clock.Now()
+	if !origin.Text(d.BootID, 256, true) || now.BootID != d.BootID || math.IsNaN(d.NotAfter) || math.IsInf(d.NotAfter, 0) || math.IsNaN(now.NotAfter) || math.IsInf(now.NotAfter, 0) || now.NotAfter < 0 {
+		return 0, "invalid_deadline"
+	}
+	delta := d.NotAfter - now.NotAfter
+	if delta <= 0 {
+		return 0, "deadline_exceeded"
+	}
+	if delta > 15 {
+		return 0, "invalid_deadline"
+	}
+	return time.Duration(delta * float64(time.Second)), ""
+}
+
+// Notify accepts typed payload and a separately constructed origin. No future,
+// goroutine, queue or retry is created; delivery is invoked at most once after
+// durable admission. Ports must honor context cancellation and the boot deadline.
+func (s *Service) Notify(ctx context.Context, p Payload, o origin.Context, deadline notification.Deadline) Receipt {
+	out := Receipt{Status: "rejected", RetrySafe: true, Navigation: notification.NavigationResult{Capability: "unavailable", Precision: "none"}}
+	if p.RequestID != nil {
+		id := *p.RequestID
+		p.RequestID = &id
+		out.RequestID = &id
+	}
+	if s == nil || !validDependencies(s.deps) {
+		out.Reason = "invalid_dependencies"
+		return out
+	}
+	s.mu.Lock()
+	closed := s.closed
+	s.mu.Unlock()
+	if closed {
+		out.Reason = "service_closed"
+		return out
+	}
+	budget, reason := s.remaining(ctx, deadline)
+	if reason != "" {
+		out.Reason = reason
+		return out
+	}
+	ctx, cancel := context.WithTimeout(ctx, budget)
+	defer cancel()
+	p, reason = validate(p, o)
+	if reason != "" {
+		out.Reason = reason
+		return out
+	}
+	tracking, e := trackingID()
+	if e != nil {
+		out.Reason = "entropy_unavailable"
+		return out
+	}
+	out.TrackingID = tracking
+	source, session := o.Scope()
+	key := journal.Key{Source: source, Session: session, Kind: journal.Generated, Request: tracking}
+	if p.RequestID != nil {
+		key.Kind = journal.Explicit
+		key.Request = *p.RequestID
+	} else if o.CallID != "" {
+		key.Kind = journal.ClientCall
+		key.Request = o.CallID
+	}
+	out.KeyKind = key.Kind
+	dg := digest(p)
+	found, e := s.deps.Admission.Lookup(ctx, key, dg)
+	if e != nil {
+		return journalFailure(out, e)
+	}
+	if found.Found {
+		return replay(found)
+	}
+	if reason = s.enter(); reason != "" {
+		out.Reason = reason
+		return out
+	}
+	defer s.leave()
+	if _, reason = s.remaining(ctx, deadline); reason != "" {
+		out.Reason = reason
+		return out
+	}
+	policy, e := s.deps.Policy.Load(ctx, o)
+	if e != nil || !policy.Delivery.Valid {
+		out.Reason = "configuration_invalid"
+		return out
+	}
+	policy.Rates, e = policy.Rates.Normalize()
+	if e != nil {
+		out.Reason = "configuration_invalid"
+		return out
+	}
+	if !policy.Delivery.ExplicitEnabled || !policy.Delivery.DesktopEnabled {
+		out.Status = "suppressed"
+		out.Reason = "disabled"
+		return out
+	}
+	if o.Locality == origin.Remote || o.Interface == origin.Headless {
+		out.Reason = "local_gui_unavailable"
+		return out
+	}
+	if ((o.Interface == origin.InterfaceUnknown || o.Locality == origin.LocalityUnknown) && (!policy.Route.LocalRouting || !policy.Route.AllowUnknownCaller)) || (o.Provenance == origin.CallerAsserted && (!policy.Route.LocalRouting || !policy.Route.AllowCallerAsserted)) {
+		out.Reason = "local_routing_unavailable"
+		return out
+	}
+	target := origin.Target{Navigation: notification.NavigationResult{Capability: "disabled", Precision: "none", Reason: "navigation_none"}}
+	if p.Navigation != notification.None {
+		if !policy.Delivery.ClickToFocus {
+			target.Navigation = notification.NavigationResult{Capability: "disabled", Precision: "none", Reason: "click_to_focus_disabled"}
+		} else if o.Hidden {
+			target.Navigation = notification.NavigationResult{Capability: "unavailable", Precision: "none", Reason: "hidden_target"}
+		} else if !policy.Route.LocalRouting || ((o.Interface == origin.InterfaceUnknown || o.Locality == origin.LocalityUnknown) && !policy.Route.AllowUnknownCaller) || (o.Provenance == origin.CallerAsserted && !policy.Route.AllowCallerAsserted) {
+			target.Navigation = notification.NavigationResult{Capability: "unavailable", Precision: "none", Reason: "local_routing_unavailable"}
+		} else {
+			target, e = s.deps.Target.Resolve(ctx, o, policy.Route)
+			if e != nil {
+				out.Reason = "target_unavailable"
+				return out
+			}
+		}
+		if !validTarget(target) {
+			out.Reason = "invalid_target"
+			return out
+		}
+		if target.Navigation.Capability != "available" {
+			target.Desktop = notification.DesktopTarget{}
+		}
+		if p.Navigation == notification.Required && target.Navigation.Capability != "available" {
+			out.Reason = "navigation_unavailable"
+			out.Navigation = target.Navigation
+			return out
+		}
+	}
+	req := notification.Request{CorrelationID: correlationID("preflight", tracking), Content: notification.Content{Title: p.Title, Body: p.Body, Category: p.Category}, Deadline: deadline, Policy: policy.Delivery, Navigation: p.Navigation, Target: target.Desktop, Silent: !policy.Delivery.SoundEnabled}
+	if _, reason = s.remaining(ctx, deadline); reason != "" {
+		out.Reason = reason
+		return out
+	}
+	// CheckReadiness must have released its installation lease when it returns.
+	// Admission and Deliver therefore never nest component and journal locks.
+	ready := s.deps.Readiness.CheckReadiness(ctx, req)
+	out.Navigation = target.Navigation
+	qualified, valid := reconcileNavigation(target.Navigation, ready.Navigation)
+	if ready.CorrelationID != req.CorrelationID || !valid || !origin.Text(ready.Reason, 128, true) || !origin.Text(ready.Backend, 128, false) || (ready.Status != "ready" && ready.Status != "rejected" && ready.Status != "suppressed") {
+		out.Reason = "invalid_readiness_receipt"
+		return out
+	}
+	out.Navigation = qualified
+	if ready.Status != "ready" {
+		out.Reason = "readiness_unavailable"
+		if origin.Text(ready.Reason, 128, true) {
+			out.Reason = ready.Reason
+		}
+		if ready.Status == "suppressed" {
+			out.Status = "suppressed"
+		}
+		return out
+	}
+	if _, reason = s.remaining(ctx, deadline); reason != "" {
+		out.Reason = reason
+		return out
+	}
+	if p.Navigation == notification.Required && qualified.Capability != "available" {
+		out.Reason = "navigation_unavailable"
+		return out
+	}
+	decision := snapshot(policy, target)
+	decision.Navigation = journal.Navigation(qualified)
+	if qualified.Capability != "available" {
+		req.Target = notification.DesktopTarget{}
+	}
+
+	admitted, e := s.deps.Admission.Admit(ctx, journal.Admission{Key: key, Digest: dg, TrackingID: tracking, Decision: decision, Rates: policy.Rates})
+	if e != nil {
+		out = journalFailure(out, e)
+		out.RetrySafe = false
+		return out
+	}
+	if !admitted.Fresh {
+		if admitted.Found {
+			return replay(admitted)
+		}
+		out.Reason = "journal_unavailable"
+		out.RetrySafe = false
+		return out
+	}
+	out = fromJournal(admitted.Record.Receipt, false)
+	// Durable pending cannot be undone by cancellation. Skipping handoff here is
+	// conservative: the stored pending receipt is never automatically resent.
+	if _, reason = s.remaining(ctx, deadline); reason != "" {
+		return out
+	}
+	req.CorrelationID = correlationID(admitted.ScopedKey, admitted.Record.Attempt)
+	delivered := s.deps.Delivery.Deliver(ctx, req)
+	status, why, backend := delivered.Status, delivered.Reason, delivered.Backend
+	finalNavigation, valid := reconcileNavigation(qualified, delivered.Navigation)
+	if delivered.CorrelationID != req.CorrelationID || (status != "submitted" && status != "rejected" && status != "unknown" && status != "suppressed") || !valid || !origin.Text(why, 128, true) || !origin.Text(backend, 128, false) {
+		status, why, backend = "unknown", "invalid_delivery_receipt", ""
+		finalNavigation = notification.NavigationResult{Capability: "unavailable", Precision: "none", Reason: "invalid_delivery_receipt"}
+	}
+	// Finalization has a separate bounded durability budget, never a new send
+	// budget. Positive OS acceptance survives late caller cancellation.
+	finalCtx, finalCancel := context.WithTimeout(context.WithoutCancel(ctx), time.Second)
+	defer finalCancel()
+	if e = s.deps.Admission.FinalizeOutcome(finalCtx, key, admitted.Record.Attempt, status, why, backend, (*journal.Navigation)(&finalNavigation)); e != nil {
+		out.Status = "unknown"
+		out.Reason = "finalization_failed"
+		return out
+	}
+	out.Status = status
+	out.Reason = why
+	out.Backend = backend
+	out.Navigation = finalNavigation
+	return out
+}
+
+// Ports may qualify or reduce a resolved capability, never create a new action.
+func reconcileNavigation(before, after notification.NavigationResult) (notification.NavigationResult, bool) {
+	if !origin.Text(after.Scope, 1024, false) || !origin.Text(after.Reason, 1024, false) {
+		return after, false
+	}
+	switch after.Capability {
+	case "available":
+		return after, after.Precision == "chat_id" && after.Scope != "" && before.Capability == "available" && before.Precision == after.Precision && before.Scope == after.Scope
+	case "unavailable", "disabled":
+		return after, after.Precision == "none"
+	default:
+		return after, false
+	}
+}
+func validTarget(t origin.Target) bool {
+	n := t.Navigation
+	if n.Capability != "available" && n.Capability != "unavailable" && n.Capability != "disabled" {
+		return false
+	}
+	for _, v := range []string{n.Scope, n.Reason} {
+		if !origin.Text(v, 1024, false) {
+			return false
+		}
+	}
+	if n.Capability != "available" {
+		return n.Precision == "none"
+	}
+	return n.Scope != "" && n.Precision == "chat_id" && origin.Text(t.Desktop.ThreadID, 256, true) && origin.Text(t.Desktop.ApplicationPath, 1024, true) && origin.Text(t.Desktop.TeamID, 256, true)
+}
+func snapshot(p Policy, t origin.Target) journal.Snapshot {
+	// Only booleans describing the admitted policy, never raw config/metadata.
+	b, _ := json.Marshal(struct {
+		Delivery notification.PolicySnapshot
+		Rates    journal.RatePolicy
+	}{p.Delivery, p.Rates})
+	kind := "none"
+	if t.Navigation.Capability == "available" {
+		kind = "desktop_thread"
+	}
+	return journal.Snapshot{Target: journal.Target{Kind: kind, ID: t.Desktop.ThreadID, Application: t.Desktop.ApplicationPath, Identity: t.Desktop.TeamID}, Policy: string(b), Navigation: journal.Navigation{Capability: t.Navigation.Capability, Precision: t.Navigation.Precision, Scope: t.Navigation.Scope, Reason: t.Navigation.Reason}}
+}
+func trackingID() (string, error) {
+	var b [32]byte
+	if _, e := rand.Read(b[:]); e != nil {
+		return "", e
+	}
+	return hex.EncodeToString(b[:]), nil
+}
+
+// correlationID uses the UUIDv8 custom layout for a SHA-256-derived identity.
+func correlationID(scoped, attempt string) string {
+	b := sha256.Sum256([]byte("agent-notify/native/v1\x00" + scoped + "\x00" + attempt))
+	b[6] = (b[6] & 0x0f) | 0x80
+	b[8] = (b[8] & 0x3f) | 0x80
+	return fmt.Sprintf("%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:16])
+}
+func replay(r journal.Result) Receipt { return fromJournal(r.Record.Receipt, true) }
+func fromJournal(r journal.Receipt, replayed bool) Receipt {
+	n := r.Decision.Navigation
+	if r.OutcomeNavigation != nil {
+		n = *r.OutcomeNavigation
+	}
+	var id *string
+	if r.RequestID != nil {
+		v := *r.RequestID
+		id = &v
+	}
+	return Receipt{RequestID: id, TrackingID: r.TrackingID, KeyKind: r.KeyKind, Status: r.Status, Reason: r.Reason, Replayed: replayed, Backend: r.Backend, Navigation: notification.NavigationResult{Capability: n.Capability, Precision: n.Precision, Scope: n.Scope, Reason: n.Reason}, RetrySafe: false}
+}
+func journalFailure(out Receipt, e error) Receipt {
+	out.Reason = "journal_unavailable"
+	switch {
+	case errors.Is(e, journal.ErrConflict):
+		out.Reason = "idempotency_conflict"
+		out.RetrySafe = false
+	case errors.Is(e, journal.ErrRate):
+		out.Status = "suppressed"
+		out.Reason = "rate_limited"
+	case errors.Is(e, journal.ErrFull):
+		out.Reason = "journal_full"
+	case errors.Is(e, journal.ErrRepair):
+		out.Reason = "state_repair_required"
+	case errors.Is(e, context.Canceled):
+		out.Reason = "canceled"
+	case errors.Is(e, context.DeadlineExceeded):
+		out.Reason = "deadline_exceeded"
+	}
+	return out
+}

--- a/internal/agentnotify/service_review_test.go
+++ b/internal/agentnotify/service_review_test.go
@@ -1,0 +1,101 @@
+// Review-only Go overlay. Never installed into the production package on disk.
+package agentnotify
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/777genius/agent-notifications/internal/agentnotify/journal"
+	"github.com/777genius/agent-notifications/internal/agentnotify/origin"
+	"github.com/777genius/agent-notifications/internal/notification"
+)
+
+func TestReviewNavigationDowngrade(t *testing.T) {
+	for _, phase := range []string{"readiness", "delivery"} {
+		t.Run(phase, func(t *testing.T) {
+			f := setup(t, journal.Limits{})
+			p := payload("navigation-review")
+			p.Navigation = notification.BestEffort
+			limited := notification.NavigationResult{Capability: "unavailable", Precision: "none", Reason: "application_unavailable"}
+			f.s.deps.Readiness = readyFunc(func(_ context.Context, r notification.Request) notification.Readiness {
+				n := origin.ResolveCodex(caller(), f.policy.Route).Navigation
+				if phase == "readiness" {
+					n = limited
+				}
+				return notification.Readiness{CorrelationID: r.CorrelationID, Status: "ready", Reason: "ready", Navigation: n}
+			})
+			f.s.deps.Delivery = deliverFunc(func(_ context.Context, r notification.Request) notification.Receipt {
+				f.effects.Add(1)
+				return notification.Receipt{CorrelationID: r.CorrelationID, Status: "submitted", Reason: "os_accepted", Backend: "fake", Navigation: limited}
+			})
+			a := f.notify(p, caller())
+			b := f.notify(p, caller())
+			t.Logf("port navigation=%+v; first=%+v; replay=%+v; fake effects=%d", limited, a, b, f.effects.Load())
+			if a.Status != "submitted" || !b.Replayed || f.effects.Load() != 1 {
+				t.Fatal("invalid reproduction")
+			}
+			if a.Navigation.Capability != "unavailable" || b.Navigation.Capability != "unavailable" {
+				t.Error("receipt and durable replay claim a chat action despite explicit port downgrade")
+			}
+		})
+	}
+}
+
+func TestReviewSuppressedReceipt(t *testing.T) {
+	f := setup(t, journal.Limits{})
+	calls := 0
+	f.s.deps.Delivery = deliverFunc(func(_ context.Context, r notification.Request) notification.Receipt {
+		calls++ // A port invocation is not an OS effect.
+		return notification.Receipt{CorrelationID: r.CorrelationID, Status: "suppressed", Reason: "disabled", Backend: "fake", Navigation: notification.NavigationResult{Capability: "disabled", Precision: "none"}}
+	})
+	a := f.notify(payload("suppressed-review"), caller())
+	b := f.notify(payload("suppressed-review"), caller())
+	t.Logf("first=%+v; replay=%+v; delivery calls=%d; effects=%d", a, b, calls, f.effects.Load())
+	if calls != 1 || f.effects.Load() != 0 || !b.Replayed {
+		t.Fatal("invalid reproduction")
+	}
+	if a.Status != "suppressed" || b.Status != "suppressed" || a.Reason != "disabled" {
+		t.Error("valid proven-no-effect suppression is mislabeled as uncertain malformed acknowledgement")
+	}
+}
+
+func TestReviewSafeTargetFailure(t *testing.T) {
+	f := setup(t, journal.Limits{})
+	p := payload("target-review")
+	p.Navigation = notification.BestEffort
+	f.s.deps.Target = TargetFunc(func(context.Context, origin.Context, origin.RoutePolicy) (origin.Target, error) {
+		return origin.Target{}, errors.New("resolver failed")
+	})
+	a := f.notify(p, caller())
+	t.Logf("resolver error=%+v; effects=%d", a, f.effects.Load())
+	if a.Status != "rejected" || a.Reason != "target_unavailable" || !a.RetrySafe || f.effects.Load() != 0 {
+		t.Fatal(a)
+	}
+	f.s.deps.Target = TargetFunc(func(_ context.Context, o origin.Context, p origin.RoutePolicy) (origin.Target, error) {
+		return origin.ResolveCodex(o, p), nil
+	})
+	b := f.notify(p, caller())
+	t.Logf("same key after resolver repair=%+v", b)
+	if b.Replayed || b.Status != "submitted" {
+		t.Fatal(b)
+	}
+}
+
+func TestReviewRateFailureIsPreAdmission(t *testing.T) {
+	f := setup(t, journal.Limits{})
+	for _, id := range []string{"rate-1", "rate-2", "rate-3"} {
+		requireStatus(t, f.notify(payload(id), caller()), "submitted")
+	}
+	a := f.notify(payload("rate-4"), caller())
+	t.Logf("rate failure=%+v; effects=%d", a, f.effects.Load())
+	if a.Status != "suppressed" || a.Reason != "rate_limited" || f.effects.Load() != 3 {
+		t.Fatal(a)
+	}
+	f.advance()
+	b := f.notify(payload("rate-4"), caller())
+	t.Logf("same key after rate window=%+v", b)
+	if b.Replayed || b.Status != "submitted" {
+		t.Fatal(b)
+	}
+}

--- a/internal/agentnotify/service_review_test.go
+++ b/internal/agentnotify/service_review_test.go
@@ -1,4 +1,6 @@
-// Review-only Go overlay. Never installed into the production package on disk.
+//go:build linux || darwin
+
+// Regression cases retained from independent service review.
 package agentnotify
 
 import (

--- a/internal/agentnotify/service_test.go
+++ b/internal/agentnotify/service_test.go
@@ -1,0 +1,827 @@
+//go:build linux || darwin
+
+package agentnotify
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"regexp"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/777genius/agent-notifications/internal/agentnotify/journal"
+	"github.com/777genius/agent-notifications/internal/agentnotify/origin"
+	"github.com/777genius/agent-notifications/internal/notification"
+)
+
+type readyFunc func(context.Context, notification.Request) notification.Readiness
+
+func (f readyFunc) CheckReadiness(c context.Context, r notification.Request) notification.Readiness {
+	return f(c, r)
+}
+
+type deliverFunc func(context.Context, notification.Request) notification.Receipt
+
+func (f deliverFunc) Deliver(c context.Context, r notification.Request) notification.Receipt {
+	return f(c, r)
+}
+
+type fixture struct {
+	s        *Service
+	store    *journal.Store
+	root     string
+	now      atomic.Int64
+	effects  atomic.Int64
+	loads    atomic.Int64
+	policy   Policy
+	requests []notification.Request
+	mu       sync.Mutex
+}
+
+func setup(t *testing.T, limits journal.Limits) *fixture {
+	t.Helper()
+	f := &fixture{}
+	f.now.Store(100)
+	root, e := filepath.EvalSymlinks(t.TempDir())
+	if e != nil {
+		t.Fatal(e)
+	}
+	if e = os.Chmod(root, 0700); e != nil {
+		t.Fatal(e)
+	}
+	f.root = root
+	f.store, e = journal.Initialize(testContext(t), journal.Options{Root: root, Limits: limits, Clock: journal.ClockFunc(func() journal.Sample {
+		return journal.Sample{Boot: "boot", Seconds: uint64(f.now.Load()), Available: true}
+	})})
+	if e != nil {
+		t.Fatal(e)
+	}
+	f.policy = Policy{Delivery: notification.PolicySnapshot{Valid: true, ExplicitEnabled: true, DesktopEnabled: true, ClickToFocus: true, SoundEnabled: true}, Route: origin.RoutePolicy{LocalRouting: true, AllowUnknownCaller: true, AllowCallerAsserted: true, ApplicationPath: "/test/A.app", TeamID: "team-A"}}
+	f.s, e = New(Dependencies{Admission: f.store, Clock: ClockFunc(func() notification.Deadline {
+		return notification.Deadline{BootID: "boot", NotAfter: float64(f.now.Load())}
+	}), Policy: PolicyFunc(func(context.Context, origin.Context) (Policy, error) { f.loads.Add(1); return f.policy, nil }), Target: TargetFunc(func(_ context.Context, o origin.Context, p origin.RoutePolicy) (origin.Target, error) {
+		return origin.ResolveCodex(o, p), nil
+	}), Readiness: readyFunc(func(_ context.Context, r notification.Request) notification.Readiness {
+		return notification.Readiness{Navigation: fakeNavigation(r), CorrelationID: r.CorrelationID, Reason: "ready", Status: "ready"}
+	}), Delivery: deliverFunc(func(_ context.Context, r notification.Request) notification.Receipt {
+		f.effects.Add(1)
+		f.mu.Lock()
+		f.requests = append(f.requests, r)
+		f.mu.Unlock()
+		return notification.Receipt{Navigation: fakeNavigation(r), CorrelationID: r.CorrelationID, Status: "submitted", Reason: "os_accepted", Backend: "fake"}
+	})})
+	if e != nil {
+		t.Fatal(e)
+	}
+	return f
+}
+func caller() origin.Context {
+	return origin.Context{Provider: "codex", Namespace: "local", SessionID: "session-A", CallID: "call-1", Provenance: origin.ClientMetadata, Locality: origin.Local, Interface: origin.InterfaceUnknown}
+}
+func payload(id string) Payload {
+	return Payload{Title: "literal --help [important]", Body: "body-private-sentinel", Category: "attention", RequestID: &id}
+}
+func (f *fixture) notify(p Payload, o origin.Context) Receipt {
+	return f.s.Notify(context.Background(), p, o, notification.Deadline{BootID: "boot", NotAfter: float64(f.now.Load() + 15)})
+}
+func requireStatus(t *testing.T, r Receipt, status string) {
+	t.Helper()
+	if r.Status != status {
+		t.Fatalf("got %+v, want %s", r, status)
+	}
+}
+func (f *fixture) advance() { f.now.Add(62) }
+
+func TestKeyPriorityScopeConflictAndReplay(t *testing.T) {
+	f := setup(t, journal.Limits{})
+	o := caller()
+	p := payload("R")
+	first := f.notify(p, o)
+	requireStatus(t, first, "submitted")
+	if first.RequestID == nil || *first.RequestID != "R" || first.KeyKind != journal.Explicit || len(first.TrackingID) != 64 {
+		t.Fatal(first)
+	}
+	o.CallID = "different-call"
+	again := f.notify(p, o)
+	if !again.Replayed || again.TrackingID != first.TrackingID || f.effects.Load() != 1 {
+		t.Fatal(again)
+	}
+	p.Body += "changed"
+	conflict := f.notify(p, o)
+	if conflict.Reason != "idempotency_conflict" || f.effects.Load() != 1 {
+		t.Fatal(conflict)
+	}
+	// Same cwd is deliberately irrelevant: neither public input has a cwd field.
+	f.advance()
+	p = payload("R")
+	o.SessionID = "session-B"
+	requireStatus(t, f.notify(p, o), "submitted")
+	f.advance()
+	o.Provider = "claude"
+	p.Navigation = notification.None
+	requireStatus(t, f.notify(p, o), "submitted")
+	f.advance()
+	o = caller()
+	requireStatus(t, f.notify(payload("R2"), o), "submitted")
+	if f.effects.Load() != 4 {
+		t.Fatal(f.effects.Load())
+	}
+}
+func TestCallIDGeneratedAndAnonymousNamespaces(t *testing.T) {
+	f := setup(t, journal.Limits{})
+	o := caller()
+	p := payload("")
+	p.RequestID = nil
+	a := f.notify(p, o)
+	requireStatus(t, a, "submitted")
+	if a.RequestID != nil || a.KeyKind != journal.ClientCall {
+		t.Fatal(a)
+	}
+	if b := f.notify(p, o); !b.Replayed || b.TrackingID != a.TrackingID {
+		t.Fatal(b)
+	}
+	f.advance()
+	o.CallID = ""
+	a = f.notify(p, o)
+	f.advance()
+	b := f.notify(p, o)
+	if a.KeyKind != journal.Generated || a.RequestID != nil || b.TrackingID == a.TrackingID || b.Replayed {
+		t.Fatal(a, b)
+	}
+	f.advance()
+	o.SessionID = ""
+	o.AnonymousCaller = "session-A"
+	p.Navigation = notification.None
+	requireStatus(t, f.notify(p, o), "submitted")
+	f.mu.Lock()
+	last := f.requests[len(f.requests)-1]
+	f.mu.Unlock()
+	if last.Target != (notification.DesktopTarget{}) {
+		t.Fatal(last)
+	}
+	sa, aa := o.Scope()
+	o.SessionID = "session-A"
+	sb, ab := o.Scope()
+	if sa != sb || aa == ab {
+		t.Fatal("anonymous/session collision")
+	}
+}
+func TestPreflightDoesNotConsumeKeyAndReplaySkipsMutablePorts(t *testing.T) {
+	f := setup(t, journal.Limits{})
+	p := payload("R")
+	o := caller()
+	f.s.deps.Readiness = readyFunc(func(_ context.Context, r notification.Request) notification.Readiness {
+		return notification.Readiness{Navigation: fakeNavigation(r), CorrelationID: r.CorrelationID, Reason: "permission_denied", Status: "rejected"}
+	})
+	if r := f.notify(p, o); r.Reason != "permission_denied" || f.effects.Load() != 0 {
+		t.Fatal(r)
+	}
+	f.s.deps.Readiness = readyFunc(func(_ context.Context, r notification.Request) notification.Readiness {
+		return notification.Readiness{Navigation: fakeNavigation(r), CorrelationID: r.CorrelationID, Reason: "ready", Status: "ready"}
+	})
+	a := f.notify(p, o)
+	requireStatus(t, a, "submitted")
+	f.policy = Policy{}
+	f.s.deps.Target = TargetFunc(func(context.Context, origin.Context, origin.RoutePolicy) (origin.Target, error) {
+		t.Error("replay resolved target")
+		return origin.Target{}, nil
+	})
+	f.s.deps.Readiness = readyFunc(func(_ context.Context, r notification.Request) notification.Readiness {
+		t.Error("replay probed readiness")
+		return notification.Readiness{}
+	})
+	b := f.notify(p, o)
+	if !b.Replayed || !reflect.DeepEqual(a.Navigation, b.Navigation) || a.TrackingID != b.TrackingID || f.loads.Load() != 2 {
+		t.Fatal(a, b)
+	}
+	source, session := o.Scope()
+	r, e := f.store.Lookup(testContext(t), journal.Key{Source: source, Session: session, Kind: journal.Explicit, Request: "R"}, digest(Payload{Title: p.Title, Body: p.Body, Category: p.Category, Navigation: notification.Required}))
+	if e != nil || r.Record.Receipt.Decision.Target.Application != "/test/A.app" {
+		t.Fatal(r, e)
+	}
+}
+
+func waitSignal(t *testing.T, c <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-c:
+	case <-time.After(5 * time.Second):
+		t.Fatal("barrier timed out")
+	}
+}
+func TestConcurrentAdmitLoserUsesStoredDecision(t *testing.T) {
+	f := setup(t, journal.Limits{})
+	arrived := make(chan struct{}, 2)
+	release := make(chan struct{})
+	var count atomic.Int64
+	f.s.deps.Policy = PolicyFunc(func(context.Context, origin.Context) (Policy, error) {
+		p := f.policy
+		if count.Add(1) == 2 {
+			p.Route.ApplicationPath = "/test/B.app"
+		}
+		return p, nil
+	})
+	f.s.deps.Readiness = readyFunc(func(_ context.Context, r notification.Request) notification.Readiness {
+		arrived <- struct{}{}
+		<-release
+		return notification.Readiness{Navigation: fakeNavigation(r), CorrelationID: r.CorrelationID, Reason: "ready", Status: "ready"}
+	})
+	done := make(chan Receipt, 2)
+	for i := 0; i < 2; i++ {
+		go func() { done <- f.notify(payload("same"), caller()) }()
+	}
+	waitSignal(t, arrived)
+	waitSignal(t, arrived)
+	close(release)
+	a, b := <-done, <-done
+	if f.effects.Load() != 1 || a.TrackingID != b.TrackingID || a.Replayed == b.Replayed || !reflect.DeepEqual(a.Navigation, b.Navigation) {
+		t.Fatal(a, b, f.effects.Load())
+	}
+	// The loser can observe pending or terminal; it never waits for delivery.
+	if a.Status != "submitted" && b.Status != "submitted" {
+		t.Fatal(a, b)
+	}
+}
+func TestBusyNoQueueReplayWhileFullAndCloseDrain(t *testing.T) {
+	f := setup(t, journal.Limits{})
+	entered := make(chan struct{}, 2)
+	release := make(chan struct{})
+	var calls atomic.Int64
+	f.s.deps.Delivery = deliverFunc(func(_ context.Context, r notification.Request) notification.Receipt {
+		calls.Add(1)
+		entered <- struct{}{}
+		<-release
+		return notification.Receipt{Navigation: fakeNavigation(r), CorrelationID: r.CorrelationID, Status: "submitted", Reason: "os_accepted"}
+	})
+	done := make(chan Receipt, 2)
+	go func() { done <- f.notify(payload("one"), caller()) }()
+	waitSignal(t, entered)
+	go func() { done <- f.notify(payload("two"), caller()) }()
+	waitSignal(t, entered)
+	if r := f.notify(payload("three"), caller()); r.Reason != "busy" {
+		t.Fatal(r)
+	}
+	if r := f.notify(payload("one"), caller()); !r.Replayed || r.Status != "unknown" || r.RetrySafe {
+		t.Fatal(r)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if e := f.s.Close(ctx); !errors.Is(e, context.Canceled) {
+		t.Fatal(e)
+	}
+	if r := f.notify(payload("four"), caller()); r.Reason != "service_closed" {
+		t.Fatal(r)
+	}
+	close(release)
+	requireStatus(t, <-done, "submitted")
+	requireStatus(t, <-done, "submitted")
+	if e := f.s.Close(context.Background()); e != nil {
+		t.Fatal(e)
+	}
+	if e := f.s.Close(context.Background()); e != nil {
+		t.Fatal(e)
+	}
+	if calls.Load() != 2 {
+		t.Fatal("queued effect", calls.Load())
+	}
+}
+
+type admissionWrap struct {
+	AdmissionPort
+	beforeAdmit   func(context.Context)
+	afterAdmit    func()
+	finalizeError bool
+}
+
+func (w admissionWrap) Admit(c context.Context, a journal.Admission) (journal.Result, error) {
+	if w.beforeAdmit != nil {
+		w.beforeAdmit(c)
+	}
+	r, e := w.AdmissionPort.Admit(c, a)
+	if w.afterAdmit != nil {
+		w.afterAdmit()
+	}
+	return r, e
+}
+func (w admissionWrap) FinalizeOutcome(c context.Context, k journal.Key, a, s, r, b string, n *journal.Navigation) error {
+	if w.finalizeError {
+		return errors.New("injected finalize fault")
+	}
+	return w.AdmissionPort.FinalizeOutcome(c, k, a, s, r, b, n)
+}
+func TestReadinessLeaseReleasedBeforeAdmissionAndDeliveryOutsideJournal(t *testing.T) {
+	f := setup(t, journal.Limits{})
+	held := atomic.Bool{}
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	f.s.deps.Readiness = readyFunc(func(_ context.Context, r notification.Request) notification.Readiness {
+		held.Store(true)
+		close(entered)
+		<-release
+		held.Store(false)
+		return notification.Readiness{Navigation: fakeNavigation(r), CorrelationID: r.CorrelationID, Reason: "ready", Status: "ready"}
+	})
+	f.s.deps.Admission = admissionWrap{AdmissionPort: f.store, beforeAdmit: func(context.Context) {
+		if held.Load() {
+			t.Error("lease nested with journal admission")
+		}
+	}}
+	f.s.deps.Delivery = deliverFunc(func(c context.Context, r notification.Request) notification.Receipt {
+		// A reentrant actual journal Lookup would time out if delivery held its lock.
+		source, session := caller().Scope()
+		p, _ := validate(payload("R"), caller())
+		q, e := f.store.Lookup(c, journal.Key{Source: source, Session: session, Kind: journal.Explicit, Request: "R"}, digest(p))
+		if e != nil || !q.Found {
+			t.Error(q, e)
+		}
+		return notification.Receipt{Navigation: fakeNavigation(r), CorrelationID: r.CorrelationID, Status: "submitted", Reason: "os_accepted"}
+	})
+	done := make(chan Receipt, 1)
+	go func() { done <- f.notify(payload("R"), caller()) }()
+	waitSignal(t, entered)
+	entries, e := os.ReadDir(f.root)
+	if e != nil {
+		t.Fatal(e)
+	}
+	for _, entry := range entries {
+		b, e := os.ReadFile(filepath.Join(f.root, entry.Name()))
+		if e != nil {
+			t.Fatal(e)
+		}
+		if strings.Contains(string(b), "dispatching") {
+			t.Fatal("admitted while readiness lease held")
+		}
+	}
+	close(release)
+	requireStatus(t, <-done, "submitted")
+}
+
+func TestCancellationAndDeadlineBoundaries(t *testing.T) {
+	for _, point := range []string{"before", "policy", "readiness", "admit_wait", "after_admit", "delivery", "late_accepted", "expired", "boot", "missing", "too_long"} {
+		t.Run(point, func(t *testing.T) {
+			f := setup(t, journal.Limits{})
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			deadline := notification.Deadline{BootID: "boot", NotAfter: 115}
+			switch point {
+			case "before":
+				cancel()
+			case "policy":
+				f.s.deps.Policy = PolicyFunc(func(context.Context, origin.Context) (Policy, error) { cancel(); return f.policy, nil })
+			case "readiness":
+				f.s.deps.Readiness = readyFunc(func(_ context.Context, r notification.Request) notification.Readiness {
+					f.now.Store(116)
+					return notification.Readiness{Navigation: fakeNavigation(r), CorrelationID: r.CorrelationID, Reason: "ready", Status: "ready"}
+				})
+			case "admit_wait":
+				f.s.deps.Admission = admissionWrap{AdmissionPort: f.store, beforeAdmit: func(context.Context) { cancel() }}
+			case "after_admit":
+				f.s.deps.Admission = admissionWrap{AdmissionPort: f.store, afterAdmit: cancel}
+			case "delivery", "late_accepted":
+				f.s.deps.Delivery = deliverFunc(func(_ context.Context, r notification.Request) notification.Receipt {
+					f.effects.Add(1)
+					cancel()
+					status, reason := "unknown", "handoff_canceled"
+					if point == "late_accepted" {
+						status, reason = "submitted", "os_accepted"
+					}
+					return notification.Receipt{Navigation: fakeNavigation(r), CorrelationID: r.CorrelationID, Status: status, Reason: reason}
+				})
+			case "expired":
+				deadline.NotAfter = 99
+			case "boot":
+				deadline.BootID = "other"
+			case "missing":
+				deadline = notification.Deadline{}
+			case "too_long":
+				deadline.NotAfter = 116
+			}
+			r := f.s.Notify(ctx, payload("R"), caller(), deadline)
+			switch point {
+			case "late_accepted":
+				requireStatus(t, r, "submitted")
+			case "delivery", "after_admit":
+				requireStatus(t, r, "unknown")
+			default:
+				requireStatus(t, r, "rejected")
+			}
+			if point != "delivery" && point != "late_accepted" && f.effects.Load() != 0 {
+				t.Fatal(r)
+			}
+			if point == "after_admit" || point == "delivery" || point == "late_accepted" {
+				again := f.notify(payload("R"), caller())
+				if !again.Replayed || again.RetrySafe {
+					t.Fatal(again)
+				}
+			}
+		})
+	}
+}
+func TestTerminalAndFinalizeFailureNeverResend(t *testing.T) {
+	for _, status := range []string{"submitted", "unknown", "rejected", "suppressed", "bad_correlation", "finalize_failure"} {
+		t.Run(status, func(t *testing.T) {
+			f := setup(t, journal.Limits{})
+			f.s.deps.Delivery = deliverFunc(func(_ context.Context, r notification.Request) notification.Receipt {
+				if status != "suppressed" {
+					f.effects.Add(1)
+				}
+				id, s := r.CorrelationID, status
+				if status == "bad_correlation" {
+					id = "wrong"
+					s = "submitted"
+				}
+				if status == "finalize_failure" {
+					s = "submitted"
+				}
+				return notification.Receipt{Navigation: fakeNavigation(r), CorrelationID: id, Status: s, Reason: "test_result"}
+			})
+			if status == "finalize_failure" {
+				f.s.deps.Admission = admissionWrap{AdmissionPort: f.store, finalizeError: true}
+			}
+			a := f.notify(payload("R"), caller())
+			b := f.notify(payload("R"), caller())
+			wantEffects := int64(1)
+			if status == "suppressed" {
+				wantEffects = 0
+				requireStatus(t, a, "suppressed")
+				requireStatus(t, b, "suppressed")
+			}
+			if !b.Replayed || f.effects.Load() != wantEffects || b.TrackingID != a.TrackingID || a.RetrySafe || b.RetrySafe {
+				t.Fatal(a, b)
+			}
+			if status == "finalize_failure" {
+				if a.Reason != "finalization_failed" || b.Reason != "pending_submission" {
+					t.Fatal(a, b)
+				}
+			}
+			if status == "bad_correlation" || status == "finalize_failure" {
+				requireStatus(t, a, "unknown")
+			}
+		})
+	}
+}
+func TestPayloadAbsentFromStoreAndNativeUUID(t *testing.T) {
+	f := setup(t, journal.Limits{})
+	p := payload("R")
+	requireStatus(t, f.notify(p, caller()), "submitted")
+	entries, e := os.ReadDir(f.root)
+	if e != nil {
+		t.Fatal(e)
+	}
+	for _, entry := range entries {
+		b, e := os.ReadFile(filepath.Join(f.root, entry.Name()))
+		if e != nil {
+			t.Fatal(e)
+		}
+		for _, secret := range []string{p.Title, p.Body, "client_metadata", "call-1"} {
+			if strings.Contains(string(b), secret) {
+				t.Fatalf("stored forbidden field %q", secret)
+			}
+		}
+	}
+	id := f.requests[0].CorrelationID
+	if !regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-8[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`).MatchString(id) {
+		t.Fatal(id)
+	}
+	if correlationID("key", "attempt") != correlationID("key", "attempt") || correlationID("key", "attempt") == correlationID("key", "other") {
+		t.Fatal("correlation derivation")
+	}
+	if f.requests[0].Deadline.NotAfter != 115 || f.requests[0].Content.Title != p.Title || f.requests[0].Content.Body != p.Body {
+		t.Fatal(f.requests[0])
+	}
+}
+func TestFailClosedStoreAndRates(t *testing.T) {
+	t.Run("full", func(t *testing.T) {
+		f := setup(t, journal.Limits{Records: 1})
+		requireStatus(t, f.notify(payload("one"), caller()), "submitted")
+		f.advance()
+		r := f.notify(payload("two"), caller())
+		if r.Reason != "journal_full" || f.effects.Load() != 1 {
+			t.Fatal(r)
+		}
+	})
+	t.Run("rates", func(t *testing.T) {
+		f := setup(t, journal.Limits{})
+		for _, id := range []string{"1", "2", "3"} {
+			requireStatus(t, f.notify(payload(id), caller()), "submitted")
+		}
+		r := f.notify(payload("4"), caller())
+		if r.Reason != "rate_limited" || f.effects.Load() != 3 {
+			t.Fatal(r)
+		}
+		if r = f.notify(payload("1"), caller()); !r.Replayed {
+			t.Fatal(r)
+		}
+	})
+	for _, mode := range []string{"missing", "corrupt"} {
+		t.Run(mode, func(t *testing.T) {
+			f := setup(t, journal.Limits{})
+			entries, e := os.ReadDir(f.root)
+			if e != nil {
+				t.Fatal(e)
+			}
+			for _, entry := range entries {
+				if strings.HasSuffix(entry.Name(), ".json") {
+					p := filepath.Join(f.root, entry.Name())
+					var e error
+					if mode == "missing" {
+						e = os.Remove(p)
+					} else {
+						e = os.WriteFile(p, []byte("bad"), 0600)
+					}
+					if e != nil {
+						t.Fatal(e)
+					}
+				}
+			}
+			before, e := os.ReadDir(f.root)
+			if e != nil {
+				t.Fatal(e)
+			}
+			r := f.notify(payload("R"), caller())
+			requireStatus(t, r, "rejected")
+			after, e := os.ReadDir(f.root)
+			if e != nil {
+				t.Fatal(e)
+			}
+			if len(before) != len(after) || f.effects.Load() != 0 {
+				t.Fatal(r)
+			}
+			if f.loads.Load() != 0 {
+				t.Fatal("policy loaded before failing journal")
+			}
+		})
+	}
+}
+func TestInvalidDependencies(t *testing.T) {
+	f := setup(t, journal.Limits{})
+	d := f.s.deps
+	if _, e := New(Dependencies{}); e != ErrDependencies {
+		t.Fatal(e)
+	}
+	var store *journal.Store
+	d.Admission = store
+	if _, e := New(d); e != ErrDependencies {
+		t.Fatal(e)
+	}
+	d = f.s.deps
+	d.Policy = PolicyFunc(nil)
+	if _, e := New(d); e != ErrDependencies {
+		t.Fatal(e)
+	}
+	var s *Service
+	if r := s.Notify(context.Background(), payload("R"), caller(), notification.Deadline{}); r.Reason != "invalid_dependencies" {
+		t.Fatal(r)
+	}
+	s = &Service{}
+	if r := s.Notify(context.Background(), payload("R"), caller(), notification.Deadline{}); r.Reason != "invalid_dependencies" {
+		t.Fatal(r)
+	}
+	if r := f.s.Notify(nil, payload("R"), caller(), notification.Deadline{}); r.Reason != "invalid_context" {
+		t.Fatal(r)
+	}
+}
+
+func TestInvalidDisabledAndUnavailableHaveNoEffects(t *testing.T) {
+	for _, mode := range []string{"invalid", "disabled", "desktop_disabled", "config_invalid", "remote", "headless", "hidden", "unknown_denied", "asserted_denied", "click_disabled", "target_invalid", "readiness_invalid"} {
+		t.Run(mode, func(t *testing.T) {
+			f := setup(t, journal.Limits{})
+			p, o := payload("R"), caller()
+			switch mode {
+			case "invalid":
+				p.Title = "\x00"
+			case "disabled":
+				f.policy.Delivery.ExplicitEnabled = false
+			case "desktop_disabled":
+				f.policy.Delivery.DesktopEnabled = false
+			case "config_invalid":
+				f.policy.Delivery.Valid = false
+			case "remote":
+				o.Locality = origin.Remote
+			case "headless":
+				o.Interface = origin.Headless
+			case "hidden":
+				o.Hidden = true
+			case "unknown_denied":
+				f.policy.Route.AllowUnknownCaller = false
+			case "asserted_denied":
+				o.Provenance = origin.CallerAsserted
+				f.policy.Route.AllowCallerAsserted = false
+			case "click_disabled":
+				f.policy.Delivery.ClickToFocus = false
+			case "target_invalid":
+				f.s.deps.Target = TargetFunc(func(context.Context, origin.Context, origin.RoutePolicy) (origin.Target, error) {
+					return origin.Target{Navigation: notification.NavigationResult{Capability: "available", Precision: "chat_id"}}, nil
+				})
+			case "readiness_invalid":
+				f.s.deps.Readiness = readyFunc(func(_ context.Context, r notification.Request) notification.Readiness {
+					return notification.Readiness{Navigation: fakeNavigation(r), CorrelationID: r.CorrelationID, Reason: "ready", Status: "unknown"}
+				})
+			}
+			r := f.notify(p, o)
+			if r.Status == "submitted" || r.Status == "unknown" || f.effects.Load() != 0 {
+				t.Fatal(r)
+			}
+			// No denied request consumes the key; the same key can be admitted after repair.
+			f.policy = setupPolicy()
+			f.s.deps.Target = TargetFunc(func(_ context.Context, o origin.Context, p origin.RoutePolicy) (origin.Target, error) {
+				return origin.ResolveCodex(o, p), nil
+			})
+			f.s.deps.Readiness = readyFunc(func(_ context.Context, r notification.Request) notification.Readiness {
+				return notification.Readiness{Navigation: fakeNavigation(r), CorrelationID: r.CorrelationID, Reason: "ready", Status: "ready"}
+			})
+			requireStatus(t, f.notify(payload("R"), caller()), "submitted")
+		})
+	}
+}
+func setupPolicy() Policy {
+	return Policy{Delivery: notification.PolicySnapshot{Valid: true, ExplicitEnabled: true, DesktopEnabled: true, ClickToFocus: true, SoundEnabled: true}, Route: origin.RoutePolicy{LocalRouting: true, AllowUnknownCaller: true, AllowCallerAsserted: true, ApplicationPath: "/test/A.app", TeamID: "team-A"}}
+}
+
+func testContext(t *testing.T) context.Context {
+	t.Helper()
+	c, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+	return c
+}
+
+func TestActualJournalLockConsumesOriginalDeadline(t *testing.T) {
+	for _, phase := range []string{"lookup", "admit"} {
+		t.Run(phase, func(t *testing.T) {
+			f := setup(t, journal.Limits{})
+			fd, e := unix.Open(filepath.Join(f.root, "lock"), unix.O_RDWR, 0)
+			if e != nil {
+				t.Fatal(e)
+			}
+			defer func() {
+				if e := unix.Close(fd); e != nil {
+					t.Error(e)
+				}
+			}()
+			lock := func() {
+				if e := unix.Flock(fd, unix.LOCK_EX|unix.LOCK_NB); e != nil {
+					t.Fatal(e)
+				}
+			}
+			if phase == "lookup" {
+				lock()
+			} else {
+				f.s.deps.Readiness = readyFunc(func(_ context.Context, r notification.Request) notification.Readiness {
+					lock()
+					return notification.Readiness{Navigation: fakeNavigation(r), CorrelationID: r.CorrelationID, Reason: "ready", Status: "ready"}
+				})
+			}
+			start := time.Now()
+			r := f.s.Notify(context.Background(), payload("R"), caller(), notification.Deadline{BootID: "boot", NotAfter: 100.04})
+			if e := unix.Flock(fd, unix.LOCK_UN); e != nil {
+				t.Fatal(e)
+			}
+			if r.Reason != "deadline_exceeded" || f.effects.Load() != 0 || time.Since(start) > time.Second {
+				t.Fatal(r, time.Since(start))
+			}
+			f.s.deps.Readiness = readyFunc(func(_ context.Context, r notification.Request) notification.Readiness {
+				return notification.Readiness{Navigation: fakeNavigation(r), CorrelationID: r.CorrelationID, Reason: "ready", Status: "ready"}
+			})
+			requireStatus(t, f.notify(payload("R"), caller()), "submitted")
+		})
+	}
+}
+func TestBestEffortNoneAndSilent(t *testing.T) {
+	for _, mode := range []string{"hidden_best_effort", "click_disabled_best_effort", "none", "unknown_none_denied"} {
+		t.Run(mode, func(t *testing.T) {
+			f := setup(t, journal.Limits{})
+			p, o := payload("R"), caller()
+			p.Navigation = notification.BestEffort
+			f.policy.Delivery.SoundEnabled = false
+			switch mode {
+			case "hidden_best_effort":
+				o.Hidden = true
+			case "click_disabled_best_effort":
+				f.policy.Delivery.ClickToFocus = false
+			case "none":
+				p.Navigation = notification.None
+			case "unknown_none_denied":
+				p.Navigation = notification.None
+				f.policy.Route.AllowUnknownCaller = false
+			}
+			r := f.notify(p, o)
+			if mode == "unknown_none_denied" {
+				requireStatus(t, r, "rejected")
+				if f.effects.Load() != 0 {
+					t.Fatal(r)
+				}
+				return
+			}
+			requireStatus(t, r, "submitted")
+			if f.requests[0].Target != (notification.DesktopTarget{}) || !f.requests[0].Silent || r.Navigation.Precision != "none" {
+				t.Fatal(r, f.requests[0])
+			}
+		})
+	}
+}
+func TestDefaultNavigationCanonicalReplayAndExactUnicodeConflict(t *testing.T) {
+	f := setup(t, journal.Limits{})
+	p := payload("R")
+	p.Title = "é"
+	a := f.notify(p, caller())
+	requireStatus(t, a, "submitted")
+	p.Navigation = notification.Required
+	if b := f.notify(p, caller()); !b.Replayed || b.TrackingID != a.TrackingID {
+		t.Fatal(b)
+	}
+	p.Title = "e\u0301"
+	if b := f.notify(p, caller()); b.Reason != "idempotency_conflict" {
+		t.Fatal(b)
+	}
+}
+func TestConstructorHasNoEffectsAndEachNilPortFails(t *testing.T) {
+	f := setup(t, journal.Limits{})
+	before, e := os.ReadFile(filepath.Join(f.root, "journal.json"))
+	if e != nil {
+		t.Fatal(e)
+	}
+	if _, e := New(f.s.deps); e != nil {
+		t.Fatal(e)
+	}
+	after, e := os.ReadFile(filepath.Join(f.root, "journal.json"))
+	if e != nil {
+		t.Fatal(e)
+	}
+	if string(before) != string(after) || f.loads.Load() != 0 || f.effects.Load() != 0 {
+		t.Fatal("constructor effects")
+	}
+	for i := 0; i < 6; i++ {
+		d := f.s.deps
+		switch i {
+		case 0:
+			d.Admission = nil
+		case 1:
+			d.Policy = nil
+		case 2:
+			d.Target = nil
+		case 3:
+			d.Readiness = readyFunc(nil)
+		case 4:
+			d.Delivery = deliverFunc(nil)
+		case 5:
+			d.Clock = ClockFunc(nil)
+		}
+		if _, e := New(d); e != ErrDependencies {
+			t.Fatal(i, e)
+		}
+	}
+	var zero Service
+	if e := zero.Close(context.Background()); e != ErrDependencies {
+		t.Fatal(e)
+	}
+}
+
+func TestClientCallKeyKindsAndSourceIsolation(t *testing.T) {
+	f := setup(t, journal.Limits{})
+	p, o := payload("call-1"), caller()
+	p.RequestID = nil
+	first := f.notify(p, o)
+	requireStatus(t, first, "submitted")
+	for _, change := range []func(*Payload, *origin.Context){
+		func(p *Payload, o *origin.Context) { id := o.CallID; p.RequestID = &id },
+		func(_ *Payload, o *origin.Context) { o.SessionID = "session-B" },
+		func(_ *Payload, o *origin.Context) { o.Namespace = "other-source" },
+	} {
+		f.advance()
+		q, c := p, o
+		change(&q, &c)
+		r := f.notify(q, c)
+		requireStatus(t, r, "submitted")
+		if r.Replayed || r.TrackingID == first.TrackingID {
+			t.Fatal(r)
+		}
+	}
+	p.Body += "changed"
+	if r := f.notify(p, o); r.Reason != "idempotency_conflict" || f.effects.Load() != 4 {
+		t.Fatal(r)
+	}
+}
+
+func TestUnqualifiedServiceClockFailsBeforePorts(t *testing.T) {
+	f := setup(t, journal.Limits{})
+	f.s.deps.Clock = ClockFunc(func() notification.Deadline { return notification.Deadline{} })
+	r := f.notify(payload("R"), caller())
+	if r.Reason != "invalid_deadline" || f.loads.Load() != 0 || f.effects.Load() != 0 {
+		t.Fatal(r)
+	}
+}
+
+func fakeNavigation(r notification.Request) notification.NavigationResult {
+	if r.Target.ThreadID != "" {
+		return notification.NavigationResult{Capability: "available", Precision: "chat_id", Scope: "local_current_profile"}
+	}
+	return notification.NavigationResult{Capability: "disabled", Precision: "none", Reason: "no_action"}
+}

--- a/internal/agentnotify/service_test.go
+++ b/internal/agentnotify/service_test.go
@@ -491,7 +491,8 @@ func TestPayloadAbsentFromStoreAndNativeUUID(t *testing.T) {
 	if !regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-8[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`).MatchString(id) {
 		t.Fatal(id)
 	}
-	if correlationID("key", "attempt") != correlationID("key", "attempt") || correlationID("key", "attempt") == correlationID("key", "other") {
+	first := correlationID("key", "attempt")
+	if first != correlationID("key", "attempt") || first == correlationID("key", "other") {
 		t.Fatal("correlation derivation")
 	}
 	if f.requests[0].Deadline.NotAfter != 115 || f.requests[0].Content.Title != p.Title || f.requests[0].Content.Body != p.Body {
@@ -585,7 +586,7 @@ func TestInvalidDependencies(t *testing.T) {
 	if r := s.Notify(context.Background(), payload("R"), caller(), notification.Deadline{}); r.Reason != "invalid_dependencies" {
 		t.Fatal(r)
 	}
-	if r := f.s.Notify(nil, payload("R"), caller(), notification.Deadline{}); r.Reason != "invalid_context" {
+	if r := f.s.Notify(nil, payload("R"), caller(), notification.Deadline{}); r.Reason != "invalid_context" { //nolint:staticcheck // Deliberately verify nil-context rejection.
 		t.Fatal(r)
 	}
 }

--- a/internal/agentnotify/types.go
+++ b/internal/agentnotify/types.go
@@ -1,0 +1,108 @@
+// Package agentnotify orchestrates explicit notifications over injected ports.
+// Composition owns opening the journal and delivery resources; constructors and
+// replay never initialize, repair, collect, load configuration or probe the OS.
+package agentnotify
+
+import (
+	"context"
+	"errors"
+	"reflect"
+
+	"github.com/777genius/agent-notifications/internal/agentnotify/journal"
+	"github.com/777genius/agent-notifications/internal/agentnotify/origin"
+	"github.com/777genius/agent-notifications/internal/notification"
+)
+
+type Payload struct {
+	Title      string                  `json:"title"`
+	Body       string                  `json:"body"`
+	Category   string                  `json:"category"`
+	RequestID  *string                 `json:"request_id"`
+	Navigation notification.Navigation `json:"navigation"`
+}
+
+type Receipt struct {
+	RequestID  *string                       `json:"request_id"`
+	TrackingID string                        `json:"tracking_id"`
+	KeyKind    journal.KeyKind               `json:"key_kind"`
+	Status     string                        `json:"status"`
+	Reason     string                        `json:"reason"`
+	Replayed   bool                          `json:"replayed"`
+	Backend    string                        `json:"backend"`
+	Navigation notification.NavigationResult `json:"navigation"`
+	RetrySafe  bool                          `json:"retry_safe"`
+}
+
+// AdmissionPort is configured by composition. Rates/capacity are atomic journal
+// responsibilities, never a second service limiter. Each admission carries the
+// validated authoritative policy snapshot for that request. FinalizeOutcome is
+// required so adapters cannot silently discard terminal navigation; Store.Finalize
+// remains available to legacy journal callers.
+type AdmissionPort interface {
+	Lookup(context.Context, journal.Key, journal.Digest) (journal.Result, error)
+	Admit(context.Context, journal.Admission) (journal.Result, error)
+	FinalizeOutcome(context.Context, journal.Key, string, string, string, string, *journal.Navigation) error
+}
+
+// Policy is an immutable per-call value. The fixed delivery DTO has no policy
+// generation field: composition must integrate authoritative generation fencing
+// in Delivery before activation; readiness alone cannot fence disable/uninstall.
+type Policy struct {
+	Rates    journal.RatePolicy
+	Delivery notification.PolicySnapshot
+	Route    origin.RoutePolicy
+}
+type PolicyPort interface {
+	Load(context.Context, origin.Context) (Policy, error)
+}
+type PolicyFunc func(context.Context, origin.Context) (Policy, error)
+
+func (f PolicyFunc) Load(c context.Context, o origin.Context) (Policy, error) { return f(c, o) }
+
+type TargetPort interface {
+	Resolve(context.Context, origin.Context, origin.RoutePolicy) (origin.Target, error)
+}
+type TargetFunc func(context.Context, origin.Context, origin.RoutePolicy) (origin.Target, error)
+
+func (f TargetFunc) Resolve(c context.Context, o origin.Context, p origin.RoutePolicy) (origin.Target, error) {
+	return f(c, o, p)
+}
+
+// Clock supplies qualified boot-continuous seconds (including suspend).
+// Unavailable/changed epochs fail closed. Implementations must return promptly.
+type Clock interface{ Now() notification.Deadline }
+type ClockFunc func() notification.Deadline
+
+func (f ClockFunc) Now() notification.Deadline { return f() }
+
+type Dependencies struct {
+	Admission AdmissionPort
+	Policy    PolicyPort
+	Target    TargetPort
+	Readiness notification.ReadinessPort
+	Delivery  notification.DeliveryPort
+	Clock     Clock
+}
+
+var ErrDependencies = errors.New("invalid_dependencies")
+
+func nilPort(x any) bool {
+	if x == nil {
+		return true
+	}
+	v := reflect.ValueOf(x)
+	switch v.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return v.IsNil()
+	}
+	return false
+}
+
+func validDependencies(d Dependencies) bool {
+	for _, p := range []any{d.Admission, d.Policy, d.Target, d.Readiness, d.Delivery, d.Clock} {
+		if nilPort(p) {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/agentnotify/validation.go
+++ b/internal/agentnotify/validation.go
@@ -44,7 +44,7 @@ func content(s string, max int, body bool) bool {
 		return false
 	}
 	for _, r := range s {
-		if unicode.Is(unicode.Cc, r) && !(body && (r == '\n' || r == '\t')) {
+		if unicode.Is(unicode.Cc, r) && (!body || (r != '\n' && r != '\t')) {
 			return false
 		}
 		if !body && (r == '\u2028' || r == '\u2029') {

--- a/internal/agentnotify/validation.go
+++ b/internal/agentnotify/validation.go
@@ -1,0 +1,65 @@
+package agentnotify
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/777genius/agent-notifications/internal/agentnotify/journal"
+	"github.com/777genius/agent-notifications/internal/agentnotify/origin"
+	"github.com/777genius/agent-notifications/internal/notification"
+)
+
+func validate(p Payload, o origin.Context) (Payload, string) {
+	if p.Navigation == "" {
+		p.Navigation = notification.Required
+	}
+	if p.Navigation != notification.Required && p.Navigation != notification.BestEffort && p.Navigation != notification.None {
+		return p, "invalid_navigation"
+	}
+	if p.Category != "info" && p.Category != "attention" && p.Category != "progress" {
+		return p, "invalid_category"
+	}
+	if !content(p.Title, 256, false) || !content(p.Body, 4096, true) {
+		return p, "invalid_content"
+	}
+	if p.RequestID != nil && !origin.Text(*p.RequestID, 256, true) {
+		return p, "invalid_request_id"
+	}
+	if e := o.Validate(p.Navigation); e != nil {
+		return p, e.Error()
+	}
+	total := len(p.Title) + len(p.Body) + len(p.Category) + len(p.Navigation) + len(o.Provider) + len(o.Namespace) + len(o.SessionID) + len(o.AnonymousCaller) + len(o.CallID) + len(o.Provenance) + len(o.Locality) + len(o.Interface)
+	if p.RequestID != nil {
+		total += len(*p.RequestID)
+	}
+	if total > 16<<10 {
+		return p, "request_too_large"
+	}
+	return p, ""
+}
+func content(s string, max int, body bool) bool {
+	if len(s) > max || !utf8.ValidString(s) || (!body && s == "") {
+		return false
+	}
+	for _, r := range s {
+		if unicode.Is(unicode.Cc, r) && !(body && (r == '\n' || r == '\t')) {
+			return false
+		}
+		if !body && (r == '\u2028' || r == '\u2029') {
+			return false
+		}
+	}
+	return true
+}
+func digest(p Payload) journal.Digest {
+	// Canonical typed representation: JSON escaping preserves exact scalar bytes;
+	// transport duplicate-key and unpaired-surrogate checks precede this boundary.
+	b, _ := json.Marshal(struct {
+		Version               int
+		Title, Body, Category string
+		Navigation            notification.Navigation
+	}{1, p.Title, p.Body, p.Category, p.Navigation})
+	return sha256.Sum256(b)
+}

--- a/internal/agentnotify/validation_test.go
+++ b/internal/agentnotify/validation_test.go
@@ -17,7 +17,7 @@ func TestUnicodeAndLimits(t *testing.T) {
 		ok                bool
 	}{
 		{"literal", "--help -execute [important] $(echo) \"", "body", true},
-		{"formats", "👩‍💻 می‌خواهم", "\U000e0067\U000e007f", true},
+		{"formats", "👩\u200d💻 می\u200cخواهم", "\U000e0067\U000e007f", true},
 		{"title_boundary", strings.Repeat("é", 128), "", true},
 		{"title_over", strings.Repeat("é", 128) + "a", "", false},
 		{"body_boundary", "title", strings.Repeat("é", 2048), true},

--- a/internal/agentnotify/validation_test.go
+++ b/internal/agentnotify/validation_test.go
@@ -1,0 +1,97 @@
+package agentnotify
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/777genius/agent-notifications/internal/agentnotify/origin"
+	"github.com/777genius/agent-notifications/internal/notification"
+)
+
+func validationCaller() origin.Context {
+	return origin.Context{Provider: "codex", Namespace: "local", SessionID: "A", Provenance: origin.ClientMetadata, Locality: origin.Local, Interface: origin.InterfaceUnknown}
+}
+func TestUnicodeAndLimits(t *testing.T) {
+	for _, tt := range []struct {
+		name, title, body string
+		ok                bool
+	}{
+		{"literal", "--help -execute [important] $(echo) \"", "body", true},
+		{"formats", "👩‍💻 می‌خواهم", "\U000e0067\U000e007f", true},
+		{"title_boundary", strings.Repeat("é", 128), "", true},
+		{"title_over", strings.Repeat("é", 128) + "a", "", false},
+		{"body_boundary", "title", strings.Repeat("é", 2048), true},
+		{"body_over", "title", strings.Repeat("é", 2048) + "a", false},
+		{"body_lines", "title", "\tline\nnext\u2028", true},
+		{"title_lf", "line\nnext", "", false},
+		{"title_tab", "line\tnext", "", false},
+		{"title_separator", "line\u2028next", "", false},
+		{"title_paragraph", "line\u2029next", "", false},
+		{"body_cr", "title", "\r", false},
+		{"nul", "title", "\x00", false},
+		{"c1", "title", "\u0085", false},
+		{"utf8", "title", string([]byte{0xff}), false},
+		{"empty_title", "", "body", false},
+		{"spaces", "  ", "  ", true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			p := Payload{Title: tt.title, Body: tt.body, Category: "info"}
+			v, reason := validate(p, validationCaller())
+			if (reason == "") != tt.ok {
+				t.Fatal(reason)
+			}
+			if tt.ok && (v.Title != p.Title || v.Body != p.Body || v.Navigation != notification.Required) {
+				t.Fatal("changed literal input")
+			}
+		})
+	}
+	for r := rune(0); r <= 0x9f; r++ {
+		if r > 0x1f && r < 0x7f {
+			continue
+		}
+		if content("a"+string(r), 256, false) {
+			t.Fatalf("title Cc U+%04X", r)
+		}
+		if content(string(r), 4096, true) != (r == '\n' || r == '\t') {
+			t.Fatalf("body Cc U+%04X", r)
+		}
+	}
+	a := Payload{Title: "é", Category: "info", Navigation: notification.Required}
+	b := a
+	b.Title = "e\u0301"
+	if digest(a) == digest(b) {
+		t.Fatal("normalized Unicode")
+	}
+	a.Title = " x "
+	b.Title = "x"
+	if digest(a) == digest(b) {
+		t.Fatal("trimmed Unicode")
+	}
+}
+func TestEnumsAndIDs(t *testing.T) {
+	base := Payload{Title: "x", Category: "info"}
+	o := validationCaller()
+	for _, modify := range []func(*Payload, *origin.Context){
+		func(p *Payload, _ *origin.Context) { p.Category = "urgent" },
+		func(p *Payload, _ *origin.Context) { p.Navigation = "shell" },
+		func(p *Payload, _ *origin.Context) { id := ""; p.RequestID = &id },
+		func(p *Payload, _ *origin.Context) { id := strings.Repeat("a", 257); p.RequestID = &id },
+		func(_ *Payload, o *origin.Context) { o.SessionID = strings.Repeat("a", 257) },
+		func(_ *Payload, o *origin.Context) { o.CallID = "\u0080" },
+		func(_ *Payload, o *origin.Context) { o.Provenance = "claimed_by_payload" },
+		func(_ *Payload, o *origin.Context) { o.SessionID = "" },
+	} {
+		p, c := base, o
+		modify(&p, &c)
+		if _, reason := validate(p, c); reason == "" {
+			t.Fatal("accepted invalid input")
+		}
+	}
+	id := strings.Repeat("é", 128)
+	base.RequestID = &id
+	o.SessionID = id
+	o.CallID = id
+	if _, reason := validate(base, o); reason != "" {
+		t.Fatal(reason)
+	}
+}

--- a/internal/notification/delivery.go
+++ b/internal/notification/delivery.go
@@ -1,0 +1,76 @@
+// Package notification defines the agent-independent delivery boundary.
+// Validation/policy loading, origin mapping and durable admission belong to callers.
+package notification
+
+import "context"
+
+type Content struct {
+	Title    string
+	Body     string
+	Subtitle string
+	Category string // info, attention, progress; never an analyzer status
+}
+
+type Navigation string
+
+const (
+	Required   Navigation = "required"
+	BestEffort Navigation = "best_effort"
+	None       Navigation = "none"
+)
+
+// DesktopTarget is supplied by a trusted integration and setup adapter, never
+// decoded from model arguments. App identity is operator-pinned, not inferred
+// from cwd, metadata text, or whichever app happens to be foreground.
+type DesktopTarget struct {
+	ThreadID        string
+	ApplicationPath string
+	TeamID          string
+}
+
+// Deadline is captured at transport admission, before validation or locks.
+// Seconds are boot-continuous seconds including suspend, not Unix wall time.
+type Deadline struct {
+	BootID   string
+	NotAfter float64
+}
+
+// PolicySnapshot is a value copy of the initial strict policy decision. The
+// delivery adapter never reloads legacy defaults or mutates caller policy.
+type PolicySnapshot struct {
+	Valid           bool
+	ExplicitEnabled bool
+	DesktopEnabled  bool
+	ClickToFocus    bool
+	SoundEnabled    bool
+}
+
+type Request struct {
+	Content       Content
+	CorrelationID string // UUID assigned by the durable admission owner
+	Deadline      Deadline
+	Policy        PolicySnapshot
+	Navigation    Navigation // empty defaults to Required
+	Target        DesktopTarget
+	Silent        bool
+}
+
+type NavigationResult struct {
+	Capability string // available, unavailable, disabled
+	Precision  string // chat_id or none
+	Scope      string
+	Reason     string
+}
+
+type Receipt struct {
+	CorrelationID string
+	Status        string // rejected, suppressed, submitted, unknown
+	Reason        string
+	RetrySafe     bool // always false here: delivery does not own replay admission
+	Backend       string
+	Navigation    NavigationResult
+}
+
+type DeliveryPort interface {
+	Deliver(context.Context, Request) Receipt
+}

--- a/internal/notification/readiness.go
+++ b/internal/notification/readiness.go
@@ -1,0 +1,17 @@
+package notification
+
+import "context"
+
+// Readiness is a read-only snapshot, with no retry/admission/OS acceptance claim.
+// Only Status == "ready" permits a new journal admission. The caller captures
+// Deadline before this call and reuses it for Deliver, without resetting it.
+type Readiness struct {
+	CorrelationID string
+	Status        string // ready, rejected, suppressed
+	Reason        string
+	Backend       string
+	Navigation    NavigationResult
+}
+type ReadinessPort interface {
+	CheckReadiness(context.Context, Request) Readiness
+}


### PR DESCRIPTION
Adds the explicit notification service behind injected policy, origin, readiness and delivery ports. A request is durably admitted before delivery; replays preserve the original target and the actual terminal navigation/suppression outcome without resending. Configurable limits use the shared journal transaction.

Stacked on #158. This is the service checkpoint; CLI/MCP activation and installed Desktop qualification remain later steps.

Validation: exact-source independent follow-up review found no actionable issues; focused Linux unit/race/vet passed as a non-root user; Mac service/journal/origin suites passed. The combined real SDK -> service -> journal fixture also passes with mocked OS delivery. No installed notification or release claim.

The coherent patch is 2,187 changed lines, slightly above the review target; most additions are regression tests for the single admission/outcome invariant. Splitting terminal persistence from service validation would leave an inconsistent intermediate contract. Old writers must be fenced before activation; journal history is never reset.
