### PR TITLE
docs: document frozen claude-notifications-go plugin identity

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,5 +1,6 @@
 {
     "name": "claude-notifications-go",
+    "description": "Agent Notifications marketplace; the legacy Claude Code ID is retained for compatibility",
     "owner": {
         "name": "777genius",
         "email": "iliyazelenkog@gmail.com"
@@ -10,6 +11,7 @@
     },
     "plugins": [{
         "name": "claude-notifications-go",
+        "displayName": "Agent Notifications",
         "source": "./",
         "description": "Agent Notifications for Claude Code and Codex CLI (Go implementation)",
         "version": "1.42.0",
@@ -18,6 +20,9 @@
             "email": "iliyazelenkog@gmail.com"
         },
         "repository": "https://github.com/777genius/agent-notifications",
+        "metadata": {
+            "renamePolicy": "Legacy Claude Code install identity. Do not rename; see docs/CLAUDE_PLUGIN_IDENTITY.md."
+        },
         "license": "GPL-3.0",
         "keywords": [
             "notifications",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
     "name": "claude-notifications-go",
+    "displayName": "Agent Notifications",
     "version": "1.42.0",
     "description": "Agent Notifications for Claude Code and Codex CLI (Go implementation)",
     "author": {
@@ -8,6 +9,9 @@
     },
     "license": "GPL-3.0",
     "repository": "https://github.com/777genius/agent-notifications",
+    "metadata": {
+        "renamePolicy": "Legacy Claude Code identity. Do not rename; see docs/CLAUDE_PLUGIN_IDENTITY.md."
+    },
     "keywords": ["notifications", "alerts", "productivity", "go"],
     "commands": [
         "./commands/init.md",

--- a/README.md
+++ b/README.md
@@ -111,6 +111,11 @@ Run these slash commands in the Claude Code chat, not in your system terminal:
 /claude-notifications-go:settings
 ```
 
+> **Compatibility:** `claude-notifications-go` is the frozen Claude Code marketplace,
+> plugin, and command namespace. The public product is **Agent Notifications**, but changing
+> these technical identifiers breaks existing installations and updates. See
+> [Claude plugin identity compatibility](docs/CLAUDE_PLUGIN_IDENTITY.md).
+
 </details>
 
 > Having issues with installation? See [Troubleshooting](#troubleshooting).

--- a/docs/CLAUDE_PLUGIN_IDENTITY.md
+++ b/docs/CLAUDE_PLUGIN_IDENTITY.md
@@ -1,0 +1,39 @@
+# Claude Plugin Identity Compatibility
+
+The public product and repository are named **Agent Notifications** and
+`agent-notifications`. The following Claude Code identifiers intentionally retain the legacy
+name and must not be changed as part of branding or routine cleanup:
+
+- `.claude-plugin/plugin.json` -> `name`
+- `.claude-plugin/marketplace.json` -> top-level `name`
+- `.claude-plugin/marketplace.json` -> `plugins[].name`
+- the resulting `/claude-notifications-go:*` command namespace
+
+Use `displayName: "Agent Notifications"`, descriptions, and the current repository URL for
+user-facing branding.
+
+## Why the identifiers are frozen
+
+Claude Code keys installations and updates by `plugin-name@marketplace-name`. This was also
+verified end to end on Claude Code 2.1.265 on 2026-09-10 using an isolated config and a
+throwaway project:
+
+- Renaming the marketplace, marketplace entry, and plugin manifest left the existing install
+  enabled but unresolved: `Plugin claude-notifications-go not found in marketplace
+  claude-notifications-go`.
+- Renaming only the plugin manifest allowed an update, but operations using the new internal
+  name were inconsistent: disable reported `already disabled` while the installed plugin was
+  enabled.
+- Keeping all three legacy `name` values and changing only `displayName` updated cleanly and
+  rendered as `Agent Notifications (claude-notifications-go)`.
+
+There is no documented alias or atomic rename mechanism that migrates existing marketplace
+registrations, installed-plugin records, cache paths, enabled state, and command namespaces.
+The GitHub repository URL may change independently and does not require changing these IDs.
+
+## Rule for a future migration
+
+Do not change these identifiers unless a dedicated migration ships with disposable-profile
+E2E coverage for existing installs, update/rollback, enable/disable/uninstall, duplicate-hook
+prevention, and both old and new command namespaces. A new identifier must be treated as a
+new plugin identity, not as a routine rename.

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -34,6 +34,12 @@ or JSON are reverted on `main`; user caches pick that up on their next refresh.
 
 ## 1. Bump version
 
+> **Frozen Claude Code identity:** do not rename any `claude-notifications-go` `name` in
+> `.claude-plugin/plugin.json` or `.claude-plugin/marketplace.json`. These values identify the
+> installed plugin, marketplace registration, cache, updater, and slash-command namespace.
+> Product branding belongs in `displayName`, descriptions, and repository URLs. See
+> [Claude plugin identity compatibility](CLAUDE_PLUGIN_IDENTITY.md).
+
 Update the version string in **4 files** (5 occurrences total):
 
 | File | Location | Count |


### PR DESCRIPTION
## Summary
- Documents that `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json` keep the legacy `claude-notifications-go` name/namespace on purpose (installs are keyed by it), while public branding uses `displayName: "Agent Notifications"`.
- Adds `docs/CLAUDE_PLUGIN_IDENTITY.md` with the Claude Code 2.1.265 verification notes behind that decision (rename breaks existing installs/updates).
- Cross-links the rule from README and docs/RELEASE.md so a future version bump doesn't accidentally rename these identifiers.

## Test plan
- [x] Docs-only change; no code paths affected.
- [x] Confirmed `.claude-plugin/plugin.json` / `marketplace.json` still validate as JSON after the merge with the v1.42.0 version bump.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added “Agent Notifications” as the user-facing product name in plugin listings.

* **Documentation**
  * Documented compatibility requirements for existing marketplace, plugin, and command identifiers.
  * Added guidance for preserving installation and update compatibility.
  * Documented the distinction between technical identifiers and user-facing branding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->