### PR TITLE
build: raise minimum Go version to 1.25

### DIFF
--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -10,12 +10,14 @@ jobs:
     name: Test on macOS (${{ matrix.go }})
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
+    env:
+      GOTOOLCHAIN: local
 
     strategy:
       fail-fast: false
       matrix:
         include:
-          - go: '1.22'
+          - go: '1.25'
             os: macos-15
           - go: '1.26'
             os: macos-26

--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -10,11 +10,13 @@ jobs:
     name: Test on Ubuntu
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    env:
+      GOTOOLCHAIN: local
 
     strategy:
       fail-fast: false
       matrix:
-        go: ['1.22', '1.26']
+        go: ['1.25', '1.26']
 
     steps:
       - name: Checkout code

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -10,11 +10,13 @@ jobs:
     name: Test on Windows
     runs-on: windows-latest
     timeout-minutes: 30
+    env:
+      GOTOOLCHAIN: local
 
     strategy:
       fail-fast: false
       matrix:
-        go: ['1.22', '1.26']
+        go: ['1.25', '1.26']
 
     steps:
       - name: Checkout code

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thank you for your interest in contributing to Agent Notifications!
 
 ## Prerequisites
 
-- **Go 1.21+** (tested with 1.25)
+- **Go 1.25.0+** (CI covers the minimum Go 1.25 and Go 1.26; automatic toolchain switching is disabled)
 - **Make** (for build commands)
 - **Claude Code** (tested on v2.0.15)
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/777genius/agent-notifications
 
-go 1.22
+go 1.25.0
 
 require (
 	git.sr.ht/~jackmordaunt/go-toast v1.1.2


### PR DESCRIPTION
Raises the declared build minimum to Go 1.25.0 for the upcoming managed-filesystem and MCP SDK integrations. Updates the three OS minimum CI lanes and contributor documentation; GOTOOLCHAIN=local prevents those jobs silently switching to a newer toolchain. The Go 1.26 lanes remain.

Stacked on #153. This prerequisite belongs before the runtime installer PR because it uses Go 1.25 filesystem APIs. No runtime behavior or dependency versions change here; SDK integration remains separate.

Validation: diff/manifest review passed. Direct qualification downloads for Go 1.25.14 and the exact 1.25.0 minimum returned HTTP 404 from the official archive endpoint in the hosted environment. No successful local minimum-toolchain run is claimed; this draft's minimum CI lanes must pass before readiness. Existing Go 1.26 results do not replace that requirement.
