### PR TITLE
fix(landing): add searchable locale menu and SEO files

### DIFF
--- a/landing/assets/main.css
+++ b/landing/assets/main.css
@@ -127,32 +127,140 @@ h3 {
 }
 .language-switcher {
   position: relative;
+}
+.language-switcher__trigger {
+  min-height: 36px;
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: 7px;
   border: 1px solid #29404a;
-  border-radius: 5px;
-  padding: 0 8px;
+  border-radius: 6px;
+  padding: 0 10px;
   color: #8febf5;
   background: #0c0e16;
+  font: 500 11px/1 ui-monospace, monospace;
+  cursor: pointer;
+  transition: border-color 160ms ease, background 160ms ease, box-shadow 160ms ease;
 }
-.language-switcher__icon {
-  font-size: 12px;
-  line-height: 1;
+.language-switcher__trigger:hover,
+.language-switcher__trigger[aria-expanded="true"] {
+  border-color: #58d9e8;
+  background: #111825;
+  box-shadow: 0 0 18px rgb(94 222 234 / 12%);
 }
-.language-switcher select {
-  min-height: 34px;
-  max-width: 108px;
+.language-switcher__trigger:focus-visible,
+.language-switcher__search:focus-within,
+.language-switcher__options button:focus-visible {
+  outline: 2px solid var(--cyan);
+  outline-offset: 2px;
+}
+.language-switcher__glyph {
+  font-size: 13px;
+}
+.language-switcher__chevron {
+  width: 10px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.5;
+  transition: transform 160ms ease;
+}
+[aria-expanded="true"] .language-switcher__chevron {
+  transform: rotate(180deg);
+}
+.language-switcher__popover {
+  position: absolute;
+  z-index: 50;
+  top: calc(100% + 9px);
+  right: 0;
+  width: 238px;
+  padding: 8px;
+  border: 1px solid #29404a;
+  border-radius: 9px;
+  background: rgb(9 13 22 / 98%);
+  box-shadow: 0 18px 48px rgb(0 0 0 / 55%), 0 0 30px rgb(94 222 234 / 8%);
+  backdrop-filter: blur(16px);
+}
+.language-switcher__search {
+  height: 36px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0 10px;
+  border: 1px solid #263b48;
+  border-radius: 6px;
+  background: #0d1420;
+}
+.language-switcher__search svg {
+  width: 15px;
+  fill: none;
+  stroke: #7d94a4;
+  stroke-width: 1.5;
+}
+.language-switcher__search input {
+  min-width: 0;
+  width: 100%;
   border: 0;
   outline: 0;
+  color: #e8f7f8;
   background: transparent;
-  color: inherit;
-  font-size: 11px;
+  font: 11px/1 ui-monospace, monospace;
+}
+.language-switcher__search input::placeholder {
+  color: #6e8493;
+}
+.language-switcher__search input::-webkit-search-cancel-button {
+  filter: invert(1);
+  opacity: 0.45;
+}
+.language-switcher__options {
+  display: grid;
+  gap: 3px;
+  margin-top: 7px;
+}
+.language-switcher__options button {
+  width: 100%;
+  min-height: 38px;
+  display: grid;
+  grid-template-columns: 30px 1fr 16px;
+  align-items: center;
+  gap: 9px;
+  border: 0;
+  border-radius: 5px;
+  padding: 5px 9px;
+  color: #c6d9df;
+  background: transparent;
+  text-align: left;
+  font: 12px/1.2 ui-monospace, monospace;
   cursor: pointer;
 }
-.language-switcher:focus-within {
-  outline: 2px solid var(--cyan);
-  outline-offset: 3px;
+.language-switcher__options button:hover,
+.language-switcher__options button.active {
+  color: #a9f5fc;
+  background: rgb(94 222 234 / 10%);
+}
+.language-switcher__options button > svg {
+  width: 14px;
+  fill: none;
+  stroke: #5edeea;
+  stroke-width: 2;
+}
+.language-switcher__code {
+  display: grid;
+  place-items: center;
+  width: 28px;
+  height: 23px;
+  border: 1px solid #31505b;
+  border-radius: 4px;
+  color: #69dce8;
+  background: #101b27;
+  font-size: 8px;
+  letter-spacing: 0.7px;
+}
+.language-switcher__empty {
+  padding: 13px 9px 8px;
+  color: #758995;
+  font: 10px/1.4 ui-monospace, monospace;
+  text-align: center;
 }
 .visually-hidden {
   position: absolute !important;
@@ -747,9 +855,18 @@ footer .brand {
   .github {
     display: none;
   }
-  .language-switcher select {
-    max-width: 88px;
+  .language-switcher__trigger {
+    max-width: 112px;
+    padding: 0 8px;
     font-size: 10px;
+  }
+  .language-switcher__trigger > span:nth-child(2) {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .language-switcher__popover {
+    width: min(238px, calc(100vw - 32px));
   }
   .brand-icon {
     font-size: 25px;

--- a/landing/components/LanguageSwitcher.vue
+++ b/landing/components/LanguageSwitcher.vue
@@ -1,19 +1,45 @@
 <script setup lang="ts">
-import { isLocaleCode, supportedLocales } from "~/data/i18n";
+import { isLocaleCode, supportedLocales, type LocaleCode } from "~/data/i18n";
 
 const { locale, setLocale, t, te } = useI18n();
+const root = ref<HTMLElement>();
+const searchInput = ref<HTMLInputElement>();
+const open = ref(false);
+const query = ref("");
 const pending = ref(false);
 const error = ref(false);
 
-const currentName = computed(
+const currentLocale = computed(
   () =>
-    supportedLocales.find((item) => item.code === locale.value)?.name ??
-    supportedLocales[0].name,
+    supportedLocales.find((item) => item.code === locale.value) ??
+    supportedLocales[0],
 );
+const filteredLocales = computed(() => {
+  const needle = query.value.trim().toLocaleLowerCase();
+  if (!needle) return supportedLocales;
+  return supportedLocales.filter((item) =>
+    `${item.name} ${item.code} ${item.language}`
+      .toLocaleLowerCase()
+      .includes(needle),
+  );
+});
 
-async function changeLanguage(event: Event) {
-  const value = (event.target as HTMLSelectElement).value;
-  if (!isLocaleCode(value) || value === locale.value || pending.value) return;
+function toggle() {
+  if (pending.value) return;
+  open.value = !open.value;
+  error.value = false;
+}
+
+function close() {
+  open.value = false;
+  query.value = "";
+}
+
+async function selectLanguage(value: LocaleCode) {
+  if (!isLocaleCode(value) || value === locale.value || pending.value) {
+    close();
+    return;
+  }
 
   pending.value = true;
   error.value = false;
@@ -22,6 +48,7 @@ async function changeLanguage(event: Event) {
     await setLocale(value);
     if (!te("seo.title", value))
       throw new Error(`Locale messages for ${value} were not loaded`);
+    close();
   } catch {
     if (locale.value !== previousLocale) {
       try {
@@ -31,27 +58,93 @@ async function changeLanguage(event: Event) {
       }
     }
     error.value = true;
-    (event.target as HTMLSelectElement).value = locale.value;
   } finally {
     pending.value = false;
   }
 }
+
+function focusFirstOption() {
+  root.value?.querySelector<HTMLButtonElement>("[role='option']")?.focus();
+}
+
+function onDocumentPointerDown(event: PointerEvent) {
+  if (!root.value?.contains(event.target as Node)) close();
+}
+
+watch(open, async (isOpen) => {
+  if (!isOpen) return;
+  await nextTick();
+  searchInput.value?.focus();
+});
+
+onMounted(() => document.addEventListener("pointerdown", onDocumentPointerDown));
+onBeforeUnmount(() =>
+  document.removeEventListener("pointerdown", onDocumentPointerDown),
+);
 </script>
 
 <template>
-  <div class="language-switcher">
-    <span class="language-switcher__icon" aria-hidden="true">文</span>
-    <select
-      :value="locale"
-      :aria-label="t('language.current', { language: currentName })"
+  <div ref="root" class="language-switcher">
+    <button
+      class="language-switcher__trigger"
+      type="button"
+      :aria-label="t('language.current', { language: currentLocale.name })"
+      aria-haspopup="listbox"
+      :aria-expanded="open"
+      aria-controls="language-options"
       :disabled="pending"
       :aria-busy="pending"
-      @change="changeLanguage"
+      @click="toggle"
+      @keydown.down.prevent="open = true"
+      @keydown.esc="close"
     >
-      <option v-for="item in supportedLocales" :key="item.code" :value="item.code">
-        {{ item.name }}
-      </option>
-    </select>
+      <span class="language-switcher__glyph" aria-hidden="true">文</span>
+      <span>{{ currentLocale.name }}</span>
+      <svg class="language-switcher__chevron" viewBox="0 0 12 8" aria-hidden="true">
+        <path d="m1 1 5 5 5-5" />
+      </svg>
+    </button>
+
+    <div v-if="open" class="language-switcher__popover">
+      <label class="language-switcher__search">
+        <span class="visually-hidden">{{ t("language.search") }}</span>
+        <svg viewBox="0 0 20 20" aria-hidden="true">
+          <circle cx="8.5" cy="8.5" r="5.5" />
+          <path d="m13 13 4 4" />
+        </svg>
+        <input
+          ref="searchInput"
+          v-model="query"
+          type="search"
+          autocomplete="off"
+          :placeholder="t('language.search')"
+          @keydown.esc.prevent="close"
+          @keydown.down.prevent="focusFirstOption"
+        />
+      </label>
+
+      <div id="language-options" class="language-switcher__options" role="listbox" :aria-label="t('language.label')">
+        <button
+          v-for="item in filteredLocales"
+          :key="item.code"
+          type="button"
+          role="option"
+          :aria-selected="item.code === locale"
+          :class="{ active: item.code === locale }"
+          @click="selectLanguage(item.code)"
+        >
+          <span class="language-switcher__code" aria-hidden="true">{{ item.code.toUpperCase() }}</span>
+          <span>{{ item.name }}</span>
+          <svg v-if="item.code === locale" viewBox="0 0 16 16" aria-hidden="true">
+            <path d="m3 8 3 3 7-7" />
+          </svg>
+        </button>
+        <p v-if="filteredLocales.length === 0" class="language-switcher__empty">
+          {{ t("language.noResults") }}
+        </p>
+      </div>
+    </div>
+
     <span v-if="error" class="visually-hidden" role="alert">
       {{ t("language.switchError") }}
     </span>

--- a/landing/locales/en.json
+++ b/landing/locales/en.json
@@ -6,6 +6,8 @@
   "language": {
     "label": "Language",
     "current": "Current language: {language}",
+    "search": "Search languages",
+    "noResults": "No languages found",
     "switchError": "Unable to change language. Please try again."
   },
   "accessibility": {

--- a/landing/locales/zh.json
+++ b/landing/locales/zh.json
@@ -6,6 +6,8 @@
   "language": {
     "label": "语言",
     "current": "当前语言：{language}",
+    "search": "搜索语言",
+    "noResults": "未找到语言",
     "switchError": "无法切换语言，请重试。"
   },
   "accessibility": {

--- a/landing/pages/index.vue
+++ b/landing/pages/index.vue
@@ -13,9 +13,33 @@ useHead(() => ({
     { name: "description", content: t("seo.description") },
     { property: "og:title", content: t("seo.title") },
     { property: "og:description", content: t("seo.description") },
+    { property: "og:type", content: "website" },
+    { property: "og:site_name", content: "Agent Notifications" },
     { name: "twitter:card", content: "summary" },
     { name: "twitter:title", content: t("seo.title") },
     { name: "twitter:description", content: t("seo.description") },
+    { name: "theme-color", content: "#080b12" },
+  ],
+  script: [
+    {
+      type: "application/ld+json",
+      innerHTML: JSON.stringify({
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        name: "Agent Notifications",
+        description: t("seo.description"),
+        applicationCategory: "DeveloperApplication",
+        operatingSystem: "macOS, Linux, Windows",
+        isAccessibleForFree: true,
+        offers: {
+          "@type": "Offer",
+          price: "0",
+          priceCurrency: "USD",
+        },
+        url: "https://777genius.github.io/agent-notifications/",
+        downloadUrl: repo,
+      }),
+    },
   ],
 }));
 

--- a/landing/public/robots.txt
+++ b/landing/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://777genius.github.io/agent-notifications/sitemap.xml

--- a/landing/public/sitemap.xml
+++ b/landing/public/sitemap.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+        xmlns:xhtml="http://www.w3.org/1999/xhtml">
+  <url>
+    <loc>https://777genius.github.io/agent-notifications/</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://777genius.github.io/agent-notifications/" />
+    <xhtml:link rel="alternate" hreflang="zh-CN" href="https://777genius.github.io/agent-notifications/zh/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://777genius.github.io/agent-notifications/" />
+  </url>
+  <url>
+    <loc>https://777genius.github.io/agent-notifications/zh/</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://777genius.github.io/agent-notifications/" />
+    <xhtml:link rel="alternate" hreflang="zh-CN" href="https://777genius.github.io/agent-notifications/zh/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://777genius.github.io/agent-notifications/" />
+  </url>
+</urlset>

--- a/landing/tests/browser/install.spec.ts
+++ b/landing/tests/browser/install.spec.ts
@@ -15,6 +15,10 @@ async function chooseOS(page: Page, value: string) {
   await page.getByRole("combobox", { name: "Target operating system" }).click();
   await page.getByRole("option", { name: labels[value], exact: true }).click();
 }
+async function chooseLanguage(page: Page, current: RegExp, language: string) {
+  await page.getByRole("button", { name: current }).click();
+  await page.getByRole("option", { name: language, exact: true }).click();
+}
 test("production command matrix, aftercare, clipboard and configuration", async ({
   page,
 }) => {
@@ -187,8 +191,7 @@ test("language switch localizes content, URL, metadata and persists the choice",
   await page.getByRole("button", { name: "Codex CLI · beta", exact: true }).click();
   await chooseOS(page, "windows");
   await expect(page.getByLabel("Install command")).toHaveValue(/--product codex$/);
-  const language = page.getByRole("combobox", { name: /Current language/ });
-  await language.selectOption("zh");
+  await chooseLanguage(page, /Current language/, "简体中文");
   await expect(page).toHaveURL(/\/agent-notifications\/zh\/?\?source=i18n#features$/);
   await expect(page.getByRole("heading", { level: 1 })).toContainText("保持专注");
   await expect(page.locator("html")).toHaveAttribute("lang", "zh-CN");
@@ -197,13 +200,17 @@ test("language switch localizes content, URL, metadata and persists the choice",
     "content",
     /桌面通知/,
   );
+  await expect(page.locator('meta[property="og:type"]')).toHaveAttribute("content", "website");
+  expect(
+    await page.locator('script[type="application/ld+json"]').textContent(),
+  ).toContain("SoftwareApplication");
   await expect(page.getByLabel("安装命令")).toHaveValue(/--product codex$/);
   await expect(page.getByText("请在 Windows 的 Git Bash 中运行。", { exact: true })).toBeVisible();
   expect((await page.context().cookies()).find((cookie) => cookie.name === "agent_notifications_locale")?.value).toBe("zh");
 
   await page.reload();
   await expect(page.getByRole("heading", { level: 1 })).toContainText("保持专注");
-  await page.getByRole("combobox", { name: /当前语言/ }).selectOption("en");
+  await chooseLanguage(page, /当前语言/, "English");
   await expect(page).toHaveURL(/\/agent-notifications\/?\?source=i18n#features$/);
   await expect(page.getByRole("heading", { level: 1 })).toContainText("Stay in flow");
 });
@@ -212,12 +219,31 @@ test("failed locale payload keeps the working language and reports the error", a
 }) => {
   await page.route("**/_i18n/**/zh/messages.json", (route) => route.abort());
   await page.goto("");
-  await page.getByRole("combobox", { name: /Current language/ }).selectOption("zh");
+  await chooseLanguage(page, /Current language/, "简体中文");
   await expect(page.getByRole("alert")).toContainText(
     "Unable to change language",
   );
   await expect(page.getByRole("heading", { level: 1 })).toContainText("Stay in flow");
   await expect(page).toHaveURL(/\/agent-notifications\/?$/);
+});
+test("language menu is searchable, keyboard accessible and closes outside", async ({
+  page,
+}) => {
+  await page.goto("");
+  const trigger = page.getByRole("button", { name: /Current language/ });
+  await trigger.press("ArrowDown");
+  const search = page.getByRole("searchbox", { name: "Search languages" });
+  await expect(search).toBeFocused();
+  await search.fill("zh-CN");
+  await expect(page.getByRole("option", { name: "简体中文" })).toBeVisible();
+  await expect(page.getByRole("option", { name: "English" })).toHaveCount(0);
+  await search.fill("missing");
+  await expect(page.getByText("No languages found", { exact: true })).toBeVisible();
+  await search.press("Escape");
+  await expect(search).toHaveCount(0);
+  await trigger.click();
+  await page.locator("main").click({ position: { x: 5, y: 5 } });
+  await expect(page.getByRole("searchbox", { name: "Search languages" })).toHaveCount(0);
 });
 test("notification sequence covers statuses and agents, pause and reduced motion", async ({
   page,

--- a/landing/tests/i18n.test.ts
+++ b/landing/tests/i18n.test.ts
@@ -62,3 +62,15 @@ test("locale manifest accepts only published locale codes", () => {
   assert.equal(isLocaleCode("ru"), false);
   assert.equal(isLocaleCode(null), false);
 });
+
+test("crawler files publish every localized route", async () => {
+  const [robots, sitemap] = await Promise.all([
+    readFile(new URL("../public/robots.txt", import.meta.url), "utf8"),
+    readFile(new URL("../public/sitemap.xml", import.meta.url), "utf8"),
+  ]);
+  assert.match(robots, /Sitemap: https:\/\/777genius\.github\.io\/agent-notifications\/sitemap\.xml/);
+  for (const path of ["agent-notifications/", "agent-notifications/zh/"])
+    assert.match(sitemap, new RegExp(`<loc>https://777genius\\.github\\.io/${path}</loc>`));
+  assert.match(sitemap, /hreflang="x-default"/);
+  assert.match(sitemap, /hreflang="zh-CN"/);
+});


### PR DESCRIPTION
## Summary
- replace the native language select with a searchable, accessible custom popover matching the landing visual system
- preserve locale routing, query/hash, state, persistence and rollback behavior
- complete localized SEO with crawler files, Open Graph fields and SoftwareApplication structured data

## Validation
- `tsc7 --noEmit`
- `npm test` (5 passed)
- `npm run build`
- `npx playwright test --workers=1` (12 scenarios passed; the JSON-LD assertion was corrected and the affected scenario rerun successfully)
- visual QA of the open desktop popover

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Redesigned the language selector with searchable options, language codes, keyboard navigation, and click-outside dismissal.
  - Added localized search and empty-state messages in English and Chinese.
  - Added enhanced search-engine metadata, structured app information, and theme color settings.
  - Added crawler guidance and a sitemap covering English and Chinese pages.

- **Tests**
  - Added coverage for language filtering, accessibility, dismissal behavior, metadata, robots.txt, and sitemap links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->