### PR TITLE
feat: add universal agent configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,17 +172,18 @@ no `jq` and is not automatically added to your `PATH`.
 From the bundle directory:
 
 ```bash
-./bin/claude-notifications setup-codex --plugin-root .
+./bin/agent-notifications setup-codex --plugin-root .
 ```
 
-On Windows, run the downloaded `claude-notifications-windows-amd64.exe` in PowerShell:
+On Windows, run the installed primary launcher in PowerShell (the downloaded
+`claude-notifications-windows-amd64.exe` remains compatible):
 
 ```powershell
-.\bin\claude-notifications-windows-amd64.exe setup-codex --plugin-root .
+.\bin\agent-notifications.bat setup-codex --plugin-root .
 ```
 
 Run these commands in the bundle directory. If you have explicitly added the binary to
-`PATH`, `claude-notifications setup-codex --plugin-root <bundle-directory>` also works.
+`PATH`, `agent-notifications setup-codex --plugin-root <bundle-directory>` also works.
 
 It installs a self-contained copy of the plugin at `~/.codex/claude-notifications-go` and writes
 the hook entries into `~/.codex/hooks.json`. Existing foreign hook definitions and unknown fields are preserved,
@@ -351,7 +352,7 @@ The following JSON illustrates the schema. Do not replace your existing document
       "clickToFocus": true,
       "terminalBundleId": "",
       "showSessionLabel": true,
-      "appIcon": "${CLAUDE_PLUGIN_ROOT}/claude_icon.png"
+      "appIcon": "${AGENT_NOTIFICATIONS_ROOT}/claude_icon.png"
     },
     "webhook": {
       "enabled": false,
@@ -382,31 +383,31 @@ The following JSON illustrates the schema. Do not replace your existing document
   "statuses": {
     "task_complete": {
       "title": "✅ Completed",
-      "sound": "${CLAUDE_PLUGIN_ROOT}/sounds/task-complete.mp3"
+      "sound": "${AGENT_NOTIFICATIONS_ROOT}/sounds/task-complete.mp3"
     },
     "review_complete": {
       "title": "🔍 Review",
-      "sound": "${CLAUDE_PLUGIN_ROOT}/sounds/review-complete.mp3"
+      "sound": "${AGENT_NOTIFICATIONS_ROOT}/sounds/review-complete.mp3"
     },
     "question": {
       "title": "❓ Question",
-      "sound": "${CLAUDE_PLUGIN_ROOT}/sounds/question.mp3"
+      "sound": "${AGENT_NOTIFICATIONS_ROOT}/sounds/question.mp3"
     },
     "plan_ready": {
       "title": "📋 Plan",
-      "sound": "${CLAUDE_PLUGIN_ROOT}/sounds/plan-ready.mp3"
+      "sound": "${AGENT_NOTIFICATIONS_ROOT}/sounds/plan-ready.mp3"
     },
     "session_limit_reached": {
       "title": "⏱️ Session Limit Reached",
-      "sound": "${CLAUDE_PLUGIN_ROOT}/sounds/error.mp3"
+      "sound": "${AGENT_NOTIFICATIONS_ROOT}/sounds/error.mp3"
     },
     "api_error": {
       "title": "🔴 API Error: 401",
-      "sound": "${CLAUDE_PLUGIN_ROOT}/sounds/error.mp3"
+      "sound": "${AGENT_NOTIFICATIONS_ROOT}/sounds/error.mp3"
     },
     "api_error_overloaded": {
       "title": "🔴 API Error",
-      "sound": "${CLAUDE_PLUGIN_ROOT}/sounds/error.mp3"
+      "sound": "${AGENT_NOTIFICATIONS_ROOT}/sounds/error.mp3"
     }
   }
 }
@@ -434,7 +435,7 @@ You can also override individual channels per status:
   "statuses": {
     "question": {
       "title": "❓ Question",
-      "sound": "${CLAUDE_PLUGIN_ROOT}/sounds/question.mp3",
+      "sound": "${AGENT_NOTIFICATIONS_ROOT}/sounds/question.mp3",
       "desktop": { "enabled": true },
       "webhook": { "enabled": false }
     }
@@ -475,11 +476,11 @@ Unknown means "show the notification", not "suppress it".
 ### Sound Options
 
 **Built-in sounds** (included):
-- `${CLAUDE_PLUGIN_ROOT}/sounds/task-complete.mp3`
-- `${CLAUDE_PLUGIN_ROOT}/sounds/review-complete.mp3`
-- `${CLAUDE_PLUGIN_ROOT}/sounds/question.mp3`
-- `${CLAUDE_PLUGIN_ROOT}/sounds/plan-ready.mp3`
-- `${CLAUDE_PLUGIN_ROOT}/sounds/error.mp3`
+- `${AGENT_NOTIFICATIONS_ROOT}/sounds/task-complete.mp3`
+- `${AGENT_NOTIFICATIONS_ROOT}/sounds/review-complete.mp3`
+- `${AGENT_NOTIFICATIONS_ROOT}/sounds/question.mp3`
+- `${AGENT_NOTIFICATIONS_ROOT}/sounds/plan-ready.mp3`
+- `${AGENT_NOTIFICATIONS_ROOT}/sounds/error.mp3`
 
 **System sounds:**
 - macOS: `/System/Library/Sounds/Glass.aiff`, `/System/Library/Sounds/Hero.aiff`, etc.
@@ -567,11 +568,11 @@ The plugin is invoked automatically by Claude Code hooks. To test manually:
 ```bash
 # Test PreToolUse hook
 echo '{"session_id":"test","transcript_path":"/path/to/transcript.jsonl","tool_name":"ExitPlanMode"}' | \
-  claude-notifications handle-hook PreToolUse
+  agent-notifications handle-hook PreToolUse
 
 # Test Stop hook
 echo '{"session_id":"test","transcript_path":"/path/to/transcript.jsonl"}' | \
-  claude-notifications handle-hook Stop
+  agent-notifications handle-hook Stop
 ```
 
 ## Contributing
@@ -622,3 +623,6 @@ See **[Troubleshooting Guide](docs/troubleshooting.md)** for common issues:
 ## License
 
 GPL-3.0 - See [LICENSE](LICENSE) file for details.
+
+For per-agent sound and notification settings, see [shared configuration and schema 2 overrides](docs/AGENT_CONFIGURATION.md).
+The primary command is `agent-notifications`; `claude-notifications` remains a permanent compatibility alias.

--- a/bin/agent-launcher_test.sh
+++ b/bin/agent-launcher_test.sh
@@ -17,10 +17,24 @@ BINARY_PATH="$SCRIPT_DIR/$BINARY_NAME"
 printf '#!/bin/sh\nprintf "fixture-binary\\n"\n' > "$BINARY_PATH"
 chmod +x "$BINARY_PATH"
 create_symlink
-[ "$(readlink "$SCRIPT_DIR/agent-notifications")" = "$BINARY_NAME" ]
-[ "$(readlink "$SCRIPT_DIR/claude-notifications")" = "$BINARY_NAME" ]
-[ "$("$SCRIPT_DIR/agent-notifications")" = fixture-binary ]
-[ "$("$SCRIPT_DIR/claude-notifications")" = fixture-binary ]
+for name in agent-notifications claude-notifications; do
+    launcher="$SCRIPT_DIR/$name"
+    if [ -L "$launcher" ]; then
+        [ "$(readlink "$launcher")" = "$BINARY_NAME" ]
+    else
+        # Git Bash may implement ln as a copy when native symlinks are disabled.
+        # The installer also explicitly supports copying on such filesystems.
+        [ -f "$launcher" ]
+        cmp -s "$BINARY_PATH" "$launcher"
+    fi
+    case "$(uname -s)" in
+        MINGW*|MSYS*|CYGWIN*)
+            # This fixture is a POSIX script, not a native Windows executable.
+            [ "$(sh "$launcher")" = fixture-binary ]
+            ;;
+        *) [ "$("$launcher")" = fixture-binary ] ;;
+    esac
+done
 PLATFORM=windows
 BINARY_NAME=claude-notifications-windows-amd64.exe
 create_symlink

--- a/bin/agent-launcher_test.sh
+++ b/bin/agent-launcher_test.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/test-env.sh"
+test_env_enter "$0" "$@"
+set -eo pipefail
+root=$(cd "$(dirname "$0")" && pwd)
+sandbox=$(mktemp -d)
+trap 'rm -rf "$sandbox"' EXIT
+sed '/^main "\$@"$/d' "$root/install.sh" > "$sandbox/functions.sh"
+source "$sandbox/functions.sh"
+# Only launcher creation is exercised. All mutations stay in a disposable bundle.
+SCRIPT_DIR="$sandbox/bundle"
+mkdir -p "$SCRIPT_DIR"
+guard_install_paths() { :; }
+PLATFORM=linux
+BINARY_NAME=claude-notifications-linux-amd64
+BINARY_PATH="$SCRIPT_DIR/$BINARY_NAME"
+printf '#!/bin/sh\nprintf "fixture-binary\\n"\n' > "$BINARY_PATH"
+chmod +x "$BINARY_PATH"
+create_symlink
+[ "$(readlink "$SCRIPT_DIR/agent-notifications")" = "$BINARY_NAME" ]
+[ "$(readlink "$SCRIPT_DIR/claude-notifications")" = "$BINARY_NAME" ]
+[ "$("$SCRIPT_DIR/agent-notifications")" = fixture-binary ]
+[ "$("$SCRIPT_DIR/claude-notifications")" = fixture-binary ]
+PLATFORM=windows
+BINARY_NAME=claude-notifications-windows-amd64.exe
+create_symlink
+for name in agent-notifications claude-notifications; do
+ grep -F '"%SCRIPT_DIR%claude-notifications-windows-amd64.exe" %*' "$SCRIPT_DIR/$name.bat"
+ grep -F "set AGENT_NOTIFICATIONS_LAUNCHER=$name" "$SCRIPT_DIR/$name.bat"
+done
+echo 'PASS: dual launchers preserve the platform binary and Windows identity'

