### PR TITLE
fix(installer): protect explicit config during lazy updates

### DIFF
--- a/bin/codex-hook-wrapper_test.sh
+++ b/bin/codex-hook-wrapper_test.sh
@@ -104,12 +104,12 @@ for EXISTING in yes no; do main >/dev/null; done
 rm -rf "$venv"
 main >/dev/null
 [ ! -e "$venv" ]
-# Positive Claude control: the same failing pip fixture reaches old cleanup.
+# Positive Claude control: failed private pip preserves the broken live tree.
 unset CN_PRODUCT
 mkdir -p "$venv"
 echo keep > "$venv/canary"
 main >/dev/null
 [ -f "$ROOT/python-called" ]
-[ ! -e "$venv" ]
+[ "$(cat "$venv/canary")" = keep ]
 echo 'PASS: isolated Codex cache and installer regressions'
 RUN

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -24,6 +24,108 @@ fi
 # Ensure target directory exists
 mkdir -p "$SCRIPT_DIR" 2>/dev/null || true
 
+# Explicit config protection uses the canonical Go command. Try the installed
+# helper first so safe existing installs need no network. Old binaries that do
+# not speak this protocol require a verified staged release before live changes.
+INSTALL_CONFIG_STAGE=""
+INSTALL_CONFIG_HELPER=""
+
+cleanup_install_config() {
+    [ -z "$INSTALL_CONFIG_STAGE" ] || rm -rf "$INSTALL_CONFIG_STAGE"
+}
+trap 'cleanup_install_config' EXIT
+
+config_preflight_stop() {
+    echo 'Config preflight stopped installation; existing runtime retained. Check AGENT_NOTIFICATIONS_CONFIG and repair/recover the selected file, or rerun bootstrap with a config-capable release and Python 3.' >&2
+    return 1
+}
+
+prepare_install_config_preflight() {
+    [ "${AGENT_NOTIFICATIONS_CONFIG+x}" = x ] || return 0
+    command -v python3 >/dev/null 2>&1 || { config_preflight_stop; return 1; }
+    local status
+    [ -n "$INSTALL_CONFIG_HELPER" ] || INSTALL_CONFIG_HELPER="$BINARY_PATH"
+    if install_config_preflight "$@"; then return 0; else status=$?; fi
+    # A canonical rejection is final; only an unavailable protocol needs staging.
+    [ "$status" = 2 ] || return 1
+    [ -z "$INSTALL_CONFIG_STAGE" ] || { config_preflight_stop; return 1; }
+    if [ "$OFFLINE_MODE" = true ] && [ -z "${INSTALL_STAGED_ASSETS:-}" ]; then
+        config_preflight_stop
+        return 1
+    fi
+    INSTALL_CONFIG_STAGE=$(mktemp -d "${TMPDIR:-${TEMP:-/tmp}}/install-config.XXXXXX") || return 1
+    # Existing download/verification logic is confined to this new directory.
+    if ! (
+        SCRIPT_DIR="$INSTALL_CONFIG_STAGE"
+        detect_platform
+        REQUIRE_CHECKSUM=true
+        pin_release_urls
+        download_and_verify_binary && verify_executable
+    ) >/dev/null 2>&1; then
+        config_preflight_stop
+        return 1
+    fi
+    INSTALL_CONFIG_HELPER="$INSTALL_CONFIG_STAGE/$BINARY_NAME"
+    install_config_preflight "$@" || { config_preflight_stop; return 1; }
+    cp "$INSTALL_CONFIG_STAGE/.checksums.txt" "$INSTALL_CONFIG_STAGE/checksums.txt" || return 1
+    # Reuse the verified bytes for promotion, even when upgrading an old binary.
+    INSTALL_STAGED_ASSETS="$INSTALL_CONFIG_STAGE"
+}
+
+install_config_preflight() {
+    [ "${AGENT_NOTIFICATIONS_CONFIG+x}" = x ] || return 0
+    [ -n "$INSTALL_CONFIG_HELPER" ] || { config_preflight_stop; return 1; }
+    local -a targets=("$@")
+    local helper="$INSTALL_CONFIG_HELPER"
+    local i
+    if [ "$PLATFORM" = windows ]; then
+        helper=$(cygpath -aw "$helper") || { config_preflight_stop; return 1; }
+        for ((i=0; i<${#targets[@]}; i++)); do
+            targets[$i]=$(cygpath -aw "${targets[$i]}") || { config_preflight_stop; return 1; }
+        done
+    fi
+    # Python only transports JSON/native paths and bounds helper execution. All
+    # selection, validation and alias identity decisions belong to Go Store.
+    local status
+    if python3 -I - "$helper" "$PLATFORM" "${targets[@]}" <<'PYINSTALL'
+import json, os, subprocess, sys
+try:
+    helper, platform, *paths = sys.argv[1:]
+    if platform != 'windows':
+        paths = [os.path.abspath(p) for p in paths]
+    request = json.dumps(dict(refreshDirs=paths))
+    result = subprocess.run([helper, 'config', 'preflight-update', '--stdin', '--json'],
+                            input=request, text=True, stdout=subprocess.PIPE,
+                            stderr=subprocess.DEVNULL, timeout=20)
+    response = json.loads(result.stdout)
+    if not isinstance(response, dict) or response.get('status') not in {'safe', 'unsafe-target', 'invalid-config', 'import-required'}:
+        sys.exit(2)
+    if result.returncode == 0 and response.get('status') == 'safe':
+        sys.exit(0)
+    # Only canonical codes, never paths, raw helper output, or config contents.
+    for diagnostic in response.get('diagnostics', []):
+        code = diagnostic.get('code', '')
+        if isinstance(code, str) and code in {'ConfigUnsafeTarget', 'ConfigOverrideInvalid', 'ConfigInvalid',
+                'ConfigUnsupportedSchema', 'ConfigPermissionDenied', 'ConfigRecoveryRequired',
+                'ConfigLinkedPath', 'ConfigChanged', 'ConfigLockTimeout', 'ConfigMissing',
+                'ConfigHomeUnavailable', 'ConfigBaseUnavailable'}:
+            print(code, file=sys.stderr)
+except (OSError, ValueError, TypeError, AttributeError, subprocess.TimeoutExpired):
+    sys.exit(2)
+sys.exit(1)
+PYINSTALL
+    then return 0; else status=$?; fi
+    [ "$status" != 2 ] || return 2
+    config_preflight_stop
+}
+
+# Exit even when the caller treats an optional resource failure as nonfatal.
+# 78 also carries rejection out of the optional downloader subshell.
+# Targets are supplied at mutation sites, after their non-mutating early returns.
+guard_install_paths() {
+    prepare_install_config_preflight "$@" || exit 78
+}
+
 # Lockfile to prevent parallel installations
 LOCKFILE="${SCRIPT_DIR}/.install.lock"
 
@@ -303,6 +405,7 @@ acquire_lock() {
 
             if [ "$lock_age" -gt 600 ]; then
                 echo -e "${YELLOW}⚠ Removing stale lock (${lock_age}s old)${NC}"
+                guard_install_paths "$LOCKFILE"
                 rm -rf "$LOCKFILE"
                 mkdir "$LOCKFILE" 2>/dev/null || true
             else
@@ -314,7 +417,7 @@ acquire_lock() {
     fi
 
     # Set trap to release lock on exit
-    trap 'rm -rf "$LOCKFILE" 2>/dev/null' EXIT
+    trap 'rmdir "$LOCKFILE" 2>/dev/null; cleanup_install_config' EXIT
     trap 'exit 130' INT
     trap 'exit 143' TERM
     return 0
@@ -637,7 +740,7 @@ download_utility() (
 
     # Keep the live utility intact until a complete replacement is ready.
     temp_path=$(mktemp "${util_path}.download.XXXXXX") || return 1
-    trap 'rm -f "$temp_path"' EXIT
+    trap 'rm -f "$temp_path"; cleanup_install_config' EXIT
     trap 'exit 130' INT
     trap 'exit 143' TERM
     echo -e "${BLUE}📦 Downloading ${util_name}...${NC}"
@@ -656,7 +759,7 @@ download_utility() (
     # These sound tools do not implement --version; do not launch audio/device
     # enumeration to validate an optional download.
     if [ "$downloaded" = true ] && chmod +x "$temp_path" &&
-       utility_usable "$temp_path" && mv -f "$temp_path" "$util_path"; then
+       utility_usable "$temp_path" && guard_install_paths "$util_path" && mv -f "$temp_path" "$util_path"; then
         echo -e "${GREEN}✓${NC} ${util_name} downloaded"
         return 0
     fi
@@ -669,9 +772,16 @@ download_utilities() {
     echo ""
     echo -e "${BLUE}📦 Downloading utility binaries...${NC}"
 
-    download_utility "$SOUND_PREVIEW_NAME" "$SOUND_PREVIEW_PATH" || true
-    download_utility "$LIST_DEVICES_NAME" "$LIST_DEVICES_PATH" || true
-    download_utility "$LIST_SOUNDS_NAME" "$LIST_SOUNDS_PATH" || true
+    local status
+    download_utility "$SOUND_PREVIEW_NAME" "$SOUND_PREVIEW_PATH" || {
+        status=$?; [ "$status" != 78 ] || exit 78;
+    }
+    download_utility "$LIST_DEVICES_NAME" "$LIST_DEVICES_PATH" || {
+        status=$?; [ "$status" != 78 ] || exit 78;
+    }
+    download_utility "$LIST_SOUNDS_NAME" "$LIST_SOUNDS_PATH" || {
+        status=$?; [ "$status" != 78 ] || exit 78;
+    }
     # The Windows focus handler was verified and promoted with the runtime.
     # Never overwrite that required asset through the optional downloader.
 
@@ -695,12 +805,14 @@ create_utility_symlink() {
 
     local symlink_path="${SCRIPT_DIR}/${util_base}"
 
+    guard_install_paths "$symlink_path"
     # Remove old symlink if exists
     rm -f "$symlink_path" 2>/dev/null || true
 
     if [ "$PLATFORM" = "windows" ]; then
         # Windows: create .bat wrapper
         local bat_path="${symlink_path}.bat"
+        guard_install_paths "$bat_path"
         cat > "$bat_path" << EOF
 @echo off
 setlocal
@@ -1076,6 +1188,7 @@ create_symlink() {
         local final_bat_path="${SCRIPT_DIR}/claude-notifications.bat"
         local bat_path="${final_bat_path}.tmp.$$"
 
+        guard_install_paths "$bat_path" "$final_bat_path"
         # Remove old .bat file if exists
         rm -f "$bat_path" 2>/dev/null || true
 
@@ -1102,7 +1215,7 @@ EOF
     # Unix: create symlink or copy
     local final_symlink_path="${SCRIPT_DIR}/claude-notifications"
     local symlink_path="${final_symlink_path}.tmp.$$"
-
+    guard_install_paths "$final_symlink_path" "$symlink_path"
     # Remove old symlink if exists
     rm -f "$symlink_path" 2>/dev/null || true
 
@@ -1144,6 +1257,7 @@ configure_windows_native_hooks() {
     fi
 
     local tmp_hooks="${hooks_path}.tmp.$$"
+    guard_install_paths "$hooks_path" "$tmp_hooks"
     if printf '%s\n' "$hooks_json" > "$tmp_hooks" 2>/dev/null && mv "$tmp_hooks" "$hooks_path" 2>/dev/null; then
         echo -e "${GREEN}✓${NC} Windows exec-form hooks configured"
         echo -e "${YELLOW}  Restart Claude Code to apply the Windows hook update.${NC}"
@@ -1157,6 +1271,8 @@ configure_windows_native_hooks() {
 
 # Cleanup temporary files
 cleanup() {
+    [ -e "$CHECKSUMS_PATH" ] || return 0
+    guard_install_paths "$CHECKSUMS_PATH"
     rm -f "$CHECKSUMS_PATH" 2>/dev/null || true
 }
 
@@ -1174,6 +1290,8 @@ download_terminal_notifier_modern() {
 
     echo ""
     echo -e "${BLUE}📦 Installing ClaudeNotifier (modern notifications + click-to-focus)...${NC}"
+
+    guard_install_paths "$MODERN_APP" "$TEMP_ZIP"
 
     local attempt=1
     local downloaded=false
@@ -1201,6 +1319,7 @@ download_terminal_notifier_modern() {
 
     if [ "$downloaded" != true ]; then
         echo -e "${YELLOW}⚠ Could not download ClaudeNotifier, falling back to legacy${NC}"
+        guard_install_paths "$TEMP_ZIP"
         rm -f "$TEMP_ZIP" 2>/dev/null
         return 1
     fi
@@ -1208,17 +1327,21 @@ download_terminal_notifier_modern() {
     # Verify zip
     if ! unzip -t "$TEMP_ZIP" &>/dev/null; then
         echo -e "${YELLOW}⚠ Downloaded file is not a valid zip, falling back to legacy${NC}"
+        guard_install_paths "$TEMP_ZIP"
         rm -f "$TEMP_ZIP"
         return 1
     fi
 
     # Extract
+    guard_install_paths "$MODERN_APP" "$TEMP_ZIP"
     if ! unzip -o -q "$TEMP_ZIP" -d "${SCRIPT_DIR}/" 2>&1; then
         echo -e "${YELLOW}⚠ Could not extract ClaudeNotifier${NC}"
+        guard_install_paths "$TEMP_ZIP"
         rm -f "$TEMP_ZIP"
         return 1
     fi
 
+    guard_install_paths "$TEMP_ZIP"
     rm -f "$TEMP_ZIP"
 
     # Verify extraction
@@ -1237,6 +1360,7 @@ download_terminal_notifier_modern() {
         return 0
     else
         echo -e "${YELLOW}⚠ ClaudeNotifier extraction incomplete, falling back to legacy${NC}"
+        guard_install_paths "$MODERN_APP"
         rm -rf "$MODERN_APP" 2>/dev/null
         return 1
     fi
@@ -1258,6 +1382,8 @@ download_terminal_notifier() {
     echo -e "${BLUE}📦 Installing terminal-notifier (click-to-focus support)...${NC}"
 
     # Download with retry
+    guard_install_paths "$NOTIFIER_APP" "$TEMP_ZIP"
+
     local attempt=1
     local downloaded=false
 
@@ -1284,6 +1410,7 @@ download_terminal_notifier() {
 
     if [ "$downloaded" != true ]; then
         echo -e "${YELLOW}⚠ Could not download terminal-notifier (click-to-focus will be disabled)${NC}"
+        guard_install_paths "$TEMP_ZIP"
         rm -f "$TEMP_ZIP" 2>/dev/null
         return 1
     fi
@@ -1291,18 +1418,22 @@ download_terminal_notifier() {
     # Verify zip file is valid before extracting
     if ! unzip -t "$TEMP_ZIP" &>/dev/null; then
         echo -e "${YELLOW}⚠ Downloaded file is not a valid zip (click-to-focus will be disabled)${NC}"
+        guard_install_paths "$TEMP_ZIP"
         rm -f "$TEMP_ZIP"
         return 1
     fi
 
     # Extract (-o to overwrite without prompting)
+    guard_install_paths "$NOTIFIER_APP" "$TEMP_ZIP"
     if ! unzip -o -q "$TEMP_ZIP" -d "${SCRIPT_DIR}/" 2>&1; then
         echo -e "${YELLOW}⚠ Could not extract terminal-notifier${NC}"
+        guard_install_paths "$TEMP_ZIP"
         rm -f "$TEMP_ZIP"
         return 1
     fi
 
     # Cleanup
+    guard_install_paths "$TEMP_ZIP"
     rm -f "$TEMP_ZIP"
 
     # Verify extraction
@@ -1311,6 +1442,7 @@ download_terminal_notifier() {
         return 0
     else
         echo -e "${YELLOW}⚠ terminal-notifier extraction incomplete${NC}"
+        guard_install_paths "$NOTIFIER_APP"
         rm -rf "$NOTIFIER_APP" 2>/dev/null
         return 1
     fi
@@ -1336,6 +1468,9 @@ create_claude_notifications_app() {
 
     echo -e "${BLUE}🎨 Creating ClaudeNotifications.app (notification icon)...${NC}"
 
+    guard_install_paths "$APP_DIR" "${TMPDIR:-${TEMP:-/tmp}}/claude-$$.iconset" \
+        "$APP_DIR/Contents/Info.plist" "$APP_DIR/Contents/MacOS/claude-notify" \
+        "$APP_DIR/Contents/Resources/AppIcon.icns"
     # Create app structure
     mkdir -p "$APP_DIR/Contents/MacOS"
     mkdir -p "$APP_DIR/Contents/Resources"
@@ -1356,15 +1491,19 @@ create_claude_notifications_app() {
     cp "$ICON_SRC" "$ICONSET_DIR/icon_512x512.png" >/dev/null 2>&1
 
     # Convert to icns
+    guard_install_paths "$APP_DIR/Contents/Resources/AppIcon.icns"
     if ! iconutil -c icns "$ICONSET_DIR" -o "$APP_DIR/Contents/Resources/AppIcon.icns" 2>/dev/null; then
         echo -e "${YELLOW}⚠ Could not create app icon${NC}"
+        guard_install_paths "$ICONSET_DIR" "$APP_DIR"
         rm -rf "$ICONSET_DIR" "$APP_DIR"
         return 1
     fi
 
+    guard_install_paths "$ICONSET_DIR"
     rm -rf "$ICONSET_DIR"
 
     # Create Info.plist
+    guard_install_paths "$APP_DIR/Contents/Info.plist"
     cat > "$APP_DIR/Contents/Info.plist" << 'PLIST_EOF'
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -1389,6 +1528,7 @@ create_claude_notifications_app() {
 PLIST_EOF
 
     # Create minimal executable
+    guard_install_paths "$APP_DIR/Contents/MacOS/claude-notify"
     cat > "$APP_DIR/Contents/MacOS/claude-notify" << 'EXEC_EOF'
 #!/bin/bash
 exit 0
@@ -1444,16 +1584,19 @@ setup_iterm2_venv() {
     echo ""
     echo -e "${BLUE}  Setting up iTerm2 tmux -CC support...${NC}"
 
+    guard_install_paths "$VENV_DIR"
     if ! "$python3_path" -m venv "$VENV_DIR" 2>/dev/null; then
         echo -e "${YELLOW}  ⚠ Could not create Python venv, skipping${NC}"
         return 0
     fi
 
+    guard_install_paths "$VENV_DIR"
     if "$VENV_DIR/bin/pip" install --quiet iterm2 2>/dev/null; then
         echo -e "${GREEN}  ✓${NC} iTerm2 Python API support installed"
         echo -e "${BLUE}    Enable 'Python API' in iTerm2 → Settings → General → Magic${NC}"
     else
         echo -e "${YELLOW}  ⚠ Could not install iterm2 module${NC}"
+        guard_install_paths "$VENV_DIR"
         rm -rf "$VENV_DIR" 2>/dev/null
     fi
 }
@@ -1535,6 +1678,7 @@ install_gnome_activate_window_extension() {
 
     echo -e "${BLUE}   Downloading extension...${NC}"
 
+    guard_install_paths "$temp_zip"
     local downloaded=false
     attempt=1
 
@@ -1561,6 +1705,7 @@ install_gnome_activate_window_extension() {
 
     if [ "$downloaded" != true ]; then
         echo -e "${YELLOW}⚠ Could not download extension (click-to-focus will be disabled)${NC}"
+        guard_install_paths "$temp_zip"
         rm -f "$temp_zip" 2>/dev/null
         return 1
     fi
@@ -1568,12 +1713,15 @@ install_gnome_activate_window_extension() {
     # Install using gnome-extensions
     echo -e "${BLUE}   Installing extension...${NC}"
 
+    guard_install_paths "${XDG_DATA_HOME:-$HOME/.local/share}/gnome-shell/extensions/$EXTENSION_UUID"
     if ! gnome-extensions install --force "$temp_zip" 2>/dev/null; then
         echo -e "${YELLOW}⚠ Could not install extension${NC}"
+        guard_install_paths "$temp_zip"
         rm -f "$temp_zip"
         return 1
     fi
 
+    guard_install_paths "$temp_zip"
     rm -f "$temp_zip"
 
     # Enable the extension
@@ -1607,6 +1755,7 @@ install_linux_notification_desktop_entry() {
         return 1
     fi
 
+    guard_install_paths "$desktop_file" "$tmp_file"
     cat > "$tmp_file" << EOF
 [Desktop Entry]
 Name=Agent Notifications
@@ -1649,7 +1798,7 @@ stage_and_promote_runtime() (
     # The trap must still know which disposable staging directory to remove.
     stage=''
     stage=$(mktemp -d "$SCRIPT_DIR/.install-stage.XXXXXX") || exit 1
-    trap 'rm -rf "$stage"' EXIT
+    trap 'rm -rf "$stage"; cleanup_install_config' EXIT
     trap 'exit 130' INT
     trap 'exit 143' TERM
 
@@ -1658,6 +1807,9 @@ stage_and_promote_runtime() (
     detect_platform
     download_and_verify_binary || exit 1
     verify_executable || exit 1
+
+    # A verified new binary supplies the protocol even on fresh/old installs.
+    INSTALL_CONFIG_HELPER="$BINARY_PATH"
 
     if [ "$PLATFORM" = "darwin" ]; then
         if ! [ -x "$live_dir/ClaudeNotifier.app/Contents/MacOS/terminal-notifier-modern" ] &&
@@ -1671,6 +1823,7 @@ stage_and_promote_runtime() (
                 esac
                 # Only an unusable bundle can be displaced here. A valid live
                 # notifier never has a rename gap, including during SIGKILL.
+                guard_install_paths "$live_dir/$app"
                 if [ -e "$live_dir/$app" ]; then
                     mv "$live_dir/$app" "$stage/old-$app" || exit 1
                 fi
@@ -1682,6 +1835,7 @@ stage_and_promote_runtime() (
         if ! [ -x "$live_dir/ClaudeNotifier.app/Contents/MacOS/terminal-notifier-modern" ] &&
            [ -x "$live_dir/terminal-notifier.app/Contents/MacOS/terminal-notifier" ] &&
            { [ -e "$live_dir/ClaudeNotifier.app" ] || [ -L "$live_dir/ClaudeNotifier.app" ]; }; then
+            guard_install_paths "$live_dir/ClaudeNotifier.app"
             mv "$live_dir/ClaudeNotifier.app" "$stage/unusable-ClaudeNotifier.app" || exit 1
         fi
     elif [ "$PLATFORM" = "windows" ]; then
@@ -1691,6 +1845,7 @@ stage_and_promote_runtime() (
         BINARY_PATH="$FOCUS_HANDLER_PATH"
         download_and_verify_binary || exit 1
         chmod +x "$BINARY_PATH" || exit 1
+        guard_install_paths "$live_dir/$BINARY_NAME"
         mv -f "$BINARY_PATH" "$live_dir/$BINARY_NAME" || exit 1
         BINARY_NAME="$main_name"
         BINARY_PATH="$main_path"
@@ -1698,6 +1853,7 @@ stage_and_promote_runtime() (
         install_linux_notification_desktop_entry || exit 1
     fi
 
+    guard_install_paths "$live_binary"
     mv -f "$BINARY_PATH" "$live_binary" || exit 1
 )
 
@@ -1720,10 +1876,6 @@ main() {
         exit 1
     fi
 
-    if ! acquire_lock; then
-        exit 1
-    fi
-
     # Detect platform
     detect_platform
     echo -e "${BLUE}Platform:${NC} ${PLATFORM}-${ARCH}"
@@ -1739,6 +1891,8 @@ main() {
             return 1
         fi
     fi
+
+    acquire_lock || return 1
 
     # Check if already installed
     if check_existing; then
@@ -1788,6 +1942,7 @@ main() {
         fi
 
         # Verify existing binary still works
+        guard_install_paths "$BINARY_PATH"
         if ! verify_executable; then
             echo -e "${RED}✗ Existing binary is corrupted or incompatible${NC}" >&2
             echo -e "${YELLOW}Please restore network access to download a fresh binary.${NC}" >&2

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -33,7 +33,7 @@ INSTALL_CONFIG_HELPER=""
 INSTALL_PRIVATE_DOWNLOAD=false
 
 cleanup_install_config() {
-    if [ -n "$INSTALL_CONFIG_STAGE" ] && [ "$INSTALL_CONFIG_STAGE_OWNER" = "$BASH_SUBSHELL" ]; then
+    if [ -n "$INSTALL_CONFIG_STAGE" ] && [ "$INSTALL_CONFIG_STAGE_OWNER" = "${BASHPID:-$BASH_SUBSHELL}" ]; then
         cleanup_install_stage "$INSTALL_CONFIG_STAGE"
     fi
     return 0
@@ -73,7 +73,7 @@ prepare_install_config_preflight() {
         return 1
     fi
     INSTALL_CONFIG_STAGE=$(mktemp -d "${TMPDIR:-${TEMP:-/tmp}}/install-config.XXXXXX") || return 1
-    INSTALL_CONFIG_STAGE_OWNER=$BASH_SUBSHELL
+    INSTALL_CONFIG_STAGE_OWNER="${BASHPID:-$BASH_SUBSHELL}"
     # Existing download/verification logic is confined to this new directory.
     if ! (
         SCRIPT_DIR="$INSTALL_CONFIG_STAGE"
@@ -1913,8 +1913,8 @@ stage_and_promote_runtime() (
     # The trap must still know which disposable staging directory to remove.
     stage=''
     stage=$(mktemp -d "$SCRIPT_DIR/.install-stage.XXXXXX") || exit 1
-    stage_owner=$BASH_SUBSHELL
-    trap 'if [ "$stage_owner" = "$BASH_SUBSHELL" ]; then cleanup_install_stage "$stage"; fi; cleanup_install_config' EXIT
+    stage_owner="${BASHPID:-$BASH_SUBSHELL}"
+    trap 'if [ "$stage_owner" = "${BASHPID:-$BASH_SUBSHELL}" ]; then cleanup_install_stage "$stage"; fi; cleanup_install_config' EXIT
     trap 'exit 130' INT
     trap 'exit 143' TERM
 

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -34,8 +34,23 @@ INSTALL_PRIVATE_DOWNLOAD=false
 
 cleanup_install_config() {
     if [ -n "$INSTALL_CONFIG_STAGE" ] && [ "$INSTALL_CONFIG_STAGE_OWNER" = "$BASH_SUBSHELL" ]; then
-        rm -rf "$INSTALL_CONFIG_STAGE"
+        cleanup_install_stage "$INSTALL_CONFIG_STAGE"
     fi
+    return 0
+}
+
+# Never bootstrap from an EXIT trap. An unavailable helper means retention.
+# Return success so cleanup cannot mask the installation's pending exit status.
+cleanup_install_stage() {
+    [ -n "$1" ] || return 0
+    if install_config_preflight "$1"; then
+        if ! rm -rf -- "$1" 2>/dev/null; then
+            echo 'Private installer stage retained; cleanup failed.' >&2
+        fi
+    else
+        echo 'Private installer stage retained; config safety could not be established.' >&2
+    fi
+    return 0
 }
 trap 'cleanup_install_config' EXIT
 
@@ -423,7 +438,7 @@ acquire_lock() {
     fi
 
     # Set trap to release lock on exit
-    trap 'rmdir "$LOCKFILE" 2>/dev/null; cleanup_install_config' EXIT
+    trap 'rmdir "$LOCKFILE" 2>/dev/null || :; cleanup_install_config' EXIT
     trap 'exit 130' INT
     trap 'exit 143' TERM
     return 0
@@ -1635,9 +1650,11 @@ setup_iterm2_venv() {
         echo -e "${YELLOW}  ⚠ Could not install iterm2 module${NC}"
         return 0
     fi
+    # Pip may have changed the selected alias into any part of this tree.
+    guard_install_paths "$venv_stage"
     # venv entry points and activation scripts embed their creation path.
     if ! "$python3_path" -I - "$venv_stage/venv" "$VENV_DIR" <<'PYVENV'
-import os, sys
+import os, shlex, sys
 old, new = sys.argv[1:]
 for name in os.listdir(os.path.join(old, 'bin')):
     path = os.path.join(old, 'bin', name)
@@ -1646,8 +1663,40 @@ for name in os.listdir(os.path.join(old, 'bin')):
     with open(path, 'rb') as f:
         data = f.read()
     if b'\0' not in data and old.encode() in data:
+        # Kernel shebangs cannot quote paths with spaces. Use the portable
+        # shell/Python trampoline used by Python packaging entry points.
+        first, sep, rest = data.partition(b'\n')
+        if first.startswith(b'#!' + old.encode() + b'/'):
+            command = shlex.split(first[2:].decode())
+            command[0] = new + command[0][len(old):]
+            header = "#!/bin/sh\n'''exec' " + ' '.join(shlex.quote(arg) for arg in command)
+            header += ' "$0" "$@"\n' + "' '''\n"
+            data = header.encode() + rest.replace(old.encode(), new.encode())
+        elif name in ('activate', 'activate.csh', 'activate.fish'):
+            # Activation scripts created under the private staging path may
+            # contain unquoted assignments. Quote the promoted path before the
+            # generic replacement so HOME values with spaces remain valid.
+            text = data.decode()
+            if name == 'activate':
+                text = text.replace(
+                    'VIRTUAL_ENV=$(cygpath ' + old + ')',
+                    'VIRTUAL_ENV=$(cygpath ' + shlex.quote(new) + ')')
+                text = text.replace(
+                    'export VIRTUAL_ENV=' + old,
+                    'export VIRTUAL_ENV=' + shlex.quote(new))
+            elif name == 'activate.csh':
+                text = text.replace(
+                    'setenv VIRTUAL_ENV ' + old,
+                    'setenv VIRTUAL_ENV ' + shlex.quote(new))
+            elif name == 'activate.fish':
+                text = text.replace(
+                    'set -gx VIRTUAL_ENV ' + old,
+                    'set -gx VIRTUAL_ENV ' + shlex.quote(new))
+            data = text.replace(old, new).encode()
+        else:
+            data = data.replace(old.encode(), new.encode())
         with open(path, 'wb') as f:
-            f.write(data.replace(old.encode(), new.encode()))
+            f.write(data)
 PYVENV
     then
         guard_install_paths "$venv_stage"
@@ -1864,7 +1913,8 @@ stage_and_promote_runtime() (
     # The trap must still know which disposable staging directory to remove.
     stage=''
     stage=$(mktemp -d "$SCRIPT_DIR/.install-stage.XXXXXX") || exit 1
-    trap 'rm -rf "$stage"; cleanup_install_config' EXIT
+    stage_owner=$BASH_SUBSHELL
+    trap 'if [ "$stage_owner" = "$BASH_SUBSHELL" ]; then cleanup_install_stage "$stage"; fi; cleanup_install_config' EXIT
     trap 'exit 130' INT
     trap 'exit 143' TERM
 
@@ -1922,6 +1972,7 @@ stage_and_promote_runtime() (
 
     guard_install_paths "$live_binary"
     mv -f "$BINARY_PATH" "$live_binary" || exit 1
+    INSTALL_CONFIG_HELPER="$live_binary"
 )
 
 # Main installation flow

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -1654,7 +1654,7 @@ setup_iterm2_venv() {
     guard_install_paths "$venv_stage"
     # venv entry points and activation scripts embed their creation path.
     if ! "$python3_path" -I - "$venv_stage/venv" "$VENV_DIR" <<'PYVENV'
-import os, shlex, sys
+import os, shlex, stat, sys, tempfile
 old, new = sys.argv[1:]
 for name in os.listdir(os.path.join(old, 'bin')):
     path = os.path.join(old, 'bin', name)
@@ -1695,8 +1695,21 @@ for name in os.listdir(os.path.join(old, 'bin')):
             data = text.replace(old, new).encode()
         else:
             data = data.replace(old.encode(), new.encode())
-        with open(path, 'wb') as f:
-            f.write(data)
+        # Replace the staged directory entry instead of truncating its inode.
+        # An explicit config outside the tree may be a hardlink to this file;
+        # atomic replacement keeps those selected bytes unchanged.
+        mode = stat.S_IMODE(os.stat(path).st_mode)
+        fd, replacement = tempfile.mkstemp(prefix='.venv-rewrite-', dir=os.path.dirname(path))
+        try:
+            with os.fdopen(fd, 'wb') as f:
+                f.write(data)
+            os.chmod(replacement, mode)
+            os.replace(replacement, path)
+        finally:
+            try:
+                os.unlink(replacement)
+            except OSError:
+                pass
 PYVENV
     then
         guard_install_paths "$venv_stage"

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -28,10 +28,14 @@ mkdir -p "$SCRIPT_DIR" 2>/dev/null || true
 # helper first so safe existing installs need no network. Old binaries that do
 # not speak this protocol require a verified staged release before live changes.
 INSTALL_CONFIG_STAGE=""
+INSTALL_CONFIG_STAGE_OWNER=""
 INSTALL_CONFIG_HELPER=""
+INSTALL_PRIVATE_DOWNLOAD=false
 
 cleanup_install_config() {
-    [ -z "$INSTALL_CONFIG_STAGE" ] || rm -rf "$INSTALL_CONFIG_STAGE"
+    if [ -n "$INSTALL_CONFIG_STAGE" ] && [ "$INSTALL_CONFIG_STAGE_OWNER" = "$BASH_SUBSHELL" ]; then
+        rm -rf "$INSTALL_CONFIG_STAGE"
+    fi
 }
 trap 'cleanup_install_config' EXIT
 
@@ -54,9 +58,11 @@ prepare_install_config_preflight() {
         return 1
     fi
     INSTALL_CONFIG_STAGE=$(mktemp -d "${TMPDIR:-${TEMP:-/tmp}}/install-config.XXXXXX") || return 1
+    INSTALL_CONFIG_STAGE_OWNER=$BASH_SUBSHELL
     # Existing download/verification logic is confined to this new directory.
     if ! (
         SCRIPT_DIR="$INSTALL_CONFIG_STAGE"
+        INSTALL_PRIVATE_DOWNLOAD=true
         detect_platform
         REQUIRE_CHECKSUM=true
         pin_release_urls
@@ -95,7 +101,7 @@ try:
         paths = [os.path.abspath(p) for p in paths]
     request = json.dumps(dict(refreshDirs=paths))
     result = subprocess.run([helper, 'config', 'preflight-update', '--stdin', '--json'],
-                            input=request, text=True, stdout=subprocess.PIPE,
+                            input=request, universal_newlines=True, stdout=subprocess.PIPE,
                             stderr=subprocess.DEVNULL, timeout=20)
     response = json.loads(result.stdout)
     if not isinstance(response, dict) or response.get('status') not in {'safe', 'unsafe-target', 'invalid-config', 'import-required'}:
@@ -463,6 +469,12 @@ check_required_tools() {
     return 0
 }
 
+# Release downloads normally run in fresh private staging. Direct callers
+# still require canonical protection for their live output paths.
+guard_download_paths() {
+    [ "${INSTALL_PRIVATE_DOWNLOAD:-false}" = true ] || guard_install_paths "$@"
+}
+
 # Retry wrapper for network operations
 retry_download() {
     local url="$1"
@@ -478,6 +490,7 @@ retry_download() {
 
         local temp_file="${output}.tmp.$$"
         local success=false
+        guard_download_paths "$temp_file"
 
         if command -v curl &>/dev/null; then
             if curl -fsSL "${CURL_EXTRA_OPTS[@]}" --connect-timeout "$CONNECT_TIMEOUT" --max-time "$CURL_TIMEOUT" "$url" -o "$temp_file" 2>/dev/null; then
@@ -490,10 +503,12 @@ retry_download() {
         fi
 
         if [ "$success" = true ] && [ -f "$temp_file" ] && [ "$(get_file_size "$temp_file")" -gt 0 ]; then
+            guard_download_paths "$temp_file" "$output"
             mv "$temp_file" "$output"
             return 0
         fi
 
+        guard_download_paths "$temp_file"
         rm -f "$temp_file" 2>/dev/null
         attempt=$((attempt + 1))
     done
@@ -739,13 +754,15 @@ download_utility() (
     fi
 
     # Keep the live utility intact until a complete replacement is ready.
+    guard_install_paths "$util_path"
     temp_path=$(mktemp "${util_path}.download.XXXXXX") || return 1
-    trap 'rm -f "$temp_path"; cleanup_install_config' EXIT
+    trap 'guard_install_paths "$temp_path"; rm -f "$temp_path"; cleanup_install_config' EXIT
     trap 'exit 130' INT
     trap 'exit 143' TERM
     echo -e "${BLUE}📦 Downloading ${util_name}...${NC}"
 
     local downloaded=false
+    guard_install_paths "$temp_path"
     if command -v curl &> /dev/null; then
         if curl -fsSL "${CURL_EXTRA_OPTS[@]}" --connect-timeout "$CONNECT_TIMEOUT" --max-time "$CURL_TIMEOUT" "$url" -o "$temp_path" 2>/dev/null; then
             downloaded=true
@@ -758,7 +775,7 @@ download_utility() (
 
     # These sound tools do not implement --version; do not launch audio/device
     # enumeration to validate an optional download.
-    if [ "$downloaded" = true ] && chmod +x "$temp_path" &&
+    if [ "$downloaded" = true ] && guard_install_paths "$temp_path" && chmod +x "$temp_path" &&
        utility_usable "$temp_path" && guard_install_paths "$util_path" && mv -f "$temp_path" "$util_path"; then
         echo -e "${GREEN}✓${NC} ${util_name} downloaded"
         return 0
@@ -834,6 +851,7 @@ EOF
 
 # Download checksums file
 download_checksums() {
+    guard_download_paths "$CHECKSUMS_PATH"
     echo -e "${BLUE}📝 Downloading checksums...${NC}"
 
     if command -v curl &> /dev/null; then
@@ -852,9 +870,12 @@ download_checksums() {
 }
 
 # Download binary with progress bar
-download_binary() {
+download_binary() (
     local url="${RELEASE_URL}/${BINARY_NAME}"
-    local error_log="${TMPDIR:-${TEMP:-/tmp}}/install-error-$$.log"
+    diagnostic_stage=$(mktemp -d "${TMPDIR:-${TEMP:-/tmp}}/install-diagnostic.XXXXXX") || return 1
+    trap 'rm -rf "$diagnostic_stage"; cleanup_install_config' EXIT
+    local error_log="$diagnostic_stage/error.log"
+    guard_download_paths "$BINARY_PATH"
     local http_code=""
     local curl_exit_code=0
     local curl_error=""
@@ -867,6 +888,7 @@ download_binary() {
     # Try curl first (with progress bar)
     if command -v curl &> /dev/null; then
         # Use a progress bar only for the first attempt; retry failures with clean stderr.
+        guard_download_paths "$BINARY_PATH"
         http_code=$(curl -w "%{http_code}" -fL "${CURL_EXTRA_OPTS[@]}" --connect-timeout "$CONNECT_TIMEOUT" --progress-bar --max-time "$CURL_TIMEOUT" \
             "$url" -o "$BINARY_PATH" 2>"$error_log") || curl_exit_code=$?
 
@@ -877,6 +899,7 @@ download_binary() {
         fi
 
         # Analyze failure
+        guard_download_paths "$BINARY_PATH"
         rm -f "$BINARY_PATH"
         if [ -f "$error_log" ]; then
             curl_error=$(<"$error_log")
@@ -894,9 +917,11 @@ download_binary() {
 
         if [ "$should_retry" = true ]; then
             echo -e "${YELLOW}  Retrying once with compatibility mode...${NC}"
+            guard_download_paths "$BINARY_PATH"
             rm -f "$error_log" "$BINARY_PATH"
 
             curl_exit_code=0
+            guard_download_paths "$BINARY_PATH"
             http_code=$(curl -w "%{http_code}" -fL "${CURL_EXTRA_OPTS[@]}" "${CURL_COMPAT_OPTS[@]}" --connect-timeout "$CONNECT_TIMEOUT" -sS --max-time "$CURL_TIMEOUT" \
                 "$url" -o "$BINARY_PATH" 2>"$error_log") || curl_exit_code=$?
 
@@ -906,6 +931,7 @@ download_binary() {
                 return 0
             fi
 
+            guard_download_paths "$BINARY_PATH"
             rm -f "$BINARY_PATH"
             if [ -f "$error_log" ]; then
                 curl_error=$(<"$error_log")
@@ -952,6 +978,7 @@ download_binary() {
     # Fallback to wget
     elif command -v wget &> /dev/null; then
         # Capture wget errors
+        guard_download_paths "$BINARY_PATH"
         if wget --show-progress --timeout=$WGET_TIMEOUT "$url" -O "$BINARY_PATH" 2>"$error_log"; then
             if [ -f "$BINARY_PATH" ] && [ "$(get_file_size "$BINARY_PATH")" -gt 100000 ]; then
                 rm -f "$error_log"
@@ -961,6 +988,7 @@ download_binary() {
         fi
 
         local wget_error=$(cat "$error_log" 2>/dev/null)
+        guard_download_paths "$BINARY_PATH"
         rm -f "$BINARY_PATH" "$error_log"
 
         echo ""
@@ -978,7 +1006,7 @@ download_binary() {
         echo -e "${YELLOW}Please install curl or wget and try again${NC}" >&2
         return 1
     fi
-}
+)
 
 # Verify checksum
 verify_checksum() {
@@ -1023,6 +1051,7 @@ verify_checksum() {
         echo -e "${RED}  Got:      ${actual_sum}${NC}" >&2
         print_unexpected_payload_diagnostics "$BINARY_PATH"
         echo -e "${YELLOW}The downloaded file may be corrupted. Try again.${NC}" >&2
+        guard_download_paths "$BINARY_PATH"
         rm -f "$BINARY_PATH"
         return 1
     fi
@@ -1042,6 +1071,7 @@ verify_binary() {
         echo -e "${RED}✗ Downloaded file too small (${size} bytes)${NC}" >&2
         echo -e "${YELLOW}This might be an error page. Check your internet connection.${NC}" >&2
         print_unexpected_payload_diagnostics "$BINARY_PATH"
+        guard_download_paths "$BINARY_PATH"
         rm -f "$BINARY_PATH"
         return 1
     fi
@@ -1060,6 +1090,7 @@ verify_binary() {
 # nominally successful download, which can happen when a proxy/CDN returns an
 # unexpected payload with HTTP 200.
 download_and_verify_binary() {
+    guard_download_paths "$BINARY_PATH" "$CHECKSUMS_PATH"
     if [ -n "${INSTALL_STAGED_ASSETS:-}" ] && [ -f "$INSTALL_STAGED_ASSETS/$BINARY_NAME" ]; then
         cp "$INSTALL_STAGED_ASSETS/$BINARY_NAME" "$BINARY_PATH" || return 1
         cp "$INSTALL_STAGED_ASSETS/checksums.txt" "$CHECKSUMS_PATH" || return 1
@@ -1085,6 +1116,7 @@ download_and_verify_binary() {
             return 0
         fi
 
+        guard_download_paths "$BINARY_PATH"
         rm -f "$BINARY_PATH"
 
         if [ $attempt -lt $MAX_RETRIES ]; then
@@ -1114,6 +1146,7 @@ verify_executable() {
         echo -e "${RED}✗ Binary failed to execute (exit code: ${exit_code})${NC}" >&2
         echo -e "${RED}  Output: ${output}${NC}" >&2
         echo -e "${YELLOW}The downloaded file may be corrupted or incompatible.${NC}" >&2
+        guard_download_paths "$BINARY_PATH"
         rm -f "$BINARY_PATH"
         return 1
     fi
@@ -1123,6 +1156,7 @@ verify_executable() {
         echo -e "${RED}✗ Binary output unexpected${NC}" >&2
         echo -e "${RED}  Output: ${output}${NC}" >&2
         echo -e "${YELLOW}This doesn't appear to be the correct binary.${NC}" >&2
+        guard_download_paths "$BINARY_PATH"
         rm -f "$BINARY_PATH"
         return 1
     fi
@@ -1262,6 +1296,7 @@ configure_windows_native_hooks() {
         echo -e "${GREEN}✓${NC} Windows exec-form hooks configured"
         echo -e "${YELLOW}  Restart Claude Code to apply the Windows hook update.${NC}"
     else
+        guard_install_paths "$tmp_hooks"
         rm -f "$tmp_hooks" 2>/dev/null || true
         echo -e "${YELLOW}⚠ Could not write Windows exec-form hooks${NC}"
     fi
@@ -1302,6 +1337,7 @@ download_terminal_notifier_modern() {
             sleep $RETRY_DELAY
         fi
 
+        guard_install_paths "$TEMP_ZIP"
         if command -v curl &>/dev/null; then
             if curl -fsSL "${CURL_EXTRA_OPTS[@]}" --connect-timeout "$CONNECT_TIMEOUT" --max-time "$CURL_TIMEOUT" "$MODERN_URL" -o "$TEMP_ZIP" 2>/dev/null; then
                 downloaded=true
@@ -1393,6 +1429,7 @@ download_terminal_notifier() {
             sleep $RETRY_DELAY
         fi
 
+        guard_install_paths "$TEMP_ZIP"
         if command -v curl &>/dev/null; then
             if curl -fsSL "${CURL_EXTRA_OPTS[@]}" --connect-timeout "$CONNECT_TIMEOUT" --max-time "$CURL_TIMEOUT" "$NOTIFIER_URL" -o "$TEMP_ZIP" 2>/dev/null; then
                 downloaded=true
@@ -1468,7 +1505,7 @@ create_claude_notifications_app() {
 
     echo -e "${BLUE}🎨 Creating ClaudeNotifications.app (notification icon)...${NC}"
 
-    guard_install_paths "$APP_DIR" "${TMPDIR:-${TEMP:-/tmp}}/claude-$$.iconset" \
+    guard_install_paths "$APP_DIR" \
         "$APP_DIR/Contents/Info.plist" "$APP_DIR/Contents/MacOS/claude-notify" \
         "$APP_DIR/Contents/Resources/AppIcon.icns"
     # Create app structure
@@ -1476,8 +1513,10 @@ create_claude_notifications_app() {
     mkdir -p "$APP_DIR/Contents/Resources"
 
     # Create iconset from PNG
-    local ICONSET_DIR="${TMPDIR:-${TEMP:-/tmp}}/claude-$$.iconset"
-    mkdir -p "$ICONSET_DIR"
+    local ICONSET_ROOT ICONSET_DIR
+    ICONSET_ROOT=$(mktemp -d "${TMPDIR:-${TEMP:-/tmp}}/claude-iconset.XXXXXX") || return 1
+    ICONSET_DIR="$ICONSET_ROOT/claude.iconset"
+    mkdir "$ICONSET_DIR" || return 1
 
     # Generate different icon sizes (silence sips stdout/stderr)
     sips -z 16 16 "$ICON_SRC" --out "$ICONSET_DIR/icon_16x16.png" >/dev/null 2>&1
@@ -1494,13 +1533,13 @@ create_claude_notifications_app() {
     guard_install_paths "$APP_DIR/Contents/Resources/AppIcon.icns"
     if ! iconutil -c icns "$ICONSET_DIR" -o "$APP_DIR/Contents/Resources/AppIcon.icns" 2>/dev/null; then
         echo -e "${YELLOW}⚠ Could not create app icon${NC}"
-        guard_install_paths "$ICONSET_DIR" "$APP_DIR"
-        rm -rf "$ICONSET_DIR" "$APP_DIR"
+        guard_install_paths "$ICONSET_ROOT" "$APP_DIR"
+        rm -rf "$ICONSET_ROOT" "$APP_DIR"
         return 1
     fi
 
-    guard_install_paths "$ICONSET_DIR"
-    rm -rf "$ICONSET_DIR"
+    guard_install_paths "$ICONSET_ROOT"
+    rm -rf "$ICONSET_ROOT"
 
     # Create Info.plist
     guard_install_paths "$APP_DIR/Contents/Info.plist"
@@ -1584,21 +1623,47 @@ setup_iterm2_venv() {
     echo ""
     echo -e "${BLUE}  Setting up iTerm2 tmux -CC support...${NC}"
 
+    # Never run venv or pip against existing children: they may alias the
+    # selected config in the reverse direction (e.g. pyvenv.cfg -> config).
     guard_install_paths "$VENV_DIR"
-    if ! "$python3_path" -m venv "$VENV_DIR" 2>/dev/null; then
-        echo -e "${YELLOW}  ⚠ Could not create Python venv, skipping${NC}"
+    local venv_stage
+    venv_stage=$(mktemp -d "${TMPDIR:-${TEMP:-/tmp}}/iterm-venv.XXXXXX") || return 1
+    if ! "$python3_path" -m venv "$venv_stage/venv" 2>/dev/null ||
+       ! "$venv_stage/venv/bin/pip" install --quiet iterm2 2>/dev/null; then
+        guard_install_paths "$venv_stage"
+        rm -rf "$venv_stage"
+        echo -e "${YELLOW}  ⚠ Could not install iterm2 module${NC}"
         return 0
     fi
-
-    guard_install_paths "$VENV_DIR"
-    if "$VENV_DIR/bin/pip" install --quiet iterm2 2>/dev/null; then
-        echo -e "${GREEN}  ✓${NC} iTerm2 Python API support installed"
-        echo -e "${BLUE}    Enable 'Python API' in iTerm2 → Settings → General → Magic${NC}"
-    else
-        echo -e "${YELLOW}  ⚠ Could not install iterm2 module${NC}"
-        guard_install_paths "$VENV_DIR"
-        rm -rf "$VENV_DIR" 2>/dev/null
+    # venv entry points and activation scripts embed their creation path.
+    if ! "$python3_path" -I - "$venv_stage/venv" "$VENV_DIR" <<'PYVENV'
+import os, sys
+old, new = sys.argv[1:]
+for name in os.listdir(os.path.join(old, 'bin')):
+    path = os.path.join(old, 'bin', name)
+    if os.path.islink(path) or not os.path.isfile(path):
+        continue
+    with open(path, 'rb') as f:
+        data = f.read()
+    if b'\0' not in data and old.encode() in data:
+        with open(path, 'wb') as f:
+            f.write(data.replace(old.encode(), new.encode()))
+PYVENV
+    then
+        guard_install_paths "$venv_stage"
+        rm -rf "$venv_stage"
+        return 1
     fi
+    # Recheck after pip and immediately before removing the broken live tree.
+    # On rejection retain the private stage too: a changed config alias may
+    # now select it. Never let cleanup remove the selected file.
+    guard_install_paths "$VENV_DIR" "$venv_stage"
+    mkdir -p "$(dirname "$VENV_DIR")" || return 1
+    rm -rf "$VENV_DIR" || return 1
+    mv "$venv_stage/venv" "$VENV_DIR" || return 1
+    rmdir "$venv_stage"
+    echo -e "${GREEN}  ✓${NC} iTerm2 Python API support installed"
+    echo -e "${BLUE}    Enable 'Python API' in iTerm2 → Settings → General → Magic${NC}"
 }
 
 # Install GNOME activate-window-by-title extension for Linux click-to-focus
@@ -1688,6 +1753,7 @@ install_gnome_activate_window_extension() {
             sleep $RETRY_DELAY
         fi
 
+        guard_install_paths "$temp_zip"
         if command -v curl &>/dev/null; then
             if curl -fsSL "${CURL_EXTRA_OPTS[@]}" --connect-timeout "$CONNECT_TIMEOUT" --max-time "$CURL_TIMEOUT" "https://extensions.gnome.org${download_url}" -o "$temp_zip" 2>/dev/null; then
                 downloaded=true
@@ -1803,6 +1869,7 @@ stage_and_promote_runtime() (
     trap 'exit 143' TERM
 
     SCRIPT_DIR="$stage"
+    INSTALL_PRIVATE_DOWNLOAD=true
     REQUIRE_CHECKSUM=true
     detect_platform
     download_and_verify_binary || exit 1

--- a/bin/install_config_native_test.sh
+++ b/bin/install_config_native_test.sh
@@ -50,7 +50,7 @@ if [ "$PLATFORM" != windows ]; then
     tmux() { :; }
     TERM_PROGRAM=iTerm.app
     python3() {
-        if [ "$1" = -I ]; then command python3 "$@"; return; fi
+        if [ "$1" = -I ]; then command python3 "$@"; return $?; fi
         mkdir -p "$3/bin"
         printf created > "$3/pyvenv.cfg"
         printf '#!/bin/sh\nexit 0\n' > "$3/bin/pip"
@@ -81,7 +81,7 @@ if [ "$PLATFORM" != windows ]; then
         if [ "$kind" = config ]; then
             (
                 INSTALL_CONFIG_STAGE=$(mktemp -d "$TMPDIR/native-stage.XXXXXX")
-                INSTALL_CONFIG_STAGE_OWNER=$BASH_SUBSHELL
+                INSTALL_CONFIG_STAGE_OWNER="${BASHPID:-$BASH_SUBSHELL}"
                 trap 'cleanup_install_config' EXIT
                 printf '{}' > "$INSTALL_CONFIG_STAGE/config.json"
                 rm "$selected"
@@ -110,7 +110,7 @@ if [ "$PLATFORM" != windows ]; then
     export AGENT_NOTIFICATIONS_CONFIG="$selected"
     rm -rf "$venv"
     python3() {
-        if [ "$1" = -I ]; then command python3 "$@"; return; fi
+        if [ "$1" = -I ]; then command python3 "$@"; return $?; fi
         mkdir -p "$3/bin"
         printf '{"path":"%s"}' "$3" > "$3/bin/config.json"
         cp "$3/bin/config.json" "$sandbox/before.json"
@@ -128,7 +128,7 @@ if [ "$PLATFORM" != windows ]; then
     export HOME="$sandbox/home with spaces"
     venv="$HOME/.claude/claude-notifications-go/iterm2-venv"
     python3() {
-        if [ "$1" = -I ]; then command python3 "$@"; return; fi
+        if [ "$1" = -I ]; then command python3 "$@"; return $?; fi
         command python3 -m venv --without-pip "$3" || return 1
         local site
         site=$("$3/bin/python3" -c 'import sysconfig; print(sysconfig.get_path("purelib"))')

--- a/bin/install_config_native_test.sh
+++ b/bin/install_config_native_test.sh
@@ -73,8 +73,60 @@ if [ "$PLATFORM" != windows ]; then
         [ ! -L "$venv/$child" ]
         echo "PASS: real helper and private venv preserve reverse $child alias"
     done
+    # Recheck both stage cleanup owners against native Store alias identity.
+    selected="$sandbox/selected-alias"
+    for kind in config runtime; do
+        ln -s "$sandbox/config.json" "$selected"
+        export AGENT_NOTIFICATIONS_CONFIG="$selected"
+        if [ "$kind" = config ]; then
+            (
+                INSTALL_CONFIG_STAGE=$(mktemp -d "$TMPDIR/native-stage.XXXXXX")
+                INSTALL_CONFIG_STAGE_OWNER=$BASH_SUBSHELL
+                trap 'cleanup_install_config' EXIT
+                printf '{}' > "$INSTALL_CONFIG_STAGE/config.json"
+                rm "$selected"
+                ln -s "$INSTALL_CONFIG_STAGE/config.json" "$selected"
+            )
+        else
+            (
+                download_and_verify_binary() { cp "$sandbox/helper.exe" "$BINARY_PATH"; }
+                verify_executable() { :; }
+                install_linux_notification_desktop_entry() {
+                    printf '{}' > "$stage/config.json"
+                    rm "$selected"
+                    ln -s "$stage/config.json" "$selected"
+                    exit 0
+                }
+                unset -f uname
+                stage_and_promote_runtime
+            )
+        fi
+        [ "$(cat "$selected")" = '{}' ]
+        rm "$selected"
+        echo "PASS: native $kind cleanup retains newly selected stage"
+    done
+    # Successful pip must not rewrite the newly selected staged JSON.
+    ln -s "$sandbox/config.json" "$selected"
+    export AGENT_NOTIFICATIONS_CONFIG="$selected"
+    rm -rf "$venv"
+    python3() {
+        if [ "$1" = -I ]; then command python3 "$@"; return; fi
+        mkdir -p "$3/bin"
+        printf '{"path":"%s"}' "$3" > "$3/bin/config.json"
+        cp "$3/bin/config.json" "$sandbox/before.json"
+        printf '#!/bin/sh\nexit 0\n' > "$3/bin/pip"
+        chmod +x "$3/bin/pip"
+        rm "$selected"
+        ln -s "$3/bin/config.json" "$selected"
+    }
+    if (setup_iterm2_venv); then exit 1; else [ "$?" = 78 ]; fi
+    cmp "$selected" "$sandbox/before.json"
+    export AGENT_NOTIFICATIONS_CONFIG="$sandbox/config.json"
+    echo 'PASS: native successful pip guard preserves staged JSON bytes'
     # Build a real offline venv and a local stand-in for the iterm2 package.
     # This verifies that moved Python and rewritten entry points still run.
+    export HOME="$sandbox/home with spaces"
+    venv="$HOME/.claude/claude-notifications-go/iterm2-venv"
     python3() {
         if [ "$1" = -I ]; then command python3 "$@"; return; fi
         command python3 -m venv --without-pip "$3" || return 1
@@ -82,12 +134,15 @@ if [ "$PLATFORM" != windows ]; then
         site=$("$3/bin/python3" -c 'import sysconfig; print(sysconfig.get_path("purelib"))')
         printf '# local test module\n' > "$site/iterm2.py"
         printf '#!%s/bin/python3\nimport sys\nsys.exit(0)\n' "$3" > "$3/bin/pip"
-        chmod +x "$3/bin/pip"
+        printf '#!/bin/sh\nexec "%s/bin/python3" -c '\''import iterm2; print("shell entry OK")'\'' "$@"\n' "$3" > "$3/bin/shell-entry"
+        chmod +x "$3/bin/pip" "$3/bin/shell-entry"
     }
     rm -rf "$venv"
     setup_iterm2_venv
     "$venv/bin/python3" -c 'import iterm2'
     "$venv/bin/pip" --version
+    "$venv/bin/shell-entry"
+    ( . "$venv/bin/activate"; [ "$VIRTUAL_ENV" = "$venv" ]; command python3 -c 'import iterm2' )
     grep -F "$venv" "$venv/bin/activate" >/dev/null
     echo 'PASS: real offline venv Python, entry point, and activation survive promotion'
 

--- a/bin/install_config_native_test.sh
+++ b/bin/install_config_native_test.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+# Real protocol fixture, including Git Bash cygpath -> native Python -> Go.
+TEST_ENV_HANDOFF_GOMODCACHE=1
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/test-env.sh"
+test_env_enter "$0" "$@"
+set -eo pipefail
+root=$(cd "$(dirname "$0")" && pwd)
+sandbox=$(mktemp -d)
+trap 'rm -rf "$sandbox"' EXIT
+test_env_setup "$sandbox"
+(cd "$root/.." && go build -o "$sandbox/helper.exe" ./cmd/claude-notifications)
+sed '/^main "\$@"$/d' "$root/install.sh" > "$sandbox/functions.sh"
+export INSTALL_TARGET_DIR="$sandbox/live"
+source "$sandbox/functions.sh"
+# Sourcing the installer installs its own trap.
+trap 'cleanup_install_config; rm -rf "$sandbox"' EXIT
+detect_platform
+INSTALL_CONFIG_HELPER="$sandbox/helper.exe"
+printf '{}' > "$sandbox/config.json"
+export AGENT_NOTIFICATIONS_CONFIG="$sandbox/config.json"
+if [ "$PLATFORM" = windows ]; then
+    AGENT_NOTIFICATIONS_CONFIG=$(cygpath -aw "$AGENT_NOTIFICATIONS_CONFIG")
+fi
+guard_install_paths "$SCRIPT_DIR"
+echo 'PASS: real native helper accepts independent config'
+if (guard_install_paths "$sandbox/config.json"); then
+    echo 'FAIL: accepted selected file mutation' >&2; exit 1
+else
+    [ "$?" = 78 ]
+fi
+[ "$(cat "$sandbox/config.json")" = '{}' ]
+echo 'PASS: real native helper rejects selected file mutation'
+export AGENT_NOTIFICATIONS_CONFIG="$SCRIPT_DIR/missing.json"
+if [ "$PLATFORM" = windows ]; then
+    AGENT_NOTIFICATIONS_CONFIG=$(cygpath -aw "$AGENT_NOTIFICATIONS_CONFIG")
+fi
+if (guard_install_paths "$SCRIPT_DIR"); then
+    echo 'FAIL: accepted missing selected child' >&2; exit 1
+else
+    [ "$?" = 78 ]
+fi
+[ ! -e "$SCRIPT_DIR/missing.json" ]
+echo 'PASS: real native helper rejects missing selected child'
+# Reverse child aliases are safe to unlink only after private construction.
+# POSIX symlink creation is optional on Windows; protocol tests above are native.
+if [ "$PLATFORM" != windows ]; then
+    export AGENT_NOTIFICATIONS_CONFIG="$sandbox/config.json"
+    venv="$HOME/.claude/claude-notifications-go/iterm2-venv"
+    uname() { echo Darwin; }
+    tmux() { :; }
+    TERM_PROGRAM=iTerm.app
+    python3() {
+        if [ "$1" = -I ]; then command python3 "$@"; return; fi
+        mkdir -p "$3/bin"
+        printf created > "$3/pyvenv.cfg"
+        printf '#!/bin/sh\nexit 0\n' > "$3/bin/pip"
+        chmod +x "$3/bin/pip"
+    }
+    for child in pyvenv.cfg bin; do
+        rm -rf "$venv"
+        mkdir -p "$venv"
+        if [ "$child" = bin ]; then
+            mkdir -p "$sandbox/protected-bin"
+            printf '{}' > "$sandbox/protected-bin/python3"
+            AGENT_NOTIFICATIONS_CONFIG="$sandbox/protected-bin/python3"
+            ln -s "$sandbox/protected-bin" "$venv/bin"
+        else
+            AGENT_NOTIFICATIONS_CONFIG="$sandbox/config.json"
+            ln -s "$AGENT_NOTIFICATIONS_CONFIG" "$venv/pyvenv.cfg"
+        fi
+        setup_iterm2_venv
+        [ "$(cat "$AGENT_NOTIFICATIONS_CONFIG")" = '{}' ]
+        [ ! -L "$venv/$child" ]
+        echo "PASS: real helper and private venv preserve reverse $child alias"
+    done
+    # Build a real offline venv and a local stand-in for the iterm2 package.
+    # This verifies that moved Python and rewritten entry points still run.
+    python3() {
+        if [ "$1" = -I ]; then command python3 "$@"; return; fi
+        command python3 -m venv --without-pip "$3" || return 1
+        local site
+        site=$("$3/bin/python3" -c 'import sysconfig; print(sysconfig.get_path("purelib"))')
+        printf '# local test module\n' > "$site/iterm2.py"
+        printf '#!%s/bin/python3\nimport sys\nsys.exit(0)\n' "$3" > "$3/bin/pip"
+        chmod +x "$3/bin/pip"
+    }
+    rm -rf "$venv"
+    setup_iterm2_venv
+    "$venv/bin/python3" -c 'import iterm2'
+    "$venv/bin/pip" --version
+    grep -F "$venv" "$venv/bin/activate" >/dev/null
+    echo 'PASS: real offline venv Python, entry point, and activation survive promotion'
+
+fi

--- a/bin/install_config_preflight_test.sh
+++ b/bin/install_config_preflight_test.sh
@@ -1,0 +1,233 @@
+#!/bin/bash
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/test-env.sh"
+test_env_enter "$0" "$@"
+# Disposable adapter tests. The helper models the CLI protocol; native Store
+# identity behavior is covered by internal/config/preflight_test.go.
+set -eo pipefail
+root=$(cd "$(dirname "$0")" && pwd)
+sandbox=$(mktemp -d)
+trap 'rm -rf "$sandbox"' EXIT
+test_env_setup "$sandbox"
+python3 - "$root" "$sandbox" <<'PY'
+import json, os, pathlib, shlex, shutil, subprocess, sys
+root, box = map(pathlib.Path, sys.argv[1:])
+functions = box/'functions.sh'
+functions.write_text((root/'install.sh').read_text().replace('main "$@"', ''))
+helper = box/'helper'
+helper.write_text("""#!/usr/bin/env python3
+import json,os,sys
+if sys.argv[1:]==['--version']:
+    print('claude-notifications 0.0.1'); sys.exit(0)
+assert sys.argv[1:]==['config','preflight-update','--stdin','--json']
+r=json.load(sys.stdin)
+with open(os.environ['TRACE'],'a') as f: f.write(json.dumps(r)+'\\n')
+e=os.environ.get('AGENT_NOTIFICATIONS_CONFIG','')
+status='safe'; code=''
+if e and not os.path.isabs(e): status='invalid-config'; code='ConfigOverrideInvalid'
+elif e:
+    e=os.path.realpath(e)
+    for p in r['refreshDirs']:
+        assert os.path.isabs(p)
+        p=os.path.realpath(p)
+        if e==p or e.startswith(p+os.sep) or (os.path.isfile(e) and os.path.isfile(p) and os.path.samefile(e,p)):
+            status='unsafe-target'; code='ConfigUnsafeTarget'; break
+print(json.dumps(dict(status=status,diagnostics=[dict(code=code,path='SECRET-CANARY')])))
+sys.exit(0 if status=='safe' else 1)
+""")
+helper.chmod(0o755)
+q=lambda p: shlex.quote(str(p))
+# Fail safely even if a regression removes a guard.
+isolation="""
+curl() { echo 'unexpected network request' >&2; return 99; }
+wget() { echo 'unexpected network request' >&2; return 99; }
+python3() {
+    if [ "$1" = -I ]; then command python3 "$@"; return; fi
+    echo 'unexpected Python environment creation' >&2
+    return 99
+}
+"""
+
+def run(name, body, e=None, ok=True):
+    case=box/name; case.mkdir()
+    env=dict(os.environ, INSTALL_TARGET_DIR=str(case), TRACE=str(case/'trace'))
+    if e is not None: env['AGENT_NOTIFICATIONS_CONFIG']=str(e)
+    script='source '+q(functions)+'\ndetect_platform\nINSTALL_CONFIG_HELPER='+q(helper)+'\n'+isolation+body
+    r=subprocess.run(['bash','-c',script],env=env,capture_output=True,timeout=30)
+    assert (r.returncode==0)==ok,(name,r.returncode,r.stderr.decode())
+    assert b'SECRET-CANARY' not in r.stdout+r.stderr
+    print('PASS:',name)
+    return case,r
+
+venv=pathlib.Path(os.environ['HOME'])/'.claude/claude-notifications-go/iterm2-venv'
+venv.mkdir(parents=True)
+config=venv/'config.json'; config.write_text('SECRET-CANARY')
+iterm="""
+uname() { echo Darwin; }
+tmux() { :; }
+TERM_PROGRAM=iTerm.app
+setup_iterm2_venv
+"""
+run('iterm-overlap',iterm,config,False)
+assert config.read_text()=='SECRET-CANARY'
+alias=box/'venv-alias'; alias.symlink_to(venv,target_is_directory=True)
+run('iterm-alias',iterm,alias/'config.json',False)
+hard=box/'config-hardlink'; os.link(config,hard)
+run('hardlink-target','guard_install_paths '+q(hard),config,False)
+for name,body,target in [
+    ('modern-app','download_terminal_notifier_modern', 'ClaudeNotifier.app/config.json'),
+    ('legacy-app','download_terminal_notifier', 'terminal-notifier.app/config.json'),
+    ('icon-app','create_claude_notifications_app', 'ClaudeNotifications.app/Contents/Info.plist'),
+]:
+    (box/'claude_icon.png').write_bytes(b'fixture')
+    run(name,body,box/name/target,False)
+# Extension CLI and downloads are explicit stubs with no desktop effects.
+extension=pathlib.Path(os.environ['XDG_DATA_HOME'])/'gnome-shell/extensions/activate-window-by-title@lucaswerkmeister.de'
+run('gnome-extension',"""
+gnome-shell() { echo 'GNOME Shell 46.0'; }
+gnome-extensions() { [ "$1" != install ] || touch "$SCRIPT_DIR/unexpected"; }
+curl() { printf '{"download_url":"/fixture.zip"}'; }
+install_gnome_activate_window_extension
+""",extension/'config.json',False)
+assert not (box/'gnome-extension/unexpected').exists()
+# No-op exits must not require a protocol or contact a release server.
+run('iterm-noop','CN_PRODUCT=codex; INSTALL_CONFIG_HELPER=/missing; '+iterm,config)
+outside=box/'outside.json'; outside.write_text('{}')
+for name,code in [
+ ('runtime','guard_install_paths "$SCRIPT_DIR"; touch "$SCRIPT_DIR/mutated"'),
+ ('utility','printf old > "$SCRIPT_DIR/sound-preview"; create_utility_symlink sound-preview x "$SCRIPT_DIR/sound-preview"'),
+ ('windows-hooks','PLATFORM=windows; cygpath() { printf "%s\\n" "$2"; }; windows_hooks_path() { echo "$SCRIPT_DIR/hooks.json"; }; windows_native_hooks_json() { echo "{}"; }; windows_native_hooks_are_exec_form() { :; }; touch "$BINARY_PATH" "$SCRIPT_DIR/hooks.json"; configure_windows_native_hooks'),
+ ('linux-desktop','PLATFORM=linux; install_linux_notification_desktop_entry'),
+]:
+    target=box/(name+'-reject')/('sound-preview' if name=='utility' else 'hooks.json' if name=='windows-hooks' else 'config.json')
+    if name=='linux-desktop': target=pathlib.Path(os.environ['XDG_DATA_HOME'])/'applications/claude-notifications.desktop'
+    run(name+'-reject',code,target,False)
+    run(name+'-safe',code,outside)
+run('relative','guard_install_paths "$SCRIPT_DIR"', 'relative.json',False)
+run('absent','INSTALL_CONFIG_HELPER=/missing; guard_install_paths "$SCRIPT_DIR"')
+run('missing-explicit-safe','guard_install_paths "$SCRIPT_DIR"',box/'missing.json')
+# The old helper cannot authorize anything. Only verified staging may replace it.
+stage_body="""
+INSTALL_CONFIG_HELPER=/missing
+pin_release_urls() { :; }
+download_and_verify_binary() {
+    cp @HELPER@ "$BINARY_PATH"
+    printf checksum > "$CHECKSUMS_PATH"
+}
+verify_executable() { :; }
+guard_install_paths "$SCRIPT_DIR"
+[ -n "$INSTALL_CONFIG_STAGE" ]
+[ -f "$INSTALL_STAGED_ASSETS/checksums.txt" ]
+""".replace('@HELPER@',q(helper))
+run('old-staged',stage_body,outside)
+run('old-staged-reject',stage_body,box/'old-staged-reject/config.json',False)
+run('old-unavailable','INSTALL_CONFIG_HELPER=/missing; pin_release_urls() { :; }; download_and_verify_binary() { return 1; }; guard_install_paths "$SCRIPT_DIR"',outside,False)
+case,r=run('old-known-offline',"""
+INSTALL_CONFIG_HELPER=/missing
+OFFLINE_MODE=true
+download_and_verify_binary() { touch "$SCRIPT_DIR/unexpected-download"; }
+guard_install_paths "$SCRIPT_DIR"
+""",outside,False)
+assert not (case/'unexpected-download').exists()
+# Force/offline keeps the old runtime without fetching a config helper.
+run('offline-noop',"""
+INSTALL_CONFIG_HELPER=/missing
+FORCE_UPDATE=true
+touch "$BINARY_PATH"
+abort_if_wsl_environment() { :; }
+check_required_tools() { :; }
+check_github_availability() { OFFLINE_MODE=true; }
+main
+""",outside)
+# Exercise the actual wrapper's lazy installer suppression and retained binary.
+case=box/'lazy'; case.mkdir()
+shutil.copy(root/'hook-wrapper.sh',case/'hook-wrapper.sh')
+binary=case/'claude-notifications'
+binary.write_text('#!/bin/sh\nif [ "$1" = version ]; then echo "claude-notifications 0.0.1"; fi\n')
+binary.chmod(0o755)
+plugin=box/'.claude-plugin'; plugin.mkdir()
+(plugin/'plugin.json').write_text('{"version":"9.9.9"}')
+installer=case/'install.sh'
+installer.write_text('#!/bin/bash\nsource '+q(functions)+'\ndetect_platform\nINSTALL_CONFIG_HELPER='+q(helper)+'\n'+isolation+iterm)
+installer.chmod(0o755)
+env=dict(os.environ,AGENT_NOTIFICATIONS_CONFIG=str(config),TRACE=str(case/'trace'))
+before=binary.read_bytes()
+r=subprocess.run(['sh',str(case/'hook-wrapper.sh'),'Stop'],env=env,input=b'{}',capture_output=True,timeout=30)
+assert r.returncode==0 and r.stdout==b'' and r.stderr==b'',r
+assert binary.read_bytes()==before and config.read_text()=='SECRET-CANARY'
+assert (case/'trace').exists()
+print('PASS: actual hook-wrapper lazy rejection is silent and preserves runtime')
+# Real transaction must use the new staged protocol and preserve live bytes.
+for overlap in (True,False):
+    name='promotion-reject' if overlap else 'promotion-safe'
+    target=box/name/'claude-notifications-linux-amd64' if overlap else outside
+    case,r=run(name,"""
+detect_platform() {
+    PLATFORM=linux ARCH=amd64 BINARY_NAME=claude-notifications-linux-amd64
+    BINARY_PATH="$SCRIPT_DIR/$BINARY_NAME"
+    CHECKSUMS_PATH="$SCRIPT_DIR/.checksums.txt"
+}
+detect_platform
+printf old-runtime > "$BINARY_PATH"
+INSTALL_CONFIG_HELPER=/old-without-protocol
+download_and_verify_binary() { cp @HELPER@ "$BINARY_PATH"; }
+verify_executable() { :; }
+install_linux_notification_desktop_entry() { :; }
+stage_and_promote_runtime
+""".replace('@HELPER@',q(helper)),target,not overlap)
+    assert (case/'claude-notifications-linux-amd64').read_bytes()==(b'old-runtime' if overlap else helper.read_bytes())
+# A config rejection from the optional downloader must not become success.
+run('optional-rejection',"""
+download_utility() ( guard_install_paths "$SCRIPT_DIR"; )
+download_utilities
+""",box/'optional-rejection/config.json',False)
+# Drive main with network/platform effects replaced, retaining real resource code.
+run('direct-main',"""
+abort_if_wsl_environment() { :; }
+check_required_tools() { :; }
+check_existing() { return 0; }
+create_symlink() { :; }
+configure_windows_native_hooks() { :; }
+download_utilities() { :; }
+create_claude_notifications_app() { :; }
+detect_platform() { PLATFORM=darwin; ARCH=amd64; BINARY_NAME=fixture; BINARY_PATH="$SCRIPT_DIR/fixture"; }
+uname() { echo Darwin; }
+tmux() { :; }
+TERM_PROGRAM=iTerm.app
+main
+""",config,False)
+assert config.read_text()=='SECRET-CANARY'
+# Real venv setup/failed-pip cleanup with only Python creation and pip stubbed.
+run('pip-failure-safe',"""
+uname() { echo Darwin; }
+tmux() { :; }
+TERM_PROGRAM=iTerm.app
+python3() {
+    if [ "$1" = -I ]; then command python3 "$@"; return; fi
+    mkdir -p "$3/bin"
+    printf '#!/bin/sh\\nexit 1\\n' > "$3/bin/pip"
+    chmod +x "$3/bin/pip"
+}
+setup_iterm2_venv
+""",outside)
+assert not venv.exists()
+print('PASS: non-overlap pip failure follows existing cleanup behavior')
+# Change a directory alias during pip, then require a fresh preflight before rm.
+late=box/'late-alias'; late.symlink_to(box/'initially-missing',target_is_directory=True)
+body="""
+uname() { echo Darwin; }
+tmux() { :; }
+TERM_PROGRAM=iTerm.app
+python3() {
+    if [ "$1" = -I ]; then command python3 "$@"; return; fi
+    mkdir -p "$3/bin"
+    printf '#!/bin/sh\\nrm @ALIAS@\\nln -s @VENV@ @ALIAS@\\nprintf protected > @VENV@/config.json\\nexit 1\\n' > "$3/bin/pip"
+    chmod +x "$3/bin/pip"
+}
+setup_iterm2_venv
+""".replace('@ALIAS@',str(late)).replace('@VENV@',str(venv))
+run('pip-late-alias',body,late/'config.json',False)
+assert (venv/'config.json').read_text()=='protected'
+print('PASS: post-pip overlap blocks recursive cleanup')
+
+
+PY

--- a/bin/install_config_preflight_test.sh
+++ b/bin/install_config_preflight_test.sh
@@ -47,7 +47,7 @@ isolation="""
 curl() { echo 'unexpected network request' >&2; return 99; }
 wget() { echo 'unexpected network request' >&2; return 99; }
 python3() {
-    if [ "$1" = -I ]; then command python3 "$@"; return; fi
+    if [ "$1" = -I ]; then command python3 "$@"; return $?; fi
     echo 'unexpected Python environment creation' >&2
     return 99
 }
@@ -208,7 +208,7 @@ uname() { echo Darwin; }
 tmux() { :; }
 TERM_PROGRAM=iTerm.app
 python3() {
-    if [ "$1" = -I ]; then command python3 "$@"; return; fi
+    if [ "$1" = -I ]; then command python3 "$@"; return $?; fi
     mkdir -p "$3/bin"
     printf '#!/bin/sh\\nexit 1\\n' > "$3/bin/pip"
     chmod +x "$3/bin/pip"
@@ -224,7 +224,7 @@ uname() { echo Darwin; }
 tmux() { :; }
 TERM_PROGRAM=iTerm.app
 python3() {
-    if [ "$1" = -I ]; then command python3 "$@"; return; fi
+    if [ "$1" = -I ]; then command python3 "$@"; return $?; fi
     mkdir -p "$3/bin"
     printf '#!/bin/sh\\nrm @ALIAS@\\nln -s @VENV@ @ALIAS@\\nprintf protected > @VENV@/config.json\\nexit 1\\n' > "$3/bin/pip"
     chmod +x "$3/bin/pip"
@@ -248,7 +248,7 @@ uname() { echo Darwin; }
 tmux() { :; }
 TERM_PROGRAM=iTerm.app
 python3() {
-    if [ "$1" = -I ]; then command python3 "$@"; return; fi
+    if [ "$1" = -I ]; then command python3 "$@"; return $?; fi
     mkdir -p "$3/bin"
     printf '#!/bin/sh\\nprintf protected > "%s/config.json"\\nrm @ALIAS@\\nln -s "%s" @ALIAS@\\nexit 1\\n' "$3" "$3" > "$3/bin/pip"
     chmod +x "$3/bin/pip"
@@ -264,7 +264,7 @@ uname() { echo Darwin; }
 tmux() { :; }
 TERM_PROGRAM=iTerm.app
 python3() {
-    if [ "$1" = -I ]; then command python3 "$@"; return; fi
+    if [ "$1" = -I ]; then command python3 "$@"; return $?; fi
     mkdir -p "$3/bin"
     printf '{"path":"%s"}' "$3" > "$3/bin/config.json"
     cp "$3/bin/config.json" @BEFORE@
@@ -283,7 +283,7 @@ for kind in ('config', 'runtime'):
         selected=box/('cleanup-{}-{}'.format(kind,status)); selected.symlink_to(outside)
         body="""
 INSTALL_CONFIG_STAGE=$(mktemp -d "$TMPDIR/config-stage.XXXXXX")
-INSTALL_CONFIG_STAGE_OWNER=$BASH_SUBSHELL
+INSTALL_CONFIG_STAGE_OWNER="${BASHPID:-$BASH_SUBSHELL}"
 printf protected > "$INSTALL_CONFIG_STAGE/config.json"
 ( trap 'cleanup_install_config' EXIT; : )
 [ -f "$INSTALL_CONFIG_STAGE/config.json" ] || exit 99
@@ -299,7 +299,7 @@ detect_platform() {
     CHECKSUMS_PATH="$SCRIPT_DIR/.checksums.txt"
 }
 install_linux_notification_desktop_entry() {
-    ( trap 'if [ "$stage_owner" = "$BASH_SUBSHELL" ]; then cleanup_install_stage "$stage"; fi' EXIT; : )
+    ( trap 'if [ "$stage_owner" = "${BASHPID:-$BASH_SUBSHELL}" ]; then cleanup_install_stage "$stage"; fi' EXIT; : )
     [ -f "$BINARY_PATH" ] || exit 99
     printf protected > "$stage/config.json"
     rm @ALIAS@
@@ -318,7 +318,7 @@ stage_and_promote_runtime
 for status in (0,17):
     case,r=run('clean-exit-'+str(status),"""
 INSTALL_CONFIG_STAGE=$(mktemp -d "$TMPDIR/config-stage.XXXXXX")
-INSTALL_CONFIG_STAGE_OWNER=$BASH_SUBSHELL
+INSTALL_CONFIG_STAGE_OWNER="${BASHPID:-$BASH_SUBSHELL}"
 printf '%s' "$INSTALL_CONFIG_STAGE" > "$SCRIPT_DIR/stage-path"
 exit @STATUS@
 """.replace('@STATUS@',str(status)),outside,status==0)
@@ -326,7 +326,7 @@ exit @STATUS@
     assert not pathlib.Path((case/'stage-path').read_text()).exists()
 case,r=run('cleanup-no-helper',"""
 INSTALL_CONFIG_STAGE=$(mktemp -d "$TMPDIR/config-stage.XXXXXX")
-INSTALL_CONFIG_STAGE_OWNER=$BASH_SUBSHELL
+INSTALL_CONFIG_STAGE_OWNER="${BASHPID:-$BASH_SUBSHELL}"
 INSTALL_CONFIG_HELPER=/missing
 printf '%s' "$INSTALL_CONFIG_STAGE" > "$SCRIPT_DIR/stage-path"
 exit 0
@@ -350,7 +350,7 @@ uname() { echo Darwin; }
 tmux() { :; }
 TERM_PROGRAM=iTerm.app
 python3() {
-    if [ "$1" = -I ]; then command python3 "$@"; return; fi
+    if [ "$1" = -I ]; then command python3 "$@"; return $?; fi
     mkdir -p "$3/bin"
     printf created > "$3/pyvenv.cfg"
     printf '#!/bin/sh\\nexit 0\\n' > "$3/bin/pip"

--- a/bin/install_config_preflight_test.sh
+++ b/bin/install_config_preflight_test.sh
@@ -276,6 +276,27 @@ setup_iterm2_venv
     private_alias/'config.json',False)
 assert (private_alias/'config.json').read_bytes()==(box/'before-json').read_bytes()
 
+# Rewriting a staged text file must not mutate an external hardlink selected as
+# the explicit config, even though directory overlap cannot identify that inode.
+private_alias.unlink()
+run('pip-success-private-hardlink', """
+uname() { echo Darwin; }
+tmux() { :; }
+TERM_PROGRAM=iTerm.app
+python3() {
+    if [ "$1" = -I ]; then command python3 "$@"; return $?; fi
+    mkdir -p "$3/bin"
+    printf '{"path":"%s"}' "$3" > "$3/bin/config.json"
+    ln "$3/bin/config.json" @ALIAS@
+    cp "$3/bin/config.json" @BEFORE@
+    printf '#!/bin/sh\\nexit 0\\n' > "$3/bin/pip"
+    chmod +x "$3/bin/pip"
+}
+setup_iterm2_venv
+""".replace('@ALIAS@',q(private_alias)).replace('@BEFORE@',q(box/'before-hardlink')),
+    private_alias)
+assert private_alias.read_bytes()==(box/'before-hardlink').read_bytes()
+
 # Both stage owners recheck changed aliases at EXIT; child traps cannot clean
 # the parent's stage. Retention is silent except for fixed/canonical messages.
 for kind in ('config', 'runtime'):

--- a/bin/install_config_preflight_test.sh
+++ b/bin/install_config_preflight_test.sh
@@ -257,6 +257,83 @@ setup_iterm2_venv
 """.replace('@ALIAS@',q(private_alias)),private_alias/'config.json',False)
 assert (private_alias/'config.json').read_text()=='protected'
 
+# Successful pip selects a staged JSON containing the exact rewrite source.
+private_alias.unlink(); private_alias.symlink_to(box/'initially-missing',target_is_directory=True)
+run('pip-success-private-json', """
+uname() { echo Darwin; }
+tmux() { :; }
+TERM_PROGRAM=iTerm.app
+python3() {
+    if [ "$1" = -I ]; then command python3 "$@"; return; fi
+    mkdir -p "$3/bin"
+    printf '{"path":"%s"}' "$3" > "$3/bin/config.json"
+    cp "$3/bin/config.json" @BEFORE@
+    printf '#!/bin/sh\\nrm @ALIAS@\\nln -s "%s/bin" @ALIAS@\\nexit 0\\n' "$3" > "$3/bin/pip"
+    chmod +x "$3/bin/pip"
+}
+setup_iterm2_venv
+""".replace('@ALIAS@',q(private_alias)).replace('@BEFORE@',q(box/'before-json')),
+    private_alias/'config.json',False)
+assert (private_alias/'config.json').read_bytes()==(box/'before-json').read_bytes()
+
+# Both stage owners recheck changed aliases at EXIT; child traps cannot clean
+# the parent's stage. Retention is silent except for fixed/canonical messages.
+for kind in ('config', 'runtime'):
+    for status in (0, 17):
+        selected=box/('cleanup-{}-{}'.format(kind,status)); selected.symlink_to(outside)
+        body="""
+INSTALL_CONFIG_STAGE=$(mktemp -d "$TMPDIR/config-stage.XXXXXX")
+INSTALL_CONFIG_STAGE_OWNER=$BASH_SUBSHELL
+printf protected > "$INSTALL_CONFIG_STAGE/config.json"
+( trap 'cleanup_install_config' EXIT; : )
+[ -f "$INSTALL_CONFIG_STAGE/config.json" ] || exit 99
+rm @ALIAS@
+ln -s "$INSTALL_CONFIG_STAGE/config.json" @ALIAS@
+exit @STATUS@
+""" if kind=='config' else """
+download_and_verify_binary() { cp @HELPER@ "$BINARY_PATH"; }
+verify_executable() { :; }
+detect_platform() {
+    PLATFORM=linux ARCH=amd64 BINARY_NAME=claude-notifications-linux-amd64
+    BINARY_PATH="$SCRIPT_DIR/$BINARY_NAME"
+    CHECKSUMS_PATH="$SCRIPT_DIR/.checksums.txt"
+}
+install_linux_notification_desktop_entry() {
+    ( trap 'if [ "$stage_owner" = "$BASH_SUBSHELL" ]; then cleanup_install_stage "$stage"; fi' EXIT; : )
+    [ -f "$BINARY_PATH" ] || exit 99
+    printf protected > "$stage/config.json"
+    rm @ALIAS@
+    ln -s "$stage/config.json" @ALIAS@
+    exit @STATUS@
+}
+stage_and_promote_runtime
+"""
+        case,r=run('trap-{}-{}'.format(kind,status),body.replace('@ALIAS@',q(selected)).replace('@HELPER@',q(helper)).replace('@STATUS@',str(status)),selected,status==0)
+        assert r.returncode==status
+        assert selected.exists(), (r.stderr, (case/'trace').read_text(), os.readlink(selected))
+        assert selected.read_text()=='protected'
+        assert b'Private installer stage retained' in r.stderr, (kind,status,r.stderr)
+        assert str(selected).encode() not in r.stderr
+# Ordinary cleanup must be silent and preserve either success or failure.
+for status in (0,17):
+    case,r=run('clean-exit-'+str(status),"""
+INSTALL_CONFIG_STAGE=$(mktemp -d "$TMPDIR/config-stage.XXXXXX")
+INSTALL_CONFIG_STAGE_OWNER=$BASH_SUBSHELL
+printf '%s' "$INSTALL_CONFIG_STAGE" > "$SCRIPT_DIR/stage-path"
+exit @STATUS@
+""".replace('@STATUS@',str(status)),outside,status==0)
+    assert r.returncode==status and r.stderr==b''
+    assert not pathlib.Path((case/'stage-path').read_text()).exists()
+case,r=run('cleanup-no-helper',"""
+INSTALL_CONFIG_STAGE=$(mktemp -d "$TMPDIR/config-stage.XXXXXX")
+INSTALL_CONFIG_STAGE_OWNER=$BASH_SUBSHELL
+INSTALL_CONFIG_HELPER=/missing
+printf '%s' "$INSTALL_CONFIG_STAGE" > "$SCRIPT_DIR/stage-path"
+exit 0
+""",outside)
+assert pathlib.Path((case/'stage-path').read_text()).is_dir()
+assert b'Private installer stage retained' in r.stderr
+
 # A reverse child alias must not be followed by venv creation.
 for child in ('pyvenv.cfg', 'bin'):
     shutil.rmtree(venv)

--- a/bin/install_config_preflight_test.sh
+++ b/bin/install_config_preflight_test.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
+TEST_ENV_HANDOFF_GOMODCACHE=1
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/test-env.sh"
 test_env_enter "$0" "$@"
+# Scripted fault injection uses POSIX executable scripts. Native Windows
+# protocol coverage runs the actual built CLI in install_config_native_test.sh.
+case "$(uname -s)" in
+    MINGW*|MSYS*|CYGWIN*) exec bash "$(dirname "$0")/install_config_native_test.sh" ;;
+esac
 # Disposable adapter tests. The helper models the CLI protocol; native Store
 # identity behavior is covered by internal/config/preflight_test.go.
 set -eo pipefail
@@ -52,7 +58,7 @@ def run(name, body, e=None, ok=True):
     env=dict(os.environ, INSTALL_TARGET_DIR=str(case), TRACE=str(case/'trace'))
     if e is not None: env['AGENT_NOTIFICATIONS_CONFIG']=str(e)
     script='source '+q(functions)+'\ndetect_platform\nINSTALL_CONFIG_HELPER='+q(helper)+'\n'+isolation+body
-    r=subprocess.run(['bash','-c',script],env=env,capture_output=True,timeout=30)
+    r=subprocess.run(['bash','-c',script],env=env,stdout=subprocess.PIPE,stderr=subprocess.PIPE,timeout=30)
     assert (r.returncode==0)==ok,(name,r.returncode,r.stderr.decode())
     assert b'SECRET-CANARY' not in r.stdout+r.stderr
     print('PASS:',name)
@@ -151,7 +157,7 @@ installer.write_text('#!/bin/bash\nsource '+q(functions)+'\ndetect_platform\nINS
 installer.chmod(0o755)
 env=dict(os.environ,AGENT_NOTIFICATIONS_CONFIG=str(config),TRACE=str(case/'trace'))
 before=binary.read_bytes()
-r=subprocess.run(['sh',str(case/'hook-wrapper.sh'),'Stop'],env=env,input=b'{}',capture_output=True,timeout=30)
+r=subprocess.run(['sh',str(case/'hook-wrapper.sh'),'Stop'],env=env,input=b'{}',stdout=subprocess.PIPE,stderr=subprocess.PIPE,timeout=30)
 assert r.returncode==0 and r.stdout==b'' and r.stderr==b'',r
 assert binary.read_bytes()==before and config.read_text()=='SECRET-CANARY'
 assert (case/'trace').exists()
@@ -196,7 +202,7 @@ TERM_PROGRAM=iTerm.app
 main
 """,config,False)
 assert config.read_text()=='SECRET-CANARY'
-# Real venv setup/failed-pip cleanup with only Python creation and pip stubbed.
+# Venv setup with only Python creation and pip stubbed; failure keeps live bytes.
 run('pip-failure-safe',"""
 uname() { echo Darwin; }
 tmux() { :; }
@@ -209,9 +215,9 @@ python3() {
 }
 setup_iterm2_venv
 """,outside)
-assert not venv.exists()
-print('PASS: non-overlap pip failure follows existing cleanup behavior')
-# Change a directory alias during pip, then require a fresh preflight before rm.
+assert config.read_text()=='SECRET-CANARY'
+print('PASS: pip failure preserves broken live venv')
+# Change a live directory alias during pip; failure never removes that live tree.
 late=box/'late-alias'; late.symlink_to(box/'initially-missing',target_is_directory=True)
 body="""
 uname() { echo Darwin; }
@@ -225,9 +231,121 @@ python3() {
 }
 setup_iterm2_venv
 """.replace('@ALIAS@',str(late)).replace('@VENV@',str(venv))
-run('pip-late-alias',body,late/'config.json',False)
+run('pip-late-alias',body,late/'config.json')
 assert (venv/'config.json').read_text()=='protected'
-print('PASS: post-pip overlap blocks recursive cleanup')
+print('PASS: failed staged pip never cleans live venv')
+late.unlink(); late.symlink_to(box/'initially-missing',target_is_directory=True)
+run('pip-success-late-alias',body.replace('exit 1', 'exit 0'),late/'config.json',False)
+assert (venv/'config.json').read_text()=='protected'
+print('PASS: fresh preflight rejects live replacement after successful pip')
 
+
+# Failed pip may change the selected alias to the newly built private tree.
+private_alias=box/'private-venv-alias'
+private_alias.symlink_to(box/'initially-missing',target_is_directory=True)
+run('pip-private-cleanup-alias', """
+uname() { echo Darwin; }
+tmux() { :; }
+TERM_PROGRAM=iTerm.app
+python3() {
+    if [ "$1" = -I ]; then command python3 "$@"; return; fi
+    mkdir -p "$3/bin"
+    printf '#!/bin/sh\\nprintf protected > "%s/config.json"\\nrm @ALIAS@\\nln -s "%s" @ALIAS@\\nexit 1\\n' "$3" "$3" > "$3/bin/pip"
+    chmod +x "$3/bin/pip"
+}
+setup_iterm2_venv
+""".replace('@ALIAS@',q(private_alias)),private_alias/'config.json',False)
+assert (private_alias/'config.json').read_text()=='protected'
+
+# A reverse child alias must not be followed by venv creation.
+for child in ('pyvenv.cfg', 'bin'):
+    shutil.rmtree(venv)
+    venv.mkdir()
+    protected=box/('protected-'+child)
+    if child == 'bin':
+        protected.mkdir(); selected=protected/'python3'; selected.write_text('protected')
+        (venv/child).symlink_to(protected, target_is_directory=True)
+    else:
+        protected.write_text('protected'); selected=protected
+        (venv/child).symlink_to(protected)
+    run('reverse-'+child, """
+uname() { echo Darwin; }
+tmux() { :; }
+TERM_PROGRAM=iTerm.app
+python3() {
+    if [ "$1" = -I ]; then command python3 "$@"; return; fi
+    mkdir -p "$3/bin"
+    printf created > "$3/pyvenv.cfg"
+    printf '#!/bin/sh\\nexit 0\\n' > "$3/bin/pip"
+    chmod +x "$3/bin/pip"
+}
+setup_iterm2_venv
+""",selected)
+    assert selected.read_text()=='protected'
+    assert not (venv/child).is_symlink()
+# Optional download children cannot remove the parent's verified helper.
+run('multiple-optionals',stage_body+"""
+FORCE_UPDATE=true
+utility_usable() { [ -s "$1" ]; }
+curl() { while [ "$1" != -o ]; do shift; done; printf utility > "$2"; }
+download_utilities
+[ -f "$INSTALL_CONFIG_HELPER" ]
+guard_install_paths "$SCRIPT_DIR"
+""",outside)
+# A selected config alias changes between attempts to the predictable zip.
+for name, function in [
+    ('modern-retry', 'download_terminal_notifier_modern'),
+    ('legacy-retry', 'download_terminal_notifier'),
+    ('gnome-retry', 'install_gnome_activate_window_extension'),
+]:
+    selected=box/(name+'-selected'); selected.symlink_to(outside)
+    case,r=run(name,"""
+MAX_RETRIES=2 RETRY_DELAY=0
+sleep() { :; }
+gnome-shell() { echo 'GNOME Shell 46.0'; }
+gnome-extensions() { return 1; }
+curl() {
+    case "$*" in
+        *extension-info*) printf '{"download_url":"/fixture.zip"}'; return 0;;
+    esac
+    while [ "$1" != -o ]; do shift; done
+    printf protected > "$2"
+    rm @SELECTED@
+    ln -s "$2" @SELECTED@
+    return 1
+}
+@FUNCTION@
+""".replace('@SELECTED@',q(selected)).replace('@FUNCTION@',function),selected,False)
+    assert selected.read_text()=='protected'
+
+# The helper bootstrap's actual downloader must not truncate shared diagnostics.
+run('private-diagnostics', """
+INSTALL_CONFIG_HELPER=/missing
+export AGENT_NOTIFICATIONS_CONFIG="$TMPDIR/install-error-$$.log"
+printf protected > "$AGENT_NOTIFICATIONS_CONFIG"
+pin_release_urls() { :; }
+get_file_size() { echo 200000; }
+curl() {
+    [ "$1" != --help ] || return 0
+    while [ "$1" != -o ]; do shift; done
+    case "$2" in "$INSTALL_CONFIG_STAGE"/*) ;; *) exit 99;; esac
+    cp @HELPER@ "$2"
+    echo diagnostic >&2
+    printf 200
+}
+download_and_verify_binary() {
+    download_binary
+    printf checksum > "$CHECKSUMS_PATH"
+}
+verify_executable() { :; }
+guard_install_paths "$SCRIPT_DIR"
+[ "$(cat "$AGENT_NOTIFICATIONS_CONFIG")" = protected ]
+""".replace('@HELPER@',q(helper)),outside)
+# Working venv returns before preflight or private creation.
+shutil.rmtree(venv)
+(venv/'bin').mkdir(parents=True)
+(venv/'bin/python3').write_text('#!/bin/sh\nexit 0\n')
+(venv/'bin/python3').chmod(0o755)
+run('working-venv',iterm,venv/'config.json')
 
 PY

--- a/bin/install_e2e_test.sh
+++ b/bin/install_e2e_test.sh
@@ -682,8 +682,9 @@ test_lock_created() {
     cat > "$fake_bin/curl" <<'FAKE_CURL_EOF'
 #!/bin/sh
 if [ "$1" = "--help" ]; then
-    sleep 5
+    exit 0
 fi
+sleep 5
 exit 28
 FAKE_CURL_EOF
     chmod +x "$fake_bin/curl"

--- a/bin/install_test.sh
+++ b/bin/install_test.sh
@@ -246,6 +246,12 @@ else
     TESTS_FAILED=$((TESTS_FAILED + 1))
 fi
 
+if bash "$SCRIPT_DIR/install_config_preflight_test.sh"; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+fi
+
 if bash "$SCRIPT_DIR/install_transaction_test.sh"; then
     TESTS_PASSED=$((TESTS_PASSED + 1))
 else

--- a/bin/install_test.sh
+++ b/bin/install_test.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+TEST_ENV_HANDOFF_GOMODCACHE=1
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/test-env.sh"
 test_env_enter "$0" "$@"
 # install_test.sh - Tests for install.sh functions
@@ -247,6 +248,12 @@ else
 fi
 
 if bash "$SCRIPT_DIR/install_config_preflight_test.sh"; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+fi
+
+if bash "$SCRIPT_DIR/install_config_native_test.sh"; then
     TESTS_PASSED=$((TESTS_PASSED + 1))
 else
     TESTS_FAILED=$((TESTS_FAILED + 1))


### PR DESCRIPTION
Direct lazy updates could mutate an explicitly selected config when it overlapped an installer-owned path, including the macOS iTerm2 venv cleanup path. This adds canonical `config preflight-update` guards immediately before installer mutations and cleanup, reuses installed helpers without network, and stages a checksum-verified current helper only when an old binary lacks the protocol.

The installer now preserves explicit config bytes across symlink, reverse-alias, and hardlink cases; rechecks aliases after pip; keeps private stages when cleanup safety cannot be established; and relocates venv entry points and activation scripts when HOME contains spaces.

Validation:
- `bash bin/install_config_preflight_test.sh`
- `bash bin/install_config_native_test.sh`
- `bash bin/install_transaction_test.sh`
- Native CI on Ubuntu, macOS, and Windows with Go 1.22 and 1.26
- Lint and Swift notifier tests
- Independent final review of exact SHA `3739f543e541aa46458d9939b5bc13d4e4b0f5d0`: no findings
