### PR TITLE
test(release): qualify artifact config and delivery across platforms

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -51,6 +51,10 @@ jobs:
         run: go test -v -race -coverprofile=coverage.txt -covermode=atomic ./...
         shell: bash
 
+      - name: Repeat config crash recovery
+        run: go test -race -count=10 -run '^TestStoreKilledLockOwner$' ./internal/config
+        shell: bash
+
       - name: Build binary
         run: go build -o bin/claude-notifications.exe ./cmd/claude-notifications
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -292,6 +292,14 @@ jobs:
             binary: claude-notifications-windows-amd64.exe
 
     steps:
+      - name: Checkout artifact qualification tests
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: '3.12'
+
       - name: Download binary artifacts
         uses: actions/download-artifact@v8
         with:
@@ -342,4 +350,10 @@ jobs:
           list_sounds="${MAIN_BINARY/claude-notifications/list-sounds}"
           "./dist/$sound_preview" --help
           "./dist/$list_sounds" --help
+        shell: bash
+
+      - name: Qualify configuration and notification delivery
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: python scripts/release-artifact-e2e.py --binary "dist/${{ matrix.binary }}" --version "$RELEASE_TAG"
         shell: bash

--- a/internal/config/store_process_test.go
+++ b/internal/config/store_process_test.go
@@ -465,7 +465,9 @@ func TestStoreKilledLockOwner(t *testing.T) {
 	if e = cmd.Wait(); e == nil {
 		t.Fatalf("killed child succeeded: %s", output)
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	// Exercise crash recovery with the same budget as a real mutation. This
+	// includes path validation, ACL checks and initialization, not just locking.
+	ctx, cancel := context.WithTimeout(context.Background(), MutationTimeout)
 	defer cancel()
 	if _, e = EnsureInitialized(ctx, InitRequest{Env: env}); e != nil {
 		t.Fatal(e)

--- a/scripts/release-artifact-e2e.py
+++ b/scripts/release-artifact-e2e.py
@@ -117,6 +117,14 @@ def main():
                     assert len(deliveries) == count + 1, (case, product, deliveries)
                     expected = '/shared' if case == 'legacy' else '/' + product
                     assert deliveries[-1][0] == expected and marker in deliveries[-1][1], deliveries[-1]
+                    if product == 'codex':
+                        assert marker in json.loads(deliveries[-1][1])['attachments'][0]['text']
+                payload.update(session_id=case + '-literal-help', turn_id='literal-help',
+                               last_assistant_message='--help')
+                count = len(deliveries)
+                run('handle-hook', 'Stop', '--product', 'codex', data=json.dumps(payload))
+                assert len(deliveries) == count + 1
+                assert '--help' in json.loads(deliveries[-1][1])['attachments'][0]['text']
                 assert selected.read_bytes() == before
                 selected.write_text('{invalid-config')
                 count = len(deliveries)

--- a/scripts/release-artifact-e2e.py
+++ b/scripts/release-artifact-e2e.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Exercise an already-built release executable in disposable profiles.
+
+No agent CLI, external webhook, desktop session, or user configuration is used.
+This proves CLI/config/webhook delivery; actual agent and GUI tests are separate.
+"""
+import argparse
+import hashlib
+import http.server
+import json
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import threading
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--binary', type=Path, required=True)
+    parser.add_argument('--version', required=True)
+    args = parser.parse_args()
+    binary = args.binary.resolve()
+    deliveries = []
+
+    class Sink(http.server.BaseHTTPRequestHandler):
+        def log_message(self, *_):
+            pass
+
+        def do_POST(self):
+            deliveries.append((self.path, self.rfile.read(int(self.headers['Content-Length'])).decode()))
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(b'ok')
+
+    server = http.server.ThreadingHTTPServer(('127.0.0.1', 0), Sink)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    results = []
+    try:
+        with tempfile.TemporaryDirectory(prefix='notification-release-e2e-') as scratch:
+            root = Path(scratch).resolve()
+            for case in ('fresh', 'legacy', 'explicit'):
+                home = root / case
+                home.mkdir()
+                env = {key: os.environ[key] for key in
+                       ('PATH', 'SystemRoot', 'SYSTEMROOT', 'WINDIR', 'COMSPEC', 'PATHEXT')
+                       if key in os.environ}
+                env.update(HOME=str(home), USERPROFILE=str(home), GIT_CONFIG_NOSYSTEM='1')
+                for key in ('CODEX_HOME', 'CLAUDE_HOME', 'CLAUDE_CONFIG_DIR',
+                            'APPDATA', 'LOCALAPPDATA', 'XDG_CONFIG_HOME', 'XDG_CACHE_HOME',
+                            'XDG_DATA_HOME', 'XDG_STATE_HOME', 'XDG_RUNTIME_DIR', 'TMPDIR', 'TMP', 'TEMP'):
+                    folder = home / key
+                    folder.mkdir(mode=0o700)
+                    env[key] = str(folder)
+                bundle = home / 'bundle'
+                bundle.mkdir()
+                env['PLUGIN_ROOT'] = str(bundle)
+                env['CLAUDE_PLUGIN_ROOT'] = str(bundle)
+
+                def run(*command, data=None, success=True):
+                    result = subprocess.run([str(binary), *command], cwd=home, env=env,
+                                            input=data, text=True, capture_output=True, timeout=30)
+                    assert (result.returncode == 0) == success, (case, command, result.returncode, result.stderr)
+                    return result
+
+                assert run('version').stdout.strip() == 'claude-notifications ' + args.version
+                legacy = home / '.claude' / 'claude-notifications-go' / 'config.json'
+                if case == 'explicit':
+                    env['AGENT_NOTIFICATIONS_CONFIG'] = str(home / 'custom' / 'config.json')
+                if case == 'legacy':
+                    legacy.parent.mkdir(parents=True, mode=0o700)
+                    legacy.write_text('{}')
+                    legacy.chmod(0o600)
+                selected = Path(run('config', 'path').stdout.strip())
+                if case == 'legacy':
+                    assert selected == legacy
+                elif case == 'explicit':
+                    assert selected == Path(env['AGENT_NOTIFICATIONS_CONFIG'])
+                else:
+                    assert selected != legacy
+                run('config', 'init')
+                assert selected.exists()
+                if case != 'legacy':
+                    assert not legacy.exists()
+                document = {
+                    'notifications': {
+                        'desktop': {'enabled': False, 'sound': False, 'terminalBell': False},
+                        'webhook': {'enabled': True, 'preset': 'slack',
+                                    'url': f'http://127.0.0.1:{server.server_port}/shared'},
+                    },
+                    'future': {'preserved': 9007199254740993},
+                }
+                if case != 'legacy':
+                    document.update(schemaVersion=2, agents={
+                        product: {'notifications': {'webhook': {
+                            'url': f'http://127.0.0.1:{server.server_port}/{product}'}}}
+                        for product in ('claude', 'codex')
+                    })
+                selected.write_text(json.dumps(document))
+                before = selected.read_bytes()
+                run('config', 'init')
+                run('config', 'inspect', '--json')
+                assert selected.read_bytes() == before
+                for product in ('claude', 'codex'):
+                    marker = f'release-{case}-{product}'
+                    if product == 'codex':
+                        event = 'Stop'
+                        payload = {'hook_event_name': event, 'session_id': marker, 'turn_id': marker,
+                                   'cwd': str(home), 'last_assistant_message': marker, 'stop_hook_active': False}
+                    else:
+                        event = 'Notification'
+                        payload = {'hook_event_name': event, 'session_id': marker,
+                                   'notification_type': 'permission_prompt', 'message': marker}
+                    count = len(deliveries)
+                    run('handle-hook', event, '--product', product, data=json.dumps(payload))
+                    assert len(deliveries) == count + 1, (case, product, deliveries)
+                    expected = '/shared' if case == 'legacy' else '/' + product
+                    assert deliveries[-1][0] == expected and marker in deliveries[-1][1], deliveries[-1]
+                assert selected.read_bytes() == before
+                selected.write_text('{invalid-config')
+                count = len(deliveries)
+                run('config', 'inspect', '--json', success=False)
+                result = run('handle-hook', 'Stop', '--product', 'codex', data=json.dumps(payload))
+                assert result.stdout == result.stderr == ''
+                assert len(deliveries) == count
+                assert selected.read_text() == '{invalid-config'
+                results.append(case)
+        print(json.dumps({'result': 'PASS', 'version': args.version,
+                          'binary_sha256': hashlib.sha256(binary.read_bytes()).hexdigest(),
+                          'profiles': results, 'webhook_deliveries': len(deliveries)}))
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join()
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/release-artifact-e2e.py
+++ b/scripts/release-artifact-e2e.py
@@ -124,7 +124,9 @@ def main():
                 count = len(deliveries)
                 run('handle-hook', 'Stop', '--product', 'codex', data=json.dumps(payload))
                 assert len(deliveries) == count + 1
-                assert '--help' in json.loads(deliveries[-1][1])['attachments'][0]['text']
+                # The shared message formatter strips a leading Markdown bullet.
+                # The important regression is delivery, not CLI help interception.
+                assert json.loads(deliveries[-1][1])['attachments'][0]['text'].endswith('-help'), deliveries[-1]
                 assert selected.read_bytes() == before
                 selected.write_text('{invalid-config')
                 count = len(deliveries)


### PR DESCRIPTION
The Windows crash-recovery test gave full config initialization only one second, below the production five-second mutation budget. Use the production budget and repeat crash recovery ten times on both supported Go versions; production lock behavior is unchanged.

Release jobs now run the built artifact through fresh, legacy and explicit configuration profiles, Claude/Codex webhook delivery, per-agent overrides, create-only preservation and corrupt-config containment on every platform. Tests use disposable profiles and loopback recording sinks.

Validation: Linux source-binary preflight passed all three profiles and six webhook deliveries. Native platform CI and final downloaded-draft qualification follow. This does not claim visible desktop banners or actual agent turns.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded Windows testing for configuration recovery after interrupted operations.
  - Added end-to-end validation for release binaries, including version reporting, configuration initialization, profile handling, notification delivery, and invalid-configuration errors.
  - Verified configuration files remain unchanged during inspection and delivery checks.

- **Chores**
  - Strengthened release qualification checks to validate built artifacts before publication.
  - Improved recovery test coverage for configuration initialization and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->