--- a/bin/agent-notifications
+++ b/bin/agent-notifications
@@ -1,0 +1,1 @@
+claude-notifications

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -1232,9 +1232,15 @@ windows_native_hooks_update_required() {
 
 # Create symlink for hooks
 create_symlink() {
+    create_named_launcher claude-notifications || return 1
+    create_named_launcher agent-notifications
+}
+
+create_named_launcher() {
+    local launcher_name="$1"
     # On Windows, create a .bat wrapper instead of symlink
     if [ "$PLATFORM" = "windows" ]; then
-        local final_bat_path="${SCRIPT_DIR}/claude-notifications.bat"
+        local final_bat_path="${SCRIPT_DIR}/${launcher_name}.bat"
         local bat_path="${final_bat_path}.tmp.$$"
 
         guard_install_paths "$bat_path" "$final_bat_path"
@@ -1244,16 +1250,17 @@ create_symlink() {
         # Create .bat wrapper that calls the platform-specific binary
         cat > "$bat_path" << EOF
 @echo off
-REM claude-notifications Windows wrapper
+REM ${launcher_name} Windows wrapper
 REM Automatically runs the platform-specific binary
 
 setlocal
 set SCRIPT_DIR=%~dp0
+set AGENT_NOTIFICATIONS_LAUNCHER=${launcher_name}
 "%SCRIPT_DIR%${BINARY_NAME}" %*
 EOF
 
         if mv -f "$bat_path" "$final_bat_path"; then
-            echo -e "${GREEN}✓ Created wrapper${NC} claude-notifications.bat → ${BINARY_NAME}"
+            echo -e "${GREEN}✓ Created wrapper${NC} ${launcher_name}.bat → ${BINARY_NAME}"
             return 0
         else
             echo -e "${YELLOW}⚠ Could not create .bat wrapper (hooks may not work)${NC}"
@@ -1262,7 +1269,7 @@ EOF
     fi
 
     # Unix: create symlink or copy
-    local final_symlink_path="${SCRIPT_DIR}/claude-notifications"
+    local final_symlink_path="${SCRIPT_DIR}/${launcher_name}"
     local symlink_path="${final_symlink_path}.tmp.$$"
     guard_install_paths "$final_symlink_path" "$symlink_path"
     # Remove old symlink if exists
@@ -1270,14 +1277,14 @@ EOF
 
     # Create symlink pointing to platform-specific binary
     if ln -s "$BINARY_NAME" "$symlink_path" 2>/dev/null && mv -f "$symlink_path" "$final_symlink_path"; then
-        echo -e "${GREEN}✓ Created symlink${NC} claude-notifications → ${BINARY_NAME}"
+        echo -e "${GREEN}✓ Created symlink${NC} ${launcher_name} → ${BINARY_NAME}"
         return 0
     else
         # Fallback: copy if symlink fails (some systems don't support symlinks)
         if cp "$BINARY_PATH" "$symlink_path" 2>/dev/null; then
             chmod +x "$symlink_path" 2>/dev/null || true
             mv -f "$symlink_path" "$final_symlink_path" || return 1
-            echo -e "${GREEN}✓ Created copy${NC} claude-notifications (symlink not supported)"
+            echo -e "${GREEN}✓ Created copy${NC} ${launcher_name} (symlink not supported)"
             return 0
         fi
 

--- a/bin/install_test.sh
+++ b/bin/install_test.sh
@@ -271,6 +271,12 @@ else
     TESTS_FAILED=$((TESTS_FAILED + 1))
 fi
 
+if bash "$SCRIPT_DIR/agent-launcher_test.sh"; then
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+else
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+fi
+
 # Summary
 echo "========================================="
 echo " Test Summary"

--- a/cmd/claude-notifications/config_e2e_test.go
+++ b/cmd/claude-notifications/config_e2e_test.go
@@ -187,4 +187,8 @@ func TestUniversalConfigE2ELaunchersAndSilentCodex(t *testing.T) {
 	f.env = append(f.env, "PLUGIN_ROOT="+f.bundle)
 	result := runCLI(t, f.env, `{"session_id":"isolated","hook_event_name":"Stop","cwd":"`+filepath.ToSlash(f.root)+`"}`, "handle-hook", "Stop", "--product", "codex")
 	assertContained(t, "invalid inactive schema2 profile", result)
+	log := string(e2eRead(t, filepath.Join(f.bundle, "notification-debug.log")))
+	if !strings.Contains(log, "ConfigInvalid") {
+		t.Fatalf("missing ConfigInvalid diagnostic: %s", log)
+	}
 }

--- a/cmd/claude-notifications/config_e2e_test.go
+++ b/cmd/claude-notifications/config_e2e_test.go
@@ -1,12 +1,14 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -146,4 +148,43 @@ func TestConfigE2EExplicitImportAndWizardCAS(t *testing.T) {
 	if string(e2eRead(t, canonical)) != string(after) || string(e2eRead(t, legacy)) != string(legacyBytes) || string(e2eRead(t, source)) != raw {
 		t.Fatal("CAS/import changed unrelated bytes")
 	}
+}
+
+// This fixture invokes only version/config and a deliberately invalid Codex hook.
+// All homes, resource paths and the canonical document belong to t.TempDir.
+func TestUniversalConfigE2ELaunchersAndSilentCodex(t *testing.T) {
+	f := newSetupE2E(t)
+	binary := buildCLIBinary(t)
+	for _, name := range []string{"agent-notifications", "claude-notifications"} {
+		launcher := filepath.Join(f.root, name)
+		if runtime.GOOS == "windows" {
+			launcher += ".exe"
+			e2eWrite(t, launcher, e2eRead(t, binary))
+		} else if err := os.Symlink(binary, launcher); err != nil {
+			t.Fatal(err)
+		}
+		output, err := f.run(t, "", launcher, "version")
+		if err != nil || !strings.HasPrefix(output, name+" v") {
+			t.Fatalf("launcher %s: %s %v", name, output, err)
+		}
+		canonical := filepath.Join(f.home, ".claude", "claude-notifications-go", "config.json")
+		raw := []byte(`{"schemaVersion":2,"agents":{"claude":{"notifications":{"desktop":{"volume":0}}},"codex":{"notifications":{"desktop":{"sound":false}}}}}`)
+		e2eWrite(t, canonical, raw)
+		output, err = f.run(t, "", launcher, "config", "inspect", "--json")
+		if err != nil {
+			t.Fatalf("inspect: %s %v", output, err)
+		}
+		var inspection config.Inspection
+		if err := json.Unmarshal([]byte(output), &inspection); err != nil || !inspection.Valid || inspection.SchemaVersion != 2 {
+			t.Fatalf("inspection: %s %v", output, err)
+		}
+		if !bytes.Equal(raw, e2eRead(t, canonical)) {
+			t.Fatal("inspection rewrote config")
+		}
+	}
+	canonical := filepath.Join(f.home, ".claude", "claude-notifications-go", "config.json")
+	e2eWrite(t, canonical, []byte(`{"schemaVersion":2,"agents":{"claude":{"notifications":{"desktop":{"volume":2}}}}}`))
+	f.env = append(f.env, "PLUGIN_ROOT="+f.bundle)
+	result := runCLI(t, f.env, `{"session_id":"isolated","hook_event_name":"Stop","cwd":"`+filepath.ToSlash(f.root)+`"}`, "handle-hook", "Stop", "--product", "codex")
+	assertContained(t, "invalid inactive schema2 profile", result)
 }

--- a/cmd/claude-notifications/launcher_test.go
+++ b/cmd/claude-notifications/launcher_test.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+func TestInvocationName(t *testing.T) {
+	old := os.Args
+	t.Cleanup(func() { os.Args = old })
+	for _, tc := range []struct{ name, env, want string }{
+		{"agent-notifications", "", "agent-notifications"},
+		{"agent-notifications.exe", "", "agent-notifications"},
+		{"claude-notifications", "", "claude-notifications"},
+		{"claude-notifications", "agent-notifications", "claude-notifications"},
+		{"claude-notifications-windows-amd64.exe", "agent-notifications", "agent-notifications"},
+		{"claude-notifications-windows-amd64.exe", "claude-notifications", "claude-notifications"},
+		{"claude-notifications-windows-arm64.exe", "", "claude-notifications"},
+	} {
+		os.Args = []string{tc.name}
+		t.Setenv("AGENT_NOTIFICATIONS_LAUNCHER", tc.env)
+		if got := invocationName(); got != tc.want {
+			t.Errorf("%+v got %q", tc, got)
+		}
+	}
+}
+
+func TestBundlePrimaryLauncherPresent(t *testing.T) {
+	// Git may materialize symlinks as plain files on Windows. Both checkout forms
+	// must contain the same relative target; installation creates native launchers.
+	path := "../../bin/agent-notifications"
+	target, err := os.Readlink(path)
+	if err != nil {
+		raw, readErr := os.ReadFile(path)
+		if readErr != nil {
+			t.Fatal(readErr)
+		}
+		target = string(raw)
+	}
+	if target != "claude-notifications" {
+		t.Fatalf("unexpected bundle alias target %q", target)
+	}
+}

--- a/cmd/claude-notifications/main.go
+++ b/cmd/claude-notifications/main.go
@@ -88,7 +88,7 @@ func main() {
 	case "setup-codex":
 		runSetupCodex(os.Args[2:])
 	case "version", "--version", "-v":
-		fmt.Printf("claude-notifications v%s\n", version)
+		fmt.Printf("%s v%s\n", invocationName(), version)
 	case "help", "--help", "-h":
 		printUsage()
 	default:
@@ -743,16 +743,18 @@ func parseFocusWindowOptions(args []string) (notifier.FocusWindowOptions, error)
 }
 
 func printUsage() {
-	fmt.Println("claude-notifications - Smart notifications for Claude Code")
+	fmt.Println("agent-notifications - Smart notifications for Claude Code and Codex")
 	fmt.Println()
 	fmt.Printf("Version: %s\n", version)
 	fmt.Println()
 	fmt.Println("Usage:")
-	fmt.Println("  claude-notifications handle-hook <HookName>")
-	fmt.Println("  claude-notifications daemon")
-	fmt.Println("  claude-notifications windows-hooks [--exe <path>]")
-	fmt.Println("  claude-notifications version")
-	fmt.Println("  claude-notifications help")
+	fmt.Println("  agent-notifications handle-hook <HookName>")
+	fmt.Println("  agent-notifications daemon")
+	fmt.Println("  agent-notifications windows-hooks [--exe <path>]")
+	fmt.Println("  agent-notifications version")
+	fmt.Println("  agent-notifications config <path|inspect|init|edit|preflight-update>")
+	fmt.Println("  agent-notifications setup-codex --plugin-root <bundle>")
+	fmt.Println("  agent-notifications help")
 	fmt.Println()
 	fmt.Println("Commands:")
 	fmt.Println("  handle-hook <HookName>  Handle a Claude Code hook event")
@@ -773,18 +775,28 @@ func printUsage() {
 	fmt.Println()
 	fmt.Println("Examples:")
 	fmt.Println("  # Handle PreToolUse hook (reads JSON from stdin)")
-	fmt.Println("  echo '{\"session_id\":\"test\",\"tool_name\":\"ExitPlanMode\"}' | claude-notifications handle-hook PreToolUse")
+	fmt.Println("  echo '{\"session_id\":\"test\",\"tool_name\":\"ExitPlanMode\"}' | agent-notifications handle-hook PreToolUse")
 	fmt.Println()
 	fmt.Println("  # Handle Stop hook")
-	fmt.Println("  echo '{\"session_id\":\"test\",\"transcript_path\":\"/path/to/transcript.jsonl\"}' | claude-notifications handle-hook Stop")
+	fmt.Println("  echo '{\"session_id\":\"test\",\"transcript_path\":\"/path/to/transcript.jsonl\"}' | agent-notifications handle-hook Stop")
 	fmt.Println()
 	fmt.Println("  # Run notification daemon (Linux only, started automatically)")
-	fmt.Println("  claude-notifications daemon")
+	fmt.Println("  agent-notifications daemon")
 	fmt.Println()
 	fmt.Println("  # Print Windows exec-form hook configuration")
-	fmt.Println("  claude-notifications windows-hooks")
+	fmt.Println("  agent-notifications windows-hooks")
 	fmt.Println()
 	fmt.Println("Environment Variables:")
-	fmt.Println("  CLAUDE_PLUGIN_ROOT  Plugin root directory (auto-detected if not set)")
+	fmt.Println("  AGENT_NOTIFICATIONS_ROOT  Resource bundle root for config placeholders")
+	fmt.Println("  CLAUDE_PLUGIN_ROOT        Permanent resource-root alias; Claude hook root")
 	fmt.Println()
+}
+
+// invocationName preserves the permanent legacy launcher's version identity.
+func invocationName() string {
+	name := strings.ToLower(filepath.Base(os.Args[0]))
+	if name == "agent-notifications" || name == "agent-notifications.exe" || (strings.HasPrefix(name, "claude-notifications-windows-") && os.Getenv("AGENT_NOTIFICATIONS_LAUNCHER") == "agent-notifications") {
+		return "agent-notifications"
+	}
+	return "claude-notifications"
 }

--- a/cmd/claude-notifications/setup_codex_e2e_test.go
+++ b/cmd/claude-notifications/setup_codex_e2e_test.go
@@ -330,3 +330,46 @@ func TestSetupCodexE2EPartialInitializationExitStatus(t *testing.T) {
 		t.Fatal("retry changed registration")
 	}
 }
+
+func TestSetupCodexE2EInstalledLaunchersSurviveReplacement(t *testing.T) {
+	binary := buildCLIBinary(t)
+	f := newSetupE2E(t)
+	platformName := "claude-notifications-" + runtime.GOOS + "-" + runtime.GOARCH
+	extension := ""
+	if runtime.GOOS == "windows" {
+		platformName += ".exe"
+		extension = ".bat"
+	}
+	// Model an older source bundle with only a platform executable and no aliases.
+	e2eWrite(t, filepath.Join(f.bundle, "bin", platformName), e2eRead(t, binary))
+	installed := filepath.Join(f.home, ".codex", "claude-notifications-go", "bin")
+	for pass := 0; pass < 2; pass++ {
+		output, err := f.run(t, "", binary, "setup-codex", "--plugin-root", f.bundle)
+		if err != nil {
+			t.Fatalf("setup pass %d: %s %v", pass, output, err)
+		}
+		for _, name := range []string{"agent-notifications", "claude-notifications"} {
+			launcher := filepath.Join(installed, name+extension)
+			if runtime.GOOS == "windows" {
+				output, err = f.run(t, "", "cmd.exe", "/d", "/s", "/c", `"`+launcher+`" version`)
+			} else {
+				output, err = f.run(t, "", launcher, "version")
+			}
+			if err != nil || !strings.HasPrefix(output, name+" v") {
+				t.Fatalf("installed %s pass %d: %s %v", name, pass, output, err)
+			}
+			if runtime.GOOS != "windows" {
+				target, err := os.Readlink(launcher)
+				if err != nil || target != platformName {
+					t.Fatalf("different platform target: %s %v", target, err)
+				}
+			}
+		}
+		// Replacing bin during update must recreate a deleted primary launcher too.
+		if pass == 0 {
+			if err := os.Remove(filepath.Join(installed, "agent-notifications"+extension)); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+}

--- a/commands/settings.md
+++ b/commands/settings.md
@@ -49,7 +49,7 @@ Keep the opaque revision from the successful inspect for saving. Free-form sound
 Use AskUserQuestion to identify the settings the user wants to change. Every question defaults to **Keep unchanged**. Skipped or unanswered questions produce no operation. A request for volume and ONE status sound must yield exactly two leaf edits; every other status, channel override, webhook secret/header/payload, filter and future-agent field stays untouched.
 
 - Volume: keep unchanged, or choose 0–100% mapped to a JSON number 0–1 (70% → 0.7; zero is valid).
-- Status sound: ask which status, then keep unchanged or choose an available sound. Discover built-in files from the installed resources; macOS can also use `/System/Library/Sounds/*.aiff`. Reject unknown choices instead of silently substituting a sound. Store built-ins literally as `${CLAUDE_PLUGIN_ROOT}/sounds/<file>`; resource expansion is for playback only.
+- Status sound: ask which status, then keep unchanged or choose an available sound. Discover built-in files from the installed resources; macOS can also use `/System/Library/Sounds/*.aiff`. Reject unknown choices instead of silently substituting a sound. Store built-ins literally as `${AGENT_NOTIFICATIONS_ROOT}/sounds/<file>`; resource expansion is for playback only.
 - Status enabled: ask separately for each requested status. Never turn an unselected list of statuses into disabled statuses. Set only `/statuses/<status>/enabled` when explicitly requested.
 - Desktop enabled/sound, per-status desktop/webhook enabled, and audio device: change only the specific requested leaf. System-default device is an explicit empty string choice, not the default answer.
 - Webhooks: keep unchanged by default. An explicit disable changes only `/notifications/webhook/enabled`; it does not reset preset, URL, headers or payload. For new setup collect only the requested supported leaves from the [webhook guide](../docs/webhooks/README.md). Never insert placeholder URLs or replace the entire webhook object. Prefer literal environment references for credentials; never echo credentials in summaries.
@@ -64,7 +64,7 @@ Summarize only requested changes, redacting secret values, and confirm ambiguous
 {
   "set": {
     "/notifications/desktop/volume": 0.7,
-    "/statuses/question/sound": "${CLAUDE_PLUGIN_ROOT}/sounds/question.mp3"
+    "/statuses/question/sound": "${AGENT_NOTIFICATIONS_ROOT}/sounds/question.mp3"
   },
   "remove": []
 }
@@ -83,7 +83,7 @@ For the non-secret two-edit example above, this Bash recipe preserves the litera
   PATCH_DIR=$(mktemp -d "${TMPDIR:-/tmp}/agent-notifications-edit.XXXXXXXX") || exit 1
   trap 'rm -rf -- "$PATCH_DIR"' EXIT
   cat > "$PATCH_DIR/patch.json" <<'JSON'
-{"set":{"/notifications/desktop/volume":0.7,"/statuses/question/sound":"${CLAUDE_PLUGIN_ROOT}/sounds/question.mp3"},"remove":[]}
+{"set":{"/notifications/desktop/volume":0.7,"/statuses/question/sound":"${AGENT_NOTIFICATIONS_ROOT}/sounds/question.mp3"},"remove":[]}
 JSON
   "$NOTIFICATIONS_BIN" config edit --stdin --expect-revision "$REVISION" < "$PATCH_DIR/patch.json"
 )
@@ -98,3 +98,5 @@ On `ConfigConflict`, keep the user's answers privately, inspect again, and expla
 After confirmed success, run `config inspect --json` again. Report the selected path and only the requested changes; do not claim untouched fields were reset or infer omitted secret/sound values. Report failures honestly. Sound previews remain optional and user-requested.
 
 See [configuration paths and compatibility](../README.md#manual-configuration). Resource, permission-marker, venv and state paths, executable names and plugin IDs remain unchanged.
+
+Schema 2 agent overrides are manual-only. This wizard edits global settings only; never submit `/agents` edits or flatten an effective agent profile into the document. Existing agent overrides are preserved by `config edit`.

--- a/config/config.json
+++ b/config/config.json
@@ -4,7 +4,7 @@
       "enabled": true,
       "sound": true,
       "volume": 1.0,
-      "appIcon": "${CLAUDE_PLUGIN_ROOT}/claude_icon.png",
+      "appIcon": "${AGENT_NOTIFICATIONS_ROOT}/claude_icon.png",
       "clickToFocus": true,
       "terminalBundleId": ""
     },
@@ -24,35 +24,35 @@
   "statuses": {
     "task_complete": {
       "title": "✅ Completed",
-      "sound": "${CLAUDE_PLUGIN_ROOT}/sounds/task-complete.mp3"
+      "sound": "${AGENT_NOTIFICATIONS_ROOT}/sounds/task-complete.mp3"
     },
     "review_complete": {
       "title": "🔍 Review",
-      "sound": "${CLAUDE_PLUGIN_ROOT}/sounds/review-complete.mp3"
+      "sound": "${AGENT_NOTIFICATIONS_ROOT}/sounds/review-complete.mp3"
     },
     "question": {
       "title": "❓ Question",
-      "sound": "${CLAUDE_PLUGIN_ROOT}/sounds/question.mp3"
+      "sound": "${AGENT_NOTIFICATIONS_ROOT}/sounds/question.mp3"
     },
     "plan_ready": {
       "title": "📋 Plan",
-      "sound": "${CLAUDE_PLUGIN_ROOT}/sounds/plan-ready.mp3"
+      "sound": "${AGENT_NOTIFICATIONS_ROOT}/sounds/plan-ready.mp3"
     },
     "session_limit_reached": {
       "title": "⏱️ Session Limit Reached",
-      "sound": "${CLAUDE_PLUGIN_ROOT}/sounds/question.mp3"
+      "sound": "${AGENT_NOTIFICATIONS_ROOT}/sounds/question.mp3"
     },
     "api_error": {
       "title": "🔴 API Error: 401",
-      "sound": "${CLAUDE_PLUGIN_ROOT}/sounds/question.mp3"
+      "sound": "${AGENT_NOTIFICATIONS_ROOT}/sounds/question.mp3"
     },
     "api_error_overloaded": {
       "title": "🔴 API Error",
-      "sound": "${CLAUDE_PLUGIN_ROOT}/sounds/question.mp3"
+      "sound": "${AGENT_NOTIFICATIONS_ROOT}/sounds/question.mp3"
     },
     "permission_request": {
       "title": "🔐 Permission Request",
-      "sound": "${CLAUDE_PLUGIN_ROOT}/sounds/question.mp3"
+      "sound": "${AGENT_NOTIFICATIONS_ROOT}/sounds/question.mp3"
     }
   }
 }

--- a/config/config.json
+++ b/config/config.json
@@ -4,7 +4,7 @@
       "enabled": true,
       "sound": true,
       "volume": 1.0,
-      "appIcon": "${AGENT_NOTIFICATIONS_ROOT}/claude_icon.png",
+      "appIcon": "${CLAUDE_PLUGIN_ROOT}/claude_icon.png",
       "clickToFocus": true,
       "terminalBundleId": ""
     },
@@ -24,35 +24,35 @@
   "statuses": {
     "task_complete": {
       "title": "✅ Completed",
-      "sound": "${AGENT_NOTIFICATIONS_ROOT}/sounds/task-complete.mp3"
+      "sound": "${CLAUDE_PLUGIN_ROOT}/sounds/task-complete.mp3"
     },
     "review_complete": {
       "title": "🔍 Review",
-      "sound": "${AGENT_NOTIFICATIONS_ROOT}/sounds/review-complete.mp3"
+      "sound": "${CLAUDE_PLUGIN_ROOT}/sounds/review-complete.mp3"
     },
     "question": {
       "title": "❓ Question",
-      "sound": "${AGENT_NOTIFICATIONS_ROOT}/sounds/question.mp3"
+      "sound": "${CLAUDE_PLUGIN_ROOT}/sounds/question.mp3"
     },
     "plan_ready": {
       "title": "📋 Plan",
-      "sound": "${AGENT_NOTIFICATIONS_ROOT}/sounds/plan-ready.mp3"
+      "sound": "${CLAUDE_PLUGIN_ROOT}/sounds/plan-ready.mp3"
     },
     "session_limit_reached": {
       "title": "⏱️ Session Limit Reached",
-      "sound": "${AGENT_NOTIFICATIONS_ROOT}/sounds/question.mp3"
+      "sound": "${CLAUDE_PLUGIN_ROOT}/sounds/question.mp3"
     },
     "api_error": {
       "title": "🔴 API Error: 401",
-      "sound": "${AGENT_NOTIFICATIONS_ROOT}/sounds/question.mp3"
+      "sound": "${CLAUDE_PLUGIN_ROOT}/sounds/question.mp3"
     },
     "api_error_overloaded": {
       "title": "🔴 API Error",
-      "sound": "${AGENT_NOTIFICATIONS_ROOT}/sounds/question.mp3"
+      "sound": "${CLAUDE_PLUGIN_ROOT}/sounds/question.mp3"
     },
     "permission_request": {
       "title": "🔐 Permission Request",
-      "sound": "${AGENT_NOTIFICATIONS_ROOT}/sounds/question.mp3"
+      "sound": "${CLAUDE_PLUGIN_ROOT}/sounds/question.mp3"
     }
   }
 }

--- a/docs/AGENT_CONFIGURATION.md
+++ b/docs/AGENT_CONFIGURATION.md
@@ -52,8 +52,9 @@ field to inherit instead. Known-field casing collisions and invalid types fail.
 
 Agent IDs must match `[a-z][a-z0-9_-]{0,63}`. Overrides allow only `notifications`,
 `statuses`, and `debug`; nested agent sections and schema metadata are forbidden.
-Unknown valid agent IDs and additive settings are preserved for future runtimes.
-Current runtimes apply only `claude` and `codex`.
+Unknown valid agent IDs and additive top-level settings are preserved for future
+runtimes. Unknown fields inside `agents.<id>` are rejected by strict agent
+validation rather than preserved. Current runtimes apply only `claude` and `codex`.
 
 `config edit` and the settings wizard edit global fields only and preserve agent
 sections. `/agents/...` edits are rejected; use a text editor for these sections.

--- a/docs/AGENT_CONFIGURATION.md
+++ b/docs/AGENT_CONFIGURATION.md
@@ -1,0 +1,77 @@
+# Shared configuration and agent overrides
+
+`agent-notifications` is the primary CLI. `claude-notifications` is a permanent
+compatibility alias. Both installed launchers call the same platform binary;
+`version` displays the invoked name. Release executable names, plugin ID,
+installation directories and existing hook commands stay compatible.
+On Windows use `bin\agent-notifications.bat`; the legacy `.bat` and absolute
+`claude-notifications-windows-*.exe` paths remain supported.
+
+## Upgrade an existing configuration
+
+1. Update both Claude and Codex runtimes before enabling schema 2.
+2. Run `agent-notifications version` and `agent-notifications config inspect --json`.
+3. Find the selected file using `agent-notifications config path`.
+4. Change `schemaVersion` to `2`, then add overrides manually:
+
+```json
+{
+  "schemaVersion": 2,
+  "notifications": {
+    "desktop": {
+      "volume": 0.8,
+      "appIcon": "${AGENT_NOTIFICATIONS_ROOT}/claude_icon.png"
+    }
+  },
+  "agents": {
+    "claude": {"notifications": {"desktop": {"volume": 0.5}}},
+    "codex": {"notifications": {"desktop": {"sound": false, "volume": 0}}}
+  }
+}
+```
+
+5. Run `agent-notifications config inspect --json` again. It validates the global
+   configuration and all stored profiles without requiring inactive-agent secrets.
+
+No command automatically migrates an existing file. Missing `schemaVersion` means
+schema 1; schema 1 rejects `agents`. New installations still start with schema 1.
+Older runtimes must be upgraded before using schema 2.
+
+## Merge contract
+
+Program defaults are overlaid by global settings, then by `agents.claude` or
+`agents.codex`, selected explicitly by the hook. Config path selection remains
+explicit environment path, existing legacy path, then universal path (E > L > N).
+
+Missing fields inherit; `false`, `0`, empty strings and empty arrays are explicit
+values. Objects merge recursively, including statuses by name. Webhook `headers`
+and `payloadFields` replace the entire dictionary: `{}` clears inherited values,
+including credentials. Schema 2 preserves volume zero; schema 1 keeps its historic
+zero-to-one behavior. Null anywhere in an agent override is rejected; remove the
+field to inherit instead. Known-field casing collisions and invalid types fail.
+
+Agent IDs must match `[a-z][a-z0-9_-]{0,63}`. Overrides allow only `notifications`,
+`statuses`, and `debug`; nested agent sections and schema metadata are forbidden.
+Unknown valid agent IDs and additive settings are preserved for future runtimes.
+Current runtimes apply only `claude` and `codex`.
+
+`config edit` and the settings wizard edit global fields only and preserve agent
+sections. `/agents/...` edits are rejected; use a text editor for these sections.
+`config inspect` reports global settings, not an agent-specific effective view.
+
+## Resource placeholders
+
+`${AGENT_NOTIFICATIONS_ROOT}` is the resource bundle root, not the config directory.
+`${CLAUDE_PLUGIN_ROOT}` is a permanent alias. Resolution prefers the explicit asset
+context, then environment `AGENT_NOTIFICATIONS_ROOT`, then `CLAUDE_PLUGIN_ROOT`, then
+`.`. Expansion happens once, preserving literal dollar signs in the resolved root.
+Expanded paths are never written back to config. Existing files are not rewritten.
+
+Claude-managed hook commands must retain `${CLAUDE_PLUGIN_ROOT}` because Claude
+itself substitutes that name. The new name is for config resource paths.
+
+## Rollback
+
+Copy the desired agent values into global settings, remove `agents`, and set
+`schemaVersion` back to `1` before starting an older runtime. There is no automatic
+downgrade. Keep a backup if you need to restore individual profiles later.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -77,7 +77,7 @@ The config Store owns selection and raw patch writes; see [OS paths and recovery
 
 **Features**:
 - JSON-based configuration
-- Environment variable expansion (`${CLAUDE_PLUGIN_ROOT}`)
+- Environment variable expansion (`${AGENT_NOTIFICATIONS_ROOT}`)
 - Sensible defaults for all settings
 - Validation for webhook presets, formats, required fields
 

--- a/docs/LOCAL_DEVELOPMENT.md
+++ b/docs/LOCAL_DEVELOPMENT.md
@@ -73,7 +73,7 @@ macOS / Linux:
 
 ```bash
 go build -o bin/claude-notifications ./cmd/claude-notifications
-./bin/claude-notifications version
+./bin/agent-notifications version
 ```
 
 Windows PowerShell:
@@ -88,7 +88,7 @@ Trigger a direct desktop notification with a minimal `PreToolUse` payload:
 macOS / Linux:
 
 ```bash
-echo '{"session_id":"local-debug","tool_name":"ExitPlanMode"}' | ./bin/claude-notifications handle-hook PreToolUse
+echo '{"session_id":"local-debug","tool_name":"ExitPlanMode"}' | ./bin/agent-notifications handle-hook PreToolUse
 ```
 
 Windows PowerShell:
@@ -221,3 +221,5 @@ For click-to-focus changes:
 - Claude process debug log: printed by `scripts/e2e-real-claude.sh` for each run
 
 If a smoke test fails, keep both logs and the command output together when opening an issue or PR.
+
+The checked-in `bin/agent-notifications` symlink delegates to `bin/claude-notifications`; building the legacy development target also makes the primary command available. Installation replaces both launchers with links to the same platform executable.

--- a/docs/volume-control.md
+++ b/docs/volume-control.md
@@ -36,7 +36,7 @@ Edit the shared file selected by `config path` and set the `volume` field:
       "enabled": true,
       "sound": true,
       "volume": 0.5,
-      "appIcon": "${CLAUDE_PLUGIN_ROOT}/claude_icon.png"
+      "appIcon": "${AGENT_NOTIFICATIONS_ROOT}/claude_icon.png"
     },
     ...
   },
