### PR TITLE
docs: add Uninstall instructions to README

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,5 +1,6 @@
 {
     "name": "claude-notifications-go",
+    "description": "Agent Notifications marketplace; the legacy Claude Code ID is retained for compatibility",
     "owner": {
         "name": "777genius",
         "email": "iliyazelenkog@gmail.com"
@@ -10,6 +11,7 @@
     },
     "plugins": [{
         "name": "claude-notifications-go",
+        "displayName": "Agent Notifications",
         "source": "./",
         "description": "Agent Notifications for Claude Code and Codex CLI (Go implementation)",
         "version": "1.42.0",
@@ -18,6 +20,9 @@
             "email": "iliyazelenkog@gmail.com"
         },
         "repository": "https://github.com/777genius/agent-notifications",
+        "metadata": {
+            "renamePolicy": "Legacy Claude Code install identity. Do not rename; see docs/CLAUDE_PLUGIN_IDENTITY.md."
+        },
         "license": "GPL-3.0",
         "keywords": [
             "notifications",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
     "name": "claude-notifications-go",
+    "displayName": "Agent Notifications",
     "version": "1.42.0",
     "description": "Agent Notifications for Claude Code and Codex CLI (Go implementation)",
     "author": {
@@ -8,6 +9,9 @@
     },
     "license": "GPL-3.0",
     "repository": "https://github.com/777genius/agent-notifications",
+    "metadata": {
+        "renamePolicy": "Legacy Claude Code identity. Do not rename; see docs/CLAUDE_PLUGIN_IDENTITY.md."
+    },
     "keywords": ["notifications", "alerts", "productivity", "go"],
     "commands": [
         "./commands/init.md",

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Notifications for Claude Code and Codex CLI (beta), with sounds, git branch disp
     - [Quick Install (Recommended)](#quick-install-recommended)
     - [Manual Install](#manual-install)
     - [Updating](#updating)
+    - [Uninstalling](#uninstalling)
   - [Supported Notification Types](#supported-notification-types)
   - [Codex CLI Support (beta)](#codex-cli-support-beta)
   - [Platform Support](#platform-support)
@@ -143,6 +144,20 @@ To update manually via Claude Code UI:
 If the binary auto-update didn't work (e.g. no internet at the time), run `/claude-notifications-go:init` to download it manually. If hook definitions changed in the new version, restart Claude Code to apply them.
 
 </details>
+
+### Uninstalling
+
+**Claude:**
+
+```text
+/plugin uninstall claude-notifications-go@claude-notifications-go
+```
+
+Optionally also remove the marketplace registration: `/plugin marketplace remove claude-notifications-go`.
+
+**Codex:** Codex has no plugin manager, so removal is manual. Delete the hook entries this installer added from `~/.codex/hooks.json` (`%USERPROFILE%\.codex\hooks.json` on Windows), then remove the installed copy at `~/.codex/claude-notifications-go` (`%USERPROFILE%\.codex\claude-notifications-go` on Windows). This does not touch hooks you registered yourself for other tools.
+
+**Configuration:** uninstalling does not delete your saved settings. Run `agent-notifications config path` to find the active file, and remove it yourself if you no longer want it.
 
 ## Supported Notification Types
 

--- a/README.md
+++ b/README.md
@@ -111,6 +111,11 @@ Run these slash commands in the Claude Code chat, not in your system terminal:
 /claude-notifications-go:settings
 ```
 
+> **Compatibility:** `claude-notifications-go` is the frozen Claude Code marketplace,
+> plugin, and command namespace. The public product is **Agent Notifications**, but changing
+> these technical identifiers breaks existing installations and updates. See
+> [Claude plugin identity compatibility](docs/CLAUDE_PLUGIN_IDENTITY.md).
+
 </details>
 
 > Having issues with installation? See [Troubleshooting](#troubleshooting).

--- a/docs/CLAUDE_PLUGIN_IDENTITY.md
+++ b/docs/CLAUDE_PLUGIN_IDENTITY.md
@@ -1,0 +1,39 @@
+# Claude Plugin Identity Compatibility
+
+The public product and repository are named **Agent Notifications** and
+`agent-notifications`. The following Claude Code identifiers intentionally retain the legacy
+name and must not be changed as part of branding or routine cleanup:
+
+- `.claude-plugin/plugin.json` -> `name`
+- `.claude-plugin/marketplace.json` -> top-level `name`
+- `.claude-plugin/marketplace.json` -> `plugins[].name`
+- the resulting `/claude-notifications-go:*` command namespace
+
+Use `displayName: "Agent Notifications"`, descriptions, and the current repository URL for
+user-facing branding.
+
+## Why the identifiers are frozen
+
+Claude Code keys installations and updates by `plugin-name@marketplace-name`. This was also
+verified end to end on Claude Code 2.1.265 on 2026-09-10 using an isolated config and a
+throwaway project:
+
+- Renaming the marketplace, marketplace entry, and plugin manifest left the existing install
+  enabled but unresolved: `Plugin claude-notifications-go not found in marketplace
+  claude-notifications-go`.
+- Renaming only the plugin manifest allowed an update, but operations using the new internal
+  name were inconsistent: disable reported `already disabled` while the installed plugin was
+  enabled.
+- Keeping all three legacy `name` values and changing only `displayName` updated cleanly and
+  rendered as `Agent Notifications (claude-notifications-go)`.
+
+There is no documented alias or atomic rename mechanism that migrates existing marketplace
+registrations, installed-plugin records, cache paths, enabled state, and command namespaces.
+The GitHub repository URL may change independently and does not require changing these IDs.
+
+## Rule for a future migration
+
+Do not change these identifiers unless a dedicated migration ships with disposable-profile
+E2E coverage for existing installs, update/rollback, enable/disable/uninstall, duplicate-hook
+prevention, and both old and new command namespaces. A new identifier must be treated as a
+new plugin identity, not as a routine rename.

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -34,6 +34,12 @@ or JSON are reverted on `main`; user caches pick that up on their next refresh.
 
 ## 1. Bump version
 
+> **Frozen Claude Code identity:** do not rename any `claude-notifications-go` `name` in
+> `.claude-plugin/plugin.json` or `.claude-plugin/marketplace.json`. These values identify the
+> installed plugin, marketplace registration, cache, updater, and slash-command namespace.
+> Product branding belongs in `displayName`, descriptions, and repository URLs. See
+> [Claude plugin identity compatibility](CLAUDE_PLUGIN_IDENTITY.md).
+
 Update the version string in **4 files** (5 occurrences total):
 
 | File | Location | Count |


### PR DESCRIPTION
## Summary
- README documented install, update, and configure but had no uninstall path for either Claude or Codex.
- Adds an "Uninstalling" subsection under Installation, covering `/plugin uninstall`, manual Codex hook/dir cleanup (no plugin manager on that side), and a pointer to `agent-notifications config path` for anyone who also wants to remove their saved settings.

## Test plan
- [x] Docs-only change.
- [x] Verified `claude plugin uninstall|remove` and `claude plugin marketplace remove` exist via `claude plugin --help` / `claude plugin marketplace --help` on Claude Code 2.1.268.
- [x] Verified `agent-notifications config path` exists via `--help` on the published v1.42.0 binary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added uninstall instructions for Claude and Codex, including marketplace removal and manual cleanup steps.
  - Clarified that uninstalling does not delete saved settings.
  - Documented compatibility requirements for existing Claude Code installations and command namespaces.
  - Added release guidance for preserving legacy installation identifiers.

- **Updates**
  - Updated marketplace and plugin metadata to display the product name **Agent Notifications** while retaining compatibility with existing installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->