@@ -97,7 +97,7 @@ The same audio path is used by notifications and `cmd/sound-preview`.
       "enabled": true,
       "sound": true,
       "volume": 0.3,
-      "appIcon": "${CLAUDE_PLUGIN_ROOT}/claude_icon.png"
+      "appIcon": "${AGENT_NOTIFICATIONS_ROOT}/claude_icon.png"
     }
   }
 }
@@ -114,7 +114,7 @@ The same audio path is used by notifications and `cmd/sound-preview`.
       "enabled": true,
       "sound": true,
       "volume": 0.5,
-      "appIcon": "${CLAUDE_PLUGIN_ROOT}/claude_icon.png"
+      "appIcon": "${AGENT_NOTIFICATIONS_ROOT}/claude_icon.png"
     }
   }
 }
@@ -131,7 +131,7 @@ The same audio path is used by notifications and `cmd/sound-preview`.
       "enabled": true,
       "sound": true,
       "volume": 1.0,
-      "appIcon": "${CLAUDE_PLUGIN_ROOT}/claude_icon.png"
+      "appIcon": "${AGENT_NOTIFICATIONS_ROOT}/claude_icon.png"
     }
   }
 }
@@ -148,7 +148,7 @@ The same audio path is used by notifications and `cmd/sound-preview`.
       "enabled": true,
       "sound": false,
       "volume": 1.0,
-      "appIcon": "${CLAUDE_PLUGIN_ROOT}/claude_icon.png"
+      "appIcon": "${AGENT_NOTIFICATIONS_ROOT}/claude_icon.png"
     }
   }
 }

--- a/internal/codexsetup/codexsetup.go
+++ b/internal/codexsetup/codexsetup.go
@@ -644,6 +644,10 @@ func stageBundle(src, dst string) (func() error, func(), error) {
 		}
 		names = append(names, name)
 	}
+	if err := installBundleLaunchers(filepath.Join(stage, "new", "bin"), runtime.GOOS, runtime.GOARCH); err != nil {
+		finish()
+		return nil, nil, err
+	}
 	var moved, installed []string
 	rollback := func() error {
 		retain = true
@@ -801,7 +805,7 @@ func SortedEvents() []string {
 
 func runtimeBinary(name string) bool {
 	switch name {
-	case "terminal-notifier.app", "codex-hook-wrapper.sh", "codex-hook-wrapper.cmd", "hook-wrapper.sh", "install.sh", "claude-notifications", "ClaudeNotifier.app":
+	case "terminal-notifier.app", "codex-hook-wrapper.sh", "codex-hook-wrapper.cmd", "hook-wrapper.sh", "install.sh", "claude-notifications", "agent-notifications", "claude-notifications.bat", "agent-notifications.bat", "claude-notifications.cmd", "agent-notifications.cmd", "ClaudeNotifier.app":
 		return true
 	}
 	for _, platform := range []string{"linux", "darwin", "windows"} {
@@ -839,6 +843,43 @@ func checkHooksSnapshot(path string, expected []byte, existed bool) error {
 	}
 	if existed != (err == nil) || !bytes.Equal(current, expected) {
 		return fmt.Errorf("hooks.json changed during setup; retry")
+	}
+	return nil
+}
+
+// Launchers are generated in the private staging tree before any live entry moves.
+// This also upgrades older bundles containing only the platform executable.
+func installBundleLaunchers(bin, platform, arch string) error {
+	binary := "claude-notifications-" + platform + "-" + arch
+	if platform == "windows" {
+		binary += ".exe"
+	}
+	info, err := os.Lstat(filepath.Join(bin, binary))
+	if os.IsNotExist(err) {
+		return nil
+	} // Lazy-install bundles may have no executable yet.
+	if err != nil {
+		return err
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("platform executable is not regular")
+	}
+	for _, name := range []string{"claude-notifications", "agent-notifications"} {
+		target := filepath.Join(bin, name)
+		if platform == "windows" {
+			target += ".bat"
+		}
+		if err := os.Remove(target); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+		if platform == "windows" {
+			content := "@echo off\r\nsetlocal\r\nset AGENT_NOTIFICATIONS_LAUNCHER=" + name + "\r\n\"%~dp0" + binary + "\" %*\r\n"
+			if err := os.WriteFile(target, []byte(content), 0755); err != nil {
+				return err
+			}
+		} else if err := os.Symlink(binary, target); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/internal/codexsetup/launchers_test.go
+++ b/internal/codexsetup/launchers_test.go
@@ -1,0 +1,33 @@
+package codexsetup
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestWindowsBundleLaunchers(t *testing.T) {
+	bin := t.TempDir()
+	binary := "claude-notifications-windows-arm64.exe"
+	if err := os.WriteFile(filepath.Join(bin, binary), []byte("fixture"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := installBundleLaunchers(bin, "windows", "arm64"); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"agent-notifications", "claude-notifications"} {
+		data, err := os.ReadFile(filepath.Join(bin, name+".bat"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(string(data), `"%~dp0`+binary+`" %*`) || !strings.Contains(string(data), "set AGENT_NOTIFICATIONS_LAUNCHER="+name) {
+			t.Fatalf("wrong wrapper: %s", data)
+		}
+		for _, suffix := range []string{"", ".bat", ".cmd"} {
+			if !runtimeBinary(name + suffix) {
+				t.Fatal("launcher missing from allowlist", name+suffix)
+			}
+		}
+	}
+}

--- a/internal/config/agents.go
+++ b/internal/config/agents.go
@@ -1,0 +1,194 @@
+package config
+
+import (
+	"bytes"
+	"encoding/json"
+	"reflect"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// AgentID is selected by the composition root, never inferred from paths or env.
+type AgentID string
+
+const (
+	AgentClaude                AgentID = "claude"
+	AgentCodex                 AgentID = "codex"
+	AssetRootPlaceholder               = "AGENT_NOTIFICATIONS_ROOT"
+	LegacyAssetRootPlaceholder         = "CLAUDE_PLUGIN_ROOT"
+)
+
+func assetRoot(a AssetContext) string {
+	if a.PluginRoot != "" {
+		return a.PluginRoot
+	}
+	if a.LookupEnv != nil {
+		for _, k := range []string{AssetRootPlaceholder, LegacyAssetRootPlaceholder} {
+			if v, ok := a.LookupEnv(k); ok && !isUnresolvedPluginRoot(v) {
+				return v
+			}
+		}
+	}
+	return "."
+}
+
+var agentIDPattern = regexp.MustCompile(`^[a-z][a-z0-9_-]{0,63}$`)
+
+func validateAgents(raw map[string]json.RawMessage, schema int) error {
+	fail := func() error { return &Error{Code: ConfigInvalid} }
+	count := 0
+	for key, value := range raw {
+		if !strings.EqualFold(key, "agents") {
+			continue
+		}
+		count++
+		if schema != 2 || count > 1 {
+			return fail()
+		}
+		var agents map[string]json.RawMessage
+		if json.Unmarshal(value, &agents) != nil || agents == nil {
+			return fail()
+		}
+		for id, profile := range agents {
+			if !agentIDPattern.MatchString(id) || containsNull(profile) {
+				return fail()
+			}
+			var fields map[string]json.RawMessage
+			if json.Unmarshal(profile, &fields) != nil || fields == nil {
+				return fail()
+			}
+			for field := range fields {
+				switch strings.ToLower(field) {
+				case "notifications", "statuses", "debug":
+				default:
+					return fail()
+				}
+			}
+			var c Config
+			if decodeTyped(profile, &c) != nil || ambiguousFields(profile, reflect.TypeOf(c), "") != "" {
+				return fail()
+			}
+		}
+	}
+	return nil
+}
+
+func containsNull(data []byte) bool {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	for {
+		tok, err := dec.Token()
+		if err != nil {
+			return false
+		}
+		if tok == nil {
+			return true
+		}
+	}
+}
+
+// canonicalObject matches encoding/json's known-field casing before merging.
+// Dynamic dictionary and status names remain case-sensitive and untouched.
+func canonicalObject(data []byte, typ reflect.Type) map[string]json.RawMessage {
+	var raw map[string]json.RawMessage
+	_ = json.Unmarshal(data, &raw)
+	return canonicalFields(raw, typ)
+}
+
+func canonicalFields(raw map[string]json.RawMessage, typ reflect.Type) map[string]json.RawMessage {
+	for typ.Kind() == reflect.Pointer {
+		typ = typ.Elem()
+	}
+	if typ.Kind() != reflect.Struct && typ.Kind() != reflect.Map {
+		return raw
+	}
+	out := make(map[string]json.RawMessage, len(raw))
+	for key, value := range raw {
+		name := key
+		var child reflect.Type
+		if typ.Kind() == reflect.Map {
+			child = typ.Elem()
+		} else {
+			for i := 0; i < typ.NumField(); i++ {
+				f := typ.Field(i)
+				n := strings.Split(f.Tag.Get("json"), ",")[0]
+				if strings.EqualFold(key, n) {
+					name, child = n, f.Type
+					break
+				}
+			}
+		}
+		if typ.Kind() == reflect.Struct && child == nil {
+			continue
+		}
+		if child != nil && len(bytes.TrimSpace(value)) > 0 && bytes.TrimSpace(value)[0] == '{' {
+			value, _ = json.Marshal(canonicalObject(value, child))
+		}
+		out[name] = value
+	}
+	return out
+}
+
+func mergeObjects(base, override map[string]json.RawMessage, path string) {
+	for key, value := range override {
+		pointer := path + "/" + key
+		replace := pointer == "/notifications/webhook/headers" || pointer == "/notifications/webhook/payloadFields"
+		var right, left map[string]json.RawMessage
+		if !replace && json.Unmarshal(value, &right) == nil && right != nil {
+			_ = json.Unmarshal(base[key], &left)
+			if left == nil {
+				left = map[string]json.RawMessage{}
+			}
+			mergeObjects(left, right, pointer)
+			value, _ = json.Marshal(left)
+		}
+		base[key] = value
+	}
+}
+
+// preparedProfiles owns only recognized runtime fields. Raw document metadata
+// remains solely in Document for storage; it is never cloned for each profile.
+type preparedProfiles struct {
+	global map[string]json.RawMessage
+	agents map[AgentID]map[string]json.RawMessage
+}
+
+func (d Document) prepareProfiles() preparedProfiles {
+	raw := d.Raw() // Parse the document once, independent of the number of agents.
+	typ := reflect.TypeOf(Config{})
+	defaults, _ := json.Marshal(buildDefaultConfig("${AGENT_NOTIFICATIONS_ROOT}"))
+	p := preparedProfiles{global: canonicalObject(defaults, typ), agents: map[AgentID]map[string]json.RawMessage{}}
+	mergeObjects(p.global, canonicalFields(raw, typ), "")
+	for key, value := range raw {
+		if !strings.EqualFold(key, "agents") {
+			continue
+		}
+		var agents map[string]json.RawMessage
+		_ = json.Unmarshal(value, &agents)
+		for id, body := range agents {
+			p.agents[AgentID(id)] = canonicalObject(body, typ)
+		}
+	}
+	return p
+}
+
+func (p preparedProfiles) mergedProfile(agent AgentID) ([]byte, error) {
+	// RawMessage values are immutable. mergeObjects decodes objects into fresh
+	// maps and replaces values, so copying this small outer map isolates a view.
+	base := make(map[string]json.RawMessage, len(p.global))
+	for key, value := range p.global {
+		base[key] = value
+	}
+	mergeObjects(base, p.agents[agent], "")
+	return json.Marshal(base)
+}
+
+func (p preparedProfiles) validationAgents() []AgentID {
+	ids := make([]AgentID, 0, len(p.agents)+1)
+	ids = append(ids, "")
+	for id := range p.agents {
+		ids = append(ids, id)
+	}
+	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+	return ids
+}

--- a/internal/config/agents_test.go
+++ b/internal/config/agents_test.go
@@ -1,0 +1,211 @@
+package config
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestAgentProfilesMergeAndRawPreservation(t *testing.T) {
+	raw := []byte(`{"schemaVersion":2,"future":{"n":9007199254740993},"notifications":{"desktop":{"volume":0.8},"webhook":{"headers":{"Authorization":"secret"},"payloadFields":{"token":"secret"}},"suppressFilters":[{"folder":"x"}]},"statuses":{"question":{"title":"global"}},"agents":{"claude":{"notifications":{"desktop":{"volume":0.5}}},"codex":{"notifications":{"desktop":{"sound":false,"volume":0,"appIcon":""},"webhook":{"headers":{},"payloadFields":{}},"suppressFilters":[]},"statuses":{"question":{"title":""}}},"future-agent":{"debug":{"benchmark":true}}}}`)
+	d, err := ParseDocument(raw, "/test", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	claude, err := d.Effective(AssetContext{Agent: AgentClaude})
+	if err != nil {
+		t.Fatal(err)
+	}
+	codex, err := d.Effective(AssetContext{Agent: AgentCodex})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if claude.Notifications.Desktop.Volume != .5 || len(claude.Notifications.Webhook.Headers) != 1 {
+		t.Fatal("claude inheritance")
+	}
+	if codex.Notifications.Desktop.Volume != 0 || codex.Notifications.Desktop.Sound || codex.Notifications.Desktop.AppIcon != "" || len(codex.Notifications.Webhook.Headers) != 0 || len(codex.Notifications.Webhook.PayloadFields) != 0 || len(codex.Notifications.SuppressFilters) != 0 || codex.Statuses["question"].Title != "" {
+		t.Fatalf("codex merge: %+v", codex)
+	}
+	if !bytes.Equal(raw, d.Bytes()) {
+		t.Fatal("runtime mutated source")
+	}
+	next, err := ApplyRawEdits(d, Edits{Set: map[string]json.RawMessage{"/debug/benchmark": json.RawMessage(`true`)}}, ValidationAssets(""))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !sameJSON(d.Raw()["agents"], next.Raw()["agents"]) || !sameJSON(d.Raw()["future"], next.Raw()["future"]) {
+		t.Fatal("edit lost unknown data")
+	}
+	if _, err := ApplyRawEdits(d, Edits{Set: map[string]json.RawMessage{"/agents/codex/debug/benchmark": json.RawMessage(`true`)}}, AssetContext{}); err == nil {
+		t.Fatal("agent edit allowed")
+	}
+}
+
+func TestAgentStructureRejected(t *testing.T) {
+	for _, raw := range []string{
+		`{"agents":{}}`, `{"schemaVersion":1,"agents":{}}`,
+		`{"schemaVersion":2,"agents":null}`, `{"schemaVersion":2,"agents":[]}`,
+		`{"schemaVersion":2,"agents":{"Bad":{}}}`, `{"schemaVersion":2,"agents":{"a":{"schemaVersion":2}}}`,
+		`{"schemaVersion":2,"agents":{"a":{"agents":{}}}}`, `{"schemaVersion":2,"agents":{"a":{"future":true}}}`,
+		`{"schemaVersion":2,"agents":{"a":{"notifications":{"desktop":{"volume":null}}}}}`,
+		`{"schemaVersion":2,"agents":{"a":{"notifications":{"webhook":{"payloadFields":{"x":[null]}}}}}}`,
+		`{"schemaVersion":2,"agents":{"a":{"debug":{"benchmark":"yes"}}}}`,
+		`{"schemaVersion":2,"agents":{"a":{"debug":{"benchmark":true,"Benchmark":false}}}}`,
+		`{"schemaVersion":2,"agents":{},"Agents":{}}`,
+		`{"schemaVersion":2,"notifications":{"desktop":{"volume":1,"Volume":0}}}`,
+	} {
+		if _, err := ParseDocument([]byte(raw), "/test", true); err == nil {
+			t.Errorf("accepted %s", raw)
+		}
+	}
+}
+
+func TestAgentValidationAllProfilesWithoutForeignSecrets(t *testing.T) {
+	raw := `{"schemaVersion":2,"agents":{"claude":{"notifications":{"webhook":{"enabled":true,"url":"${CLAUDE_ONLY_SECRET}"}}}}}`
+	d, err := ParseDocument([]byte(raw), "/test", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lookup := func(string) (string, bool) { return "", false }
+	if _, err = d.Effective(AssetContext{Agent: AgentCodex, LookupEnv: lookup}); err != nil {
+		t.Fatal("foreign secret required", err)
+	}
+	if _, err = d.Effective(AssetContext{Agent: AgentClaude, LookupEnv: lookup}); err == nil {
+		t.Fatal("missing active secret accepted")
+	}
+	d, err = ParseDocument([]byte(`{"schemaVersion":2,"agents":{"claude":{"notifications":{"desktop":{"volume":3}}}}}`), "/test", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = d.Effective(AssetContext{Agent: AgentCodex}); err == nil {
+		t.Fatal("invalid inactive profile accepted")
+	}
+}
+
+func TestSchemaTwoPresenceAndKnownCasing(t *testing.T) {
+	for _, tc := range []struct {
+		raw    string
+		volume float64
+	}{
+		{`{"schemaVersion":2}`, 1}, {`{"schemaVersion":2,"notifications":{"desktop":{"volume":0}}}`, 0},
+		{`{"schemaVersion":1,"notifications":{"desktop":{"volume":0}}}`, 1},
+		{`{"schemaVersion":2,"Notifications":{"Desktop":{"Volume":0.7}},"Agents":{"codex":{"Notifications":{"Desktop":{"Volume":0}}}}}`, 0},
+	} {
+		d, err := ParseDocument([]byte(tc.raw), "/test", true)
+		if err != nil {
+			t.Fatal(err)
+		}
+		c, err := d.Effective(AssetContext{Agent: AgentCodex})
+		if err != nil || c.Notifications.Desktop.Volume != tc.volume {
+			t.Fatalf("%s: %+v %v", tc.raw, c, err)
+		}
+	}
+}
+
+func TestAssetAliasesSingleExpansion(t *testing.T) {
+	for _, root := range []string{"/assets/space Unicode 日本/$literal", `C:\space 日本\$literal`} {
+		for _, explicit := range []bool{false, true} {
+			a := AssetContext{LookupEnv: func(k string) (string, bool) {
+				if k == AssetRootPlaceholder {
+					return root, true
+				}
+				if k == LegacyAssetRootPlaceholder {
+					return "/wrong", true
+				}
+				return "expanded", true
+			}}
+			if explicit {
+				a.PluginRoot = root
+				a.LookupEnv = func(string) (string, bool) { return "/wrong", true }
+			}
+			d, err := ParseDocument([]byte(`{"notifications":{"desktop":{"appIcon":"${AGENT_NOTIFICATIONS_ROOT}/icon.png"}},"statuses":{"question":{"sound":"${CLAUDE_PLUGIN_ROOT}/icon.png"}}}`), "/test", true)
+			if err != nil {
+				t.Fatal(err)
+			}
+			c, err := d.Effective(a)
+			if err != nil {
+				t.Fatal(err)
+			}
+			want := filepath.Clean(root + "/icon.png")
+			if c.Notifications.Desktop.AppIcon != want || c.Statuses["question"].Sound != want {
+				t.Fatalf("double expansion or alias mismatch: %+v", c)
+			}
+		}
+	}
+}
+
+func TestFutureAgentValidatedButNotApplied(t *testing.T) {
+	for _, volume := range []string{"0", "3"} {
+		d, err := ParseDocument([]byte(`{"schemaVersion":2,"agents":{"future":{"notifications":{"desktop":{"volume":`+volume+`}}}}}`), "/test", true)
+		if err != nil {
+			t.Fatal(err)
+		}
+		c, err := d.Effective(AssetContext{Agent: AgentID("future")})
+		if volume == "3" {
+			if err == nil {
+				t.Fatal("invalid future profile accepted")
+			}
+			continue
+		}
+		if err != nil || c.Notifications.Desktop.Volume != 1 {
+			t.Fatal("unknown runtime applied profile", err)
+		}
+	}
+}
+
+func TestPreparedProfilesExcludeMetadataAndIsolateMerges(t *testing.T) {
+	profiles := make(map[string]any, 300)
+	for i := 0; i < 300; i++ {
+		profiles[fmt.Sprintf("agent-%03d", i)] = map[string]any{"notifications": map[string]any{"desktop": map[string]any{"volume": float64(i%10) / 10}}}
+	}
+	raw, err := json.Marshal(map[string]any{
+		"schemaVersion": 2, "agents": profiles,
+		"futureMetadata": strings.Repeat("large unknown metadata", 16000),
+		"notifications":  map[string]any{"futureMetadata": strings.Repeat("nested unknown", 16000)},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	d, err := ParseDocument(raw, "/test", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	prepared := d.prepareProfiles()
+	global, err := prepared.mergedProfile("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(global) > 10000 || bytes.Contains(global, []byte("futureMetadata")) || bytes.Contains(global, []byte(`"agents"`)) || bytes.Contains(global, []byte(`"schemaVersion"`)) {
+		t.Fatal("runtime body retains document metadata")
+	}
+	if len(prepared.agents) != len(profiles) {
+		t.Fatal("lost stored profiles")
+	}
+	// Cached profiles remain usable without the original bytes. No profile merge
+	// can reparse the full document, and view mutations cannot pollute the cache.
+	saved := d.original
+	d.original = nil
+	for _, id := range prepared.validationAgents() {
+		body, err := prepared.mergedProfile(id)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(body) > 10000 || bytes.Contains(body, []byte("futureMetadata")) {
+			t.Fatal("per-profile work includes metadata")
+		}
+	}
+	after, err := prepared.mergedProfile("")
+	if err != nil || !bytes.Equal(global, after) {
+		t.Fatal("profile merges mutated shared global")
+	}
+	d.original = saved
+	if !bytes.Equal(raw, d.Bytes()) {
+		t.Fatal("preparation rewrote raw document")
+	}
+	if _, err := d.Effective(AssetContext{Agent: AgentCodex}); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -151,7 +151,7 @@ func defaultConfig(resolvedPluginRoot string) *Config {
 	// Get plugin root from environment, fallback to current directory
 	pluginRoot := resolvedPluginRoot
 	if pluginRoot == "" {
-		pluginRoot = platform.ExpandEnv("${CLAUDE_PLUGIN_ROOT}")
+		pluginRoot = assetRoot(AssetContext{LookupEnv: os.LookupEnv})
 	}
 	if isUnresolvedPluginRoot(pluginRoot) {
 		pluginRoot = "."
@@ -161,6 +161,8 @@ func defaultConfig(resolvedPluginRoot string) *Config {
 
 func isUnresolvedPluginRoot(pluginRoot string) bool {
 	return pluginRoot == "" ||
+		pluginRoot == "$AGENT_NOTIFICATIONS_ROOT" ||
+		pluginRoot == "${AGENT_NOTIFICATIONS_ROOT}" ||
 		pluginRoot == "$CLAUDE_PLUGIN_ROOT" ||
 		pluginRoot == "${CLAUDE_PLUGIN_ROOT}"
 }
@@ -289,7 +291,7 @@ func load(path, pluginRoot string) (*Config, error) {
 func defaultConfigForLoad(pluginRoot string) *Config {
 	resolvedRoot := pluginRoot
 	if resolvedRoot == "" {
-		resolvedRoot = os.Getenv("CLAUDE_PLUGIN_ROOT")
+		resolvedRoot = assetRoot(AssetContext{LookupEnv: os.LookupEnv})
 	}
 	if isUnresolvedPluginRoot(resolvedRoot) {
 		return buildDefaultConfig(".")
@@ -327,8 +329,8 @@ func mergeStatusOverrides(data []byte, config *Config, defaults map[string]Statu
 
 func expandEnv(value, pluginRoot string) string {
 	return os.Expand(value, func(key string) string {
-		if key == "CLAUDE_PLUGIN_ROOT" && pluginRoot != "" {
-			return pluginRoot
+		if key == AssetRootPlaceholder || key == LegacyAssetRootPlaceholder {
+			return assetRoot(AssetContext{PluginRoot: pluginRoot, LookupEnv: os.LookupEnv})
 		}
 		return os.Getenv(key)
 	})
@@ -364,7 +366,11 @@ func GetStableConfigPath() (string, error) {
 // LoadFromPluginRoot reads the shared canonical Store. Bundle paths are
 // resources and historical evidence only; selected errors never fall back.
 func LoadFromPluginRoot(pluginRoot string) (*Config, error) {
-	return loadFromPluginRoot(pluginRoot, func(msg string) {
+	return LoadForAgent(pluginRoot, AgentClaude)
+}
+
+func LoadForAgent(pluginRoot string, agent AgentID) (*Config, error) {
+	return loadFromPluginRoot(pluginRoot, agent, func(msg string) {
 		fmt.Fprintln(os.Stderr, msg)
 		logging.Warn("%s", msg)
 	})
@@ -374,14 +380,19 @@ func LoadFromPluginRoot(pluginRoot string) (*Config, error) {
 // in the file log only. Observation hook routes (Codex) must never write to
 // the process stderr.
 func LoadFromPluginRootQuiet(pluginRoot string) (*Config, error) {
-	return loadFromPluginRoot(pluginRoot, func(msg string) {
+	return LoadForAgentQuiet(pluginRoot, AgentClaude)
+}
+
+func LoadForAgentQuiet(pluginRoot string, agent AgentID) (*Config, error) {
+	return loadFromPluginRoot(pluginRoot, agent, func(msg string) {
 		logging.Warn("%s", msg)
 	})
 }
 
-func loadFromPluginRoot(pluginRoot string, warn func(string)) (*Config, error) {
+func loadFromPluginRoot(pluginRoot string, agent AgentID, warn func(string)) (*Config, error) {
 	env := SnapshotEnv()
 	assets, legacy := ConsumerContext(pluginRoot)
+	assets.Agent = agent
 	_, cfg, selection, err := ReadDocumentSelection(ReadRequest{Env: env, Assets: assets, Legacy: legacy, ReadSnapshot: ReadFileSnapshot})
 	for _, diagnostic := range append(selection.Diagnostics, ConsumerDiagnostics()...) {
 		warn(string(diagnostic.Code))

--- a/internal/config/document.go
+++ b/internal/config/document.go
@@ -81,13 +81,16 @@ func ParseDocument(data []byte, physicalPath string, exists bool) (Document, err
 			if !valid || n == "0" {
 				return fail(ConfigInvalid, 0)
 			}
-			if n != "1" {
+			if n != "1" && n != "2" {
 				return fail(ConfigUnsupportedSchema, 0)
 			}
-			schema = 1
+			schema, _ = strconv.Atoi(n)
 		}
 	}
 	if count > 1 {
+		return fail(ConfigInvalid, 0)
+	}
+	if err := validateAgents(raw, schema); err != nil {
 		return fail(ConfigInvalid, 0)
 	}
 	// Typed decode checks known-field types while ignoring additive unknown fields.
@@ -97,6 +100,9 @@ func ParseDocument(data []byte, physicalPath string, exists bool) (Document, err
 	}
 	d := Document{original: bytes.Clone(data), schema: schema}
 	d.ambiguous = ambiguousFields(data, reflect.TypeOf(Config{}), "")
+	if schema == 2 && d.ambiguous != "" {
+		return fail(ConfigInvalid, 0)
+	}
 	h := sha256.New()
 	h.Write([]byte(physicalPath))
 	h.Write([]byte{0})

--- a/internal/config/document_test.go
+++ b/internal/config/document_test.go
@@ -13,7 +13,7 @@ func TestStrictDocument(t *testing.T) {
 			t.Errorf("accepted invalid input of length %d", len(s))
 		}
 	}
-	_, err := ParseDocument([]byte(`{"schemaVersion":2}`), "/fixture", true)
+	_, err := ParseDocument([]byte(`{"schemaVersion":3}`), "/fixture", true)
 	var ce *Error
 	if !errors.As(err, &ce) || ce.Code != ConfigUnsupportedSchema {
 		t.Fatalf("schema: %v", err)

--- a/internal/config/effective.go
+++ b/internal/config/effective.go
@@ -11,6 +11,7 @@ import (
 // AssetContext is separate from resolver inputs. LookupEnv must be injected;
 // no ambient environment is read when constructing an effective Config.
 type AssetContext struct {
+	Agent      AgentID
 	PluginRoot string
 	LookupEnv  func(string) (string, bool)
 }
@@ -18,15 +19,39 @@ type AssetContext struct {
 // Effective constructs an independent, expanded runtime value using historical
 // defaults and tri-state semantics. Never marshal its result back to storage.
 func (d Document) Effective(assets AssetContext) (*Config, error) {
-	c := buildDefaultConfig("${CLAUDE_PLUGIN_ROOT}")
+	if d.schema == 1 {
+		return d.effectiveProfile(assets, d.original)
+	}
+	profiles := d.prepareProfiles()
+	for _, agent := range profiles.validationAgents() {
+		data, err := profiles.mergedProfile(agent)
+		if err != nil {
+			return nil, err
+		}
+		if _, err := d.effectiveProfile(AssetContext{Agent: agent, LookupEnv: func(string) (string, bool) { return "CONFIG_ENV_PLACEHOLDER", true }}, data); err != nil {
+			return nil, err
+		}
+	}
+	if assets.Agent != AgentClaude && assets.Agent != AgentCodex {
+		assets.Agent = ""
+	}
+	data, err := profiles.mergedProfile(assets.Agent)
+	if err != nil {
+		return nil, err
+	}
+	return d.effectiveProfile(assets, data)
+}
+
+func (d Document) effectiveProfile(assets AssetContext, data []byte) (*Config, error) {
+	c := buildDefaultConfig("${AGENT_NOTIFICATIONS_ROOT}")
 	defaults := make(map[string]StatusInfo, len(c.Statuses))
 	for k, v := range c.Statuses {
 		defaults[k] = v
 	}
-	if err := decodeTyped(d.original, c); err != nil {
+	if err := decodeTyped(data, c); err != nil {
 		return nil, &Error{Code: ConfigInvalid}
 	}
-	if err := mergeStatusOverrides(d.original, c, defaults); err != nil {
+	if err := mergeStatusOverrides(data, c, defaults); err != nil {
 		return nil, &Error{Code: ConfigInvalid}
 	}
 	if c.Statuses == nil {
@@ -34,16 +59,8 @@ func (d Document) Effective(assets AssetContext) (*Config, error) {
 	}
 	expand := func(s string) string {
 		return os.Expand(s, func(k string) string {
-			if k == "CLAUDE_PLUGIN_ROOT" {
-				if assets.PluginRoot != "" {
-					return assets.PluginRoot
-				}
-				if assets.LookupEnv != nil {
-					if v, ok := assets.LookupEnv(k); ok && !isUnresolvedPluginRoot(v) {
-						return v
-					}
-				}
-				return "."
+			if k == AssetRootPlaceholder || k == LegacyAssetRootPlaceholder {
+				return assetRoot(assets)
 			}
 			if assets.LookupEnv != nil {
 				if v, ok := assets.LookupEnv(k); ok {
@@ -68,7 +85,9 @@ func (d Document) Effective(assets AssetContext) (*Config, error) {
 	}
 	// A nonempty literal root prevents applyDefaults consulting the environment.
 	// Missing statuses were already present before decode and merged above.
-	c.applyDefaults(".")
+	if d.schema == 1 {
+		c.applyDefaults(".")
+	}
 	if err := c.Validate(); err != nil {
 		return nil, &Error{Code: ConfigInvalid}
 	}

--- a/internal/config/effective_test.go
+++ b/internal/config/effective_test.go
@@ -39,6 +39,12 @@ func TestSeedMatchesShippedEffectiveDefaults(t *testing.T) {
 	if seed.SchemaVersion() != 1 || !bytes.Contains(seed.Bytes(), []byte(`"schemaVersion": 1`)) {
 		t.Fatal("seed schema")
 	}
+	if !bytes.Contains(configtemplate.Bytes(), []byte("${CLAUDE_PLUGIN_ROOT}")) ||
+		bytes.Contains(configtemplate.Bytes(), []byte("${AGENT_NOTIFICATIONS_ROOT}")) ||
+		!bytes.Contains(seed.Bytes(), []byte("${CLAUDE_PLUGIN_ROOT}")) ||
+		bytes.Contains(seed.Bytes(), []byte("${AGENT_NOTIFICATIONS_ROOT}")) {
+		t.Fatal("schema 1 template must retain the legacy asset placeholder")
+	}
 	if !bytes.HasSuffix(seed.Bytes(), []byte("\n")) || bytes.HasSuffix(seed.Bytes(), []byte("\n\n")) {
 		t.Fatal("seed newline")
 	}

--- a/internal/config/read_test.go
+++ b/internal/config/read_test.go
@@ -12,7 +12,7 @@ import (
 func TestReadDocumentSelectedErrorNeverFallsBack(t *testing.T) {
 	l := "/h/.claude/claude-notifications-go/config.json"
 	n := "/h/.config/agent-notifications/config.json"
-	for _, data := range []string{"", `null`, `{"schemaVersion":2}`, `{"notifications":{"desktop":{"volume":3}}}`} {
+	for _, data := range []string{"", `null`, `{"schemaVersion":3}`, `{"notifications":{"desktop":{"volume":3}}}`} {
 		r := ReadRequest{Env: fakeEnv("linux", map[string]string{"HOME": "/h"}, map[string]fs.FileMode{l: 0, n: 0}), ReadSnapshot: func(p string, limit int) (Snapshot, error) {
 			if p != l {
 				t.Fatal("fallback read")

--- a/internal/hooks/agent_config_test.go
+++ b/internal/hooks/agent_config_test.go
@@ -1,0 +1,21 @@
+package hooks
+
+import (
+	"github.com/777genius/agent-notifications/internal/config"
+	"testing"
+)
+
+func TestConfigAgentCompositionMapping(t *testing.T) {
+	for _, tc := range []struct {
+		product Product
+		want    config.AgentID
+	}{{ProductClaude, config.AgentClaude}, {ProductCodex, config.AgentCodex}} {
+		got, err := configAgent(tc.product)
+		if err != nil || got != tc.want {
+			t.Fatalf("%q: %q %v", tc.product, got, err)
+		}
+	}
+	if _, err := configAgent(Product("unknown")); err == nil {
+		t.Fatal("unsupported product accepted")
+	}
+}

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -90,7 +90,7 @@ type Handler struct {
 // NewHandler creates a new hook handler
 func NewHandler(pluginRoot string) (*Handler, error) {
 	// Load config
-	cfg, err := config.LoadFromPluginRoot(pluginRoot)
+	cfg, err := config.LoadForAgent(pluginRoot, config.AgentClaude)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load config: %w", err)
 	}
@@ -102,7 +102,11 @@ func NewHandler(pluginRoot string) (*Handler, error) {
 // explicit product and event source. Unlike NewHandler, config warnings go to
 // the file log only: observation routes must not write to stderr.
 func NewHandlerWithSource(pluginRoot string, product Product, source EventSource) (*Handler, error) {
-	cfg, err := config.LoadFromPluginRootQuiet(pluginRoot)
+	agent, err := configAgent(product)
+	if err != nil {
+		return nil, err
+	}
+	cfg, err := config.LoadForAgentQuiet(pluginRoot, agent)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load config: %w", err)
 	}
@@ -919,4 +923,15 @@ func (h *Handler) shouldEmitPermissionGuidance() bool {
 	}
 
 	return true
+}
+
+func configAgent(product Product) (config.AgentID, error) {
+	switch product {
+	case ProductClaude:
+		return config.AgentClaude, nil
+	case ProductCodex:
+		return config.AgentCodex, nil
+	default:
+		return "", fmt.Errorf("unsupported product: %q", product)
+	}
 }


### PR DESCRIPTION
Adds one shared schema 2 config with deterministic Claude and Codex overrides while preserving schema 1 behavior and the E > L > N resolver.

The primary user-facing command is now `agent-notifications`; `claude-notifications`, existing platform binaries, plugin IDs, config paths, hooks, and persistence identifiers remain compatible. New templates use `${AGENT_NOTIFICATIONS_ROOT}`, while `${CLAUDE_PLUGIN_ROOT}` remains a permanent runtime alias.

Validation:
- `go test ./...`
- `bash bin/agent-launcher_test.sh`
- `bash bin/install_transaction_test.sh`
- `bash bin/install_config_preflight_test.sh`
- independent Astra medium review: no findings after two remediation rounds


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `agent-notifications` as the primary command, with `claude-notifications` retained as a compatibility alias.
  * Added agent-aware configuration support for Claude and Codex, including schema 2 profiles and per-agent overrides.
  * Codex setup now creates and maintains both command launchers across supported platforms.
  * Added `setup-codex` and `config` entries to command usage documentation.

* **Documentation**
  * Updated configuration examples to use `AGENT_NOTIFICATIONS_ROOT`.
  * Added documentation covering agent configuration, inheritance, validation, and rollback procedures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->