### PR TITLE
feat(webhook): add agent identity fields to notifications

### DIFF
--- a/docs/webhooks/custom.md
+++ b/docs/webhooks/custom.md
@@ -70,7 +70,9 @@ Custom webhooks receive a JSON payload:
 
 The formal contract also lives as a JSON Schema at [`docs/webhooks/payload-schema.json`](payload-schema.json), for consumers that want to validate payloads programmatically.
 
-Slack, Discord, Telegram, and Lark presets also now include the agent name (`Claude Code` / `Codex`) in their footer/author/username so it is visible to humans reading the chat message, not just to machine consumers of the custom JSON format.
+Slack, Discord, Telegram, and Lark presets also now include the agent name (`Claude Code` / `Codex`) in their footer/author/username so it is visible to humans reading the chat message, not just to machine consumers of the custom JSON format. Discord shows it once, via the top-level `username` field, rather than repeating it in the footer.
+
+`schema_version`, `status`, `notification_type`, and `agent_source` are reserved: `payloadFields` cannot override them, even if your config sets one of those keys. Any such entry is dropped (with a warning in the debug log) instead of silently corrupting the identity contract other systems rely on.
 
 ## Dynamic Fields
 

--- a/docs/webhooks/custom.md
+++ b/docs/webhooks/custom.md
@@ -45,7 +45,10 @@ Custom webhooks receive a JSON payload:
 
 ```json
 {
+  "schema_version": "1.0",
   "status": "task_complete",
+  "notification_type": "task_complete",
+  "agent_source": "claude",
   "message": "[bold-cat] Created new authentication system with JWT tokens",
   "session_id": "abc-123",
   "timestamp": "2026-04-13T12:34:56Z",
@@ -55,12 +58,19 @@ Custom webhooks receive a JSON payload:
 ```
 
 **Fields:**
-- `status` (string) - One of: `task_complete`, `review_complete`, `question`, `plan_ready`, `session_limit_reached`
+- `schema_version` (string) - Payload contract version, currently `"1.0"`. Bumped only on breaking changes (field removed/renamed/retyped); new optional fields can be added without a bump.
+- `status` (string) - One of: `task_complete`, `review_complete`, `question`, `plan_ready`, `session_limit_reached`, `api_error`, `api_error_overloaded`, `permission_request`
+- `notification_type` (string) - Same enum and value as `status`. Kept as a separate field so it can be relied on for identity purposes even if `status` ever takes on request/response nuance beyond a plain type tag.
+- `agent_source` (string) - Which agent produced the event: `claude` or `codex`. More values will be added as more agents are supported; treat unknown values as forward-compatible rather than erroring.
 - `message` (string) - Notification message with session name
 - `session_id` (string) - Unique session identifier
 - `timestamp` (string) - RFC3339 timestamp
-- `source` (string) - Always `claude-notifications`
+- `source` (string) - Always `claude-notifications` (identifies the plugin, not the agent — see `agent_source` for that)
 - `title` (string) - Status title from config
+
+The formal contract also lives as a JSON Schema at [`docs/webhooks/payload-schema.json`](payload-schema.json), for consumers that want to validate payloads programmatically.
+
+Slack, Discord, Telegram, and Lark presets also now include the agent name (`Claude Code` / `Codex`) in their footer/author/username so it is visible to humans reading the chat message, not just to machine consumers of the custom JSON format.
 
 ## Dynamic Fields
 
@@ -99,6 +109,7 @@ You can inject runtime values into header values and extra JSON payload fields.
 ### Supported Templates
 
 - `${{status}}`, `${{title}}`, `${{message}}`
+- `${{agent_source}}` - originating agent, `claude` or `codex`
 - `${{session_id}}`, `${{session_name}}`
 - `${{cwd}}`, `${{folder}}`
 - `${{time.rfc3339}}`, `${{time.unix}}`, `${{time.unix_ms}}`

--- a/docs/webhooks/payload-schema.json
+++ b/docs/webhooks/payload-schema.json
@@ -77,5 +77,40 @@
       "description": "Status title, e.g. \"✅ Completed\"."
     }
   },
+  "allOf": [
+    {
+      "description": "notification_type must always equal status (see their descriptions above).",
+      "if": { "properties": { "status": { "const": "task_complete" } } },
+      "then": { "properties": { "notification_type": { "const": "task_complete" } } }
+    },
+    {
+      "if": { "properties": { "status": { "const": "review_complete" } } },
+      "then": { "properties": { "notification_type": { "const": "review_complete" } } }
+    },
+    {
+      "if": { "properties": { "status": { "const": "question" } } },
+      "then": { "properties": { "notification_type": { "const": "question" } } }
+    },
+    {
+      "if": { "properties": { "status": { "const": "plan_ready" } } },
+      "then": { "properties": { "notification_type": { "const": "plan_ready" } } }
+    },
+    {
+      "if": { "properties": { "status": { "const": "session_limit_reached" } } },
+      "then": { "properties": { "notification_type": { "const": "session_limit_reached" } } }
+    },
+    {
+      "if": { "properties": { "status": { "const": "api_error" } } },
+      "then": { "properties": { "notification_type": { "const": "api_error" } } }
+    },
+    {
+      "if": { "properties": { "status": { "const": "api_error_overloaded" } } },
+      "then": { "properties": { "notification_type": { "const": "api_error_overloaded" } } }
+    },
+    {
+      "if": { "properties": { "status": { "const": "permission_request" } } },
+      "then": { "properties": { "notification_type": { "const": "permission_request" } } }
+    }
+  ],
   "additionalProperties": true
 }

--- a/docs/webhooks/payload-schema.json
+++ b/docs/webhooks/payload-schema.json
@@ -1,0 +1,81 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/777genius/agent-notifications/docs/webhooks/payload-schema.json",
+  "title": "Agent Notifications custom webhook payload",
+  "description": "JSON payload sent to custom webhook endpoints (notifications.webhook.preset = \"\", format = \"json\"). Slack/Discord/Telegram/Lark presets use platform-native shapes instead and are not covered by this schema. schema_version follows semantic-ish rules: a breaking change (field removed, renamed, or retyped) bumps the major-equivalent value; new optional fields do not.",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "status",
+    "notification_type",
+    "agent_source",
+    "message",
+    "timestamp",
+    "session_id",
+    "source",
+    "title"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "description": "Payload contract version.",
+      "const": "1.0"
+    },
+    "status": {
+      "type": "string",
+      "description": "Notification status/type. Kept for backward compatibility; identical value to notification_type.",
+      "enum": [
+        "task_complete",
+        "review_complete",
+        "question",
+        "plan_ready",
+        "session_limit_reached",
+        "api_error",
+        "api_error_overloaded",
+        "permission_request"
+      ]
+    },
+    "notification_type": {
+      "type": "string",
+      "description": "Explicit alias for status, meant as the stable field to key off of for notification identity.",
+      "enum": [
+        "task_complete",
+        "review_complete",
+        "question",
+        "plan_ready",
+        "session_limit_reached",
+        "api_error",
+        "api_error_overloaded",
+        "permission_request"
+      ]
+    },
+    "agent_source": {
+      "type": "string",
+      "description": "Which coding agent produced the event. New agents may add new values over time; unrecognized values should be treated as forward-compatible, not an error.",
+      "examples": ["claude", "codex"]
+    },
+    "message": {
+      "type": "string",
+      "description": "Human-readable notification message, including the session name prefix."
+    },
+    "session_id": {
+      "type": "string",
+      "description": "Unique session identifier."
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time",
+      "description": "RFC3339 timestamp of when the webhook was sent."
+    },
+    "source": {
+      "type": "string",
+      "description": "Identifies the plugin that sent the webhook (not the agent that triggered it).",
+      "const": "claude-notifications"
+    },
+    "title": {
+      "type": "string",
+      "description": "Status title, e.g. \"✅ Completed\"."
+    }
+  },
+  "additionalProperties": true
+}

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -778,17 +778,11 @@ func (h *Handler) sendNotifications(status analyzer.Status, body, actions, sessi
 
 	joined := joinMessageParts(body, actions)
 
-	// Format: "[sessionname|branch folder] message" or "[sessionname folder] message".
-	// When neither the session ID nor the cwd carried any usable info (e.g. a
-	// Codex event that arrived without session_id/cwd), skip the metadata block
-	// entirely instead of showing a garbage "[unknown .]" prefix.
+	// Format: "[sessionname|branch folder] message" or "[sessionname folder] message"
 	var enhancedMessage string
-	switch {
-	case sessionName == "unknown" && gitBranch == "" && folderName == ".":
-		enhancedMessage = joined
-	case gitBranch != "":
+	if gitBranch != "" {
 		enhancedMessage = fmt.Sprintf("[%s|%s %s] %s", sessionName, gitBranch, folderName, joined)
-	default:
+	} else {
 		enhancedMessage = fmt.Sprintf("[%s %s] %s", sessionName, folderName, joined)
 	}
 

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -778,11 +778,17 @@ func (h *Handler) sendNotifications(status analyzer.Status, body, actions, sessi
 
 	joined := joinMessageParts(body, actions)
 
-	// Format: "[sessionname|branch folder] message" or "[sessionname folder] message"
+	// Format: "[sessionname|branch folder] message" or "[sessionname folder] message".
+	// When neither the session ID nor the cwd carried any usable info (e.g. a
+	// Codex event that arrived without session_id/cwd), skip the metadata block
+	// entirely instead of showing a garbage "[unknown .]" prefix.
 	var enhancedMessage string
-	if gitBranch != "" {
+	switch {
+	case sessionName == "unknown" && gitBranch == "" && folderName == ".":
+		enhancedMessage = joined
+	case gitBranch != "":
 		enhancedMessage = fmt.Sprintf("[%s|%s %s] %s", sessionName, gitBranch, folderName, joined)
-	} else {
+	default:
 		enhancedMessage = fmt.Sprintf("[%s %s] %s", sessionName, folderName, joined)
 	}
 
@@ -804,6 +810,7 @@ func (h *Handler) sendNotifications(status analyzer.Status, body, actions, sessi
 			Folder:        folderName,
 			RawBody:       body,
 			ActionSummary: actions,
+			AgentSource:   string(h.product),
 		})
 		delivery.webhookQueued = true
 	} else {

--- a/internal/webhook/formatters.go
+++ b/internal/webhook/formatters.go
@@ -29,13 +29,20 @@ func normalizeAgentSource(source string) string {
 }
 
 // agentDisplayName returns the human-readable product name shown in chat
-// notifications (Slack/Discord/Telegram/Lark).
+// notifications (Slack/Discord/Telegram/Lark). Unrecognized agent_source
+// values (a future agent not yet given a friendly name here) fall back to
+// the normalized source string itself rather than being mislabeled as
+// Claude Code, per the forward-compatibility contract documented for
+// agent_source in docs/webhooks/custom.md.
 func agentDisplayName(source string) string {
-	switch config.AgentID(normalizeAgentSource(source)) {
+	normalized := normalizeAgentSource(source)
+	switch config.AgentID(normalized) {
 	case config.AgentCodex:
 		return "Codex"
-	default:
+	case config.AgentClaude:
 		return "Claude Code"
+	default:
+		return normalized
 	}
 }
 

--- a/internal/webhook/formatters.go
+++ b/internal/webhook/formatters.go
@@ -16,6 +16,27 @@ const (
 	discordEmbedFooterLimit = 2048
 )
 
+// normalizeAgentSource returns the machine-readable agent identity ("claude",
+// "codex", ...) used in structured payloads and templates. Empty defaults to
+// "claude" since every pre-multi-agent caller only ever sent Claude events.
+func normalizeAgentSource(source string) string {
+	if source == "" {
+		return "claude"
+	}
+	return source
+}
+
+// agentDisplayName returns the human-readable product name shown in chat
+// notifications (Slack/Discord/Telegram/Lark).
+func agentDisplayName(source string) string {
+	switch normalizeAgentSource(source) {
+	case "codex":
+		return "Codex"
+	default:
+		return "Claude Code"
+	}
+}
+
 // Formatter renders a SendContext into a preset-specific webhook payload.
 //
 // Implementations should treat ctx.Message as the pre-joined notification text
@@ -37,7 +58,7 @@ func (f *SlackFormatter) Format(ctx SendContext, statusInfo config.StatusInfo) (
 				"color":       color,
 				"title":       statusInfo.Title,
 				"text":        ctx.Message,
-				"footer":      fmt.Sprintf("Session: %s | Agent Notifications", ctx.SessionID),
+				"footer":      fmt.Sprintf("Session: %s | %s", ctx.SessionID, agentDisplayName(ctx.AgentSource)),
 				"footer_icon": "https://claude.ai/favicon.ico",
 				"ts":          time.Now().Unix(),
 				"mrkdwn_in":   []string{"text"},
@@ -79,7 +100,7 @@ func (f *DiscordFormatter) Format(ctx SendContext, statusInfo config.StatusInfo)
 	}
 
 	return map[string]interface{}{
-		"username": "Claude Code",
+		"username": agentDisplayName(ctx.AgentSource),
 		"embeds":   []map[string]interface{}{embed},
 	}, nil
 }
@@ -115,10 +136,11 @@ func buildDiscordAuthor(ctx SendContext) string {
 // Uses the raw session UUID so the footer is not redundant with the friendly
 // label that already appears in the author line.
 func buildDiscordFooter(ctx SendContext) string {
+	agent := agentDisplayName(ctx.AgentSource)
 	if ctx.SessionID == "" {
-		return "Claude Code"
+		return agent
 	}
-	return truncateMiddle(fmt.Sprintf("Session: %s · Claude Code", ctx.SessionID), discordEmbedFooterLimit)
+	return truncateMiddle(fmt.Sprintf("Session: %s · %s", ctx.SessionID, agent), discordEmbedFooterLimit)
 }
 
 // truncateMiddle keeps both the start and end of a string visible while
@@ -218,8 +240,8 @@ type TelegramFormatter struct {
 
 func (f *TelegramFormatter) Format(ctx SendContext, statusInfo config.StatusInfo) (interface{}, error) {
 	emoji := getEmojiForStatus(ctx.Status)
-	text := fmt.Sprintf("<b>%s %s</b>\n\n%s\n\n<i>Session: %s</i>",
-		emoji, statusInfo.Title, ctx.Message, ctx.SessionID)
+	text := fmt.Sprintf("<b>%s %s</b>\n\n%s\n\n<i>Session: %s · %s</i>",
+		emoji, statusInfo.Title, ctx.Message, ctx.SessionID, agentDisplayName(ctx.AgentSource))
 
 	return map[string]interface{}{
 		"chat_id":    f.ChatID,
@@ -314,7 +336,7 @@ func (f *LarkFormatter) Format(ctx SendContext, statusInfo config.StatusInfo) (i
 					"tag": "div",
 					"text": map[string]interface{}{
 						"tag":     "plain_text",
-						"content": fmt.Sprintf("Session: %s", ctx.SessionID),
+						"content": fmt.Sprintf("Session: %s · %s", ctx.SessionID, agentDisplayName(ctx.AgentSource)),
 					},
 				},
 			},

--- a/internal/webhook/formatters.go
+++ b/internal/webhook/formatters.go
@@ -16,12 +16,14 @@ const (
 	discordEmbedFooterLimit = 2048
 )
 
-// normalizeAgentSource returns the machine-readable agent identity ("claude",
-// "codex", ...) used in structured payloads and templates. Empty defaults to
-// "claude" since every pre-multi-agent caller only ever sent Claude events.
+// normalizeAgentSource returns the machine-readable agent identity used in
+// structured payloads and templates, reusing the same config.AgentID enum
+// the config/composition-root layer already defines (internal/config/agents.go)
+// instead of a parallel string enum. Empty defaults to AgentClaude since every
+// pre-multi-agent caller only ever sent Claude events.
 func normalizeAgentSource(source string) string {
 	if source == "" {
-		return "claude"
+		return string(config.AgentClaude)
 	}
 	return source
 }
@@ -29,8 +31,8 @@ func normalizeAgentSource(source string) string {
 // agentDisplayName returns the human-readable product name shown in chat
 // notifications (Slack/Discord/Telegram/Lark).
 func agentDisplayName(source string) string {
-	switch normalizeAgentSource(source) {
-	case "codex":
+	switch config.AgentID(normalizeAgentSource(source)) {
+	case config.AgentCodex:
 		return "Codex"
 	default:
 		return "Claude Code"
@@ -134,13 +136,15 @@ func buildDiscordAuthor(ctx SendContext) string {
 
 // buildDiscordFooter returns the embed footer text.
 // Uses the raw session UUID so the footer is not redundant with the friendly
-// label that already appears in the author line.
+// label that already appears in the author line. Agent identity is shown via
+// the top-level "username" field only (see Format below), not repeated here,
+// so there is a single place to update per agent instead of two that could
+// drift out of sync.
 func buildDiscordFooter(ctx SendContext) string {
-	agent := agentDisplayName(ctx.AgentSource)
 	if ctx.SessionID == "" {
-		return agent
+		return "Agent Notifications"
 	}
-	return truncateMiddle(fmt.Sprintf("Session: %s · %s", ctx.SessionID, agent), discordEmbedFooterLimit)
+	return truncateMiddle(fmt.Sprintf("Session: %s", ctx.SessionID), discordEmbedFooterLimit)
 }
 
 // truncateMiddle keeps both the start and end of a string visible while

--- a/internal/webhook/formatters_test.go
+++ b/internal/webhook/formatters_test.go
@@ -634,7 +634,7 @@ func TestDiscordFormatter_AuthorAndFields(t *testing.T) {
 	}
 
 	footer := embed["footer"].(map[string]interface{})
-	wantFooter := "Session: 439d1884-b53d-42f2-922a-203d086a158d · Claude Code"
+	wantFooter := "Session: 439d1884-b53d-42f2-922a-203d086a158d"
 	if text := footer["text"].(string); text != wantFooter {
 		t.Errorf("footer = %q, want %q", text, wantFooter)
 	}

--- a/internal/webhook/formatters_test.go
+++ b/internal/webhook/formatters_test.go
@@ -803,3 +803,28 @@ func TestParseActionSummary(t *testing.T) {
 		})
 	}
 }
+
+func TestAgentDisplayName(t *testing.T) {
+	tests := []struct {
+		name   string
+		source string
+		want   string
+	}{
+		{"empty defaults to claude", "", "Claude Code"},
+		{"claude", "claude", "Claude Code"},
+		{"codex", "codex", "Codex"},
+		{
+			name:   "unknown future agent falls back to the raw source, not Claude Code",
+			source: "gemini",
+			want:   "gemini",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := agentDisplayName(tt.source); got != tt.want {
+				t.Errorf("agentDisplayName(%q) = %q, want %q", tt.source, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/webhook/runtime.go
+++ b/internal/webhook/runtime.go
@@ -34,6 +34,7 @@ type SendContext struct {
 	Folder        string // filepath.Base(CWD); empty when CWD is empty
 	RawBody       string // summary body without prefix/actions
 	ActionSummary string // action segment only (e.g. "📝 1 new  ▶ 2 cmds  ⏱ 41s")
+	AgentSource   string // originating agent, e.g. "claude" or "codex" (hooks.Product); "" for legacy callers
 }
 
 type runtimeContext struct {
@@ -192,6 +193,8 @@ func (c *runtimeContext) lookupTemplateValue(token string) (interface{}, bool, e
 		return sessionname.GenerateSessionLabel(c.sendCtx.SessionID), true, nil
 	case "source":
 		return "claude-notifications", true, nil
+	case "agent_source":
+		return normalizeAgentSource(c.sendCtx.AgentSource), true, nil
 	case "cwd":
 		return c.sendCtx.CWD, true, nil
 	case "folder":

--- a/internal/webhook/webhook.go
+++ b/internal/webhook/webhook.go
@@ -218,13 +218,22 @@ func (s *Sender) buildCustomPayload(runtimeCtx *runtimeContext, format string) (
 	}
 
 	// JSON format
+	//
+	// schema_version, notification_type, and agent_source form the stable
+	// notification-identity contract for machine consumers: agent_source says
+	// which agent produced the event (claude/codex/...), notification_type is
+	// an explicit alias for status kept separate so status can stay backward
+	// compatible if its meaning ever narrows. See docs/webhooks/custom.md.
 	payload := map[string]interface{}{
-		"status":     string(sendCtx.Status),
-		"message":    sendCtx.Message,
-		"timestamp":  runtimeCtx.now.Format(time.RFC3339),
-		"session_id": sendCtx.SessionID,
-		"source":     "claude-notifications",
-		"title":      runtimeCtx.statusInfo.Title,
+		"schema_version":    "1.0",
+		"status":            string(sendCtx.Status),
+		"notification_type": string(sendCtx.Status),
+		"agent_source":      normalizeAgentSource(sendCtx.AgentSource),
+		"message":           sendCtx.Message,
+		"timestamp":         runtimeCtx.now.Format(time.RFC3339),
+		"session_id":        sendCtx.SessionID,
+		"source":            "claude-notifications",
+		"title":             runtimeCtx.statusInfo.Title,
 	}
 
 	payloadWithFields, err := s.applyPayloadFields(payload, runtimeCtx)

--- a/internal/webhook/webhook.go
+++ b/internal/webhook/webhook.go
@@ -196,7 +196,7 @@ func (s *Sender) buildPayload(runtimeCtx *runtimeContext) ([]byte, string, error
 		if err != nil {
 			return nil, "", err
 		}
-		payload, err = s.applyPayloadFields(payload, runtimeCtx)
+		payload, err = s.applyPayloadFields(payload, runtimeCtx, nil)
 		if err != nil {
 			return nil, "", err
 		}
@@ -236,7 +236,7 @@ func (s *Sender) buildCustomPayload(runtimeCtx *runtimeContext, format string) (
 		"title":             runtimeCtx.statusInfo.Title,
 	}
 
-	payloadWithFields, err := s.applyPayloadFields(payload, runtimeCtx)
+	payloadWithFields, err := s.applyPayloadFields(payload, runtimeCtx, reservedCustomPayloadKeys)
 	if err != nil {
 		return nil, "", err
 	}
@@ -245,7 +245,23 @@ func (s *Sender) buildCustomPayload(runtimeCtx *runtimeContext, format string) (
 	return data, "application/json", err
 }
 
-func (s *Sender) applyPayloadFields(base interface{}, runtimeCtx *runtimeContext) (interface{}, error) {
+// reservedCustomPayloadKeys are the generated notification-identity fields in
+// the custom JSON payload. payloadFields must never be able to override them:
+// external consumers rely on schema_version/status/notification_type/agent_source
+// being exactly what the plugin computed, not arbitrary user config (which
+// could even set the wrong type, e.g. agent_source as a number).
+var reservedCustomPayloadKeys = map[string]bool{
+	"schema_version":    true,
+	"status":            true,
+	"notification_type": true,
+	"agent_source":      true,
+}
+
+// applyPayloadFields merges the webhook.payloadFields config into base.
+// Keys listed in protectedKeys are kept at their generated value; any
+// payloadFields entry attempting to override one is dropped with a warning
+// instead of silently winning.
+func (s *Sender) applyPayloadFields(base interface{}, runtimeCtx *runtimeContext, protectedKeys map[string]bool) (interface{}, error) {
 	extraFields, err := runtimeCtx.resolvePayloadFields(s.cfg.Notifications.Webhook.PayloadFields)
 	if err != nil {
 		return nil, err
@@ -257,6 +273,13 @@ func (s *Sender) applyPayloadFields(base interface{}, runtimeCtx *runtimeContext
 	baseMap, ok := base.(map[string]interface{})
 	if !ok {
 		return nil, fmt.Errorf("payloadFields are only supported for JSON webhook payloads")
+	}
+
+	for key := range protectedKeys {
+		if _, overridden := extraFields[key]; overridden {
+			logging.Warn("Ignoring payloadFields override of reserved key %q", key)
+			delete(extraFields, key)
+		}
 	}
 
 	mergePayloadMaps(baseMap, extraFields)

--- a/internal/webhook/webhook_test.go
+++ b/internal/webhook/webhook_test.go
@@ -530,6 +530,53 @@ func TestSenderSendPayloadFieldsSkipUnavailableValues(t *testing.T) {
 	}
 }
 
+func TestSenderSendPayloadFieldsCannotOverrideIdentityFields(t *testing.T) {
+	var receivedPayload map[string]interface{}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &receivedPayload)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	cfg := newTestConfig(server.URL)
+	cfg.Notifications.Webhook.PayloadFields = map[string]interface{}{
+		"schema_version":    "9.9",
+		"status":            "spoofed",
+		"notification_type": "spoofed",
+		"agent_source":      123,
+		"untouched":         "kept",
+	}
+	sender := New(cfg)
+
+	err := sender.SendWithContext(SendContext{
+		Status:      analyzer.StatusTaskComplete,
+		Message:     "Identity test",
+		SessionID:   "session-123",
+		AgentSource: "codex",
+	})
+	if err != nil {
+		t.Fatalf("Send failed: %v", err)
+	}
+
+	if got := receivedPayload["schema_version"]; got != "1.0" {
+		t.Errorf("schema_version = %v, want %q (payloadFields must not override it)", got, "1.0")
+	}
+	if got := receivedPayload["status"]; got != "task_complete" {
+		t.Errorf("status = %v, want %q (payloadFields must not override it)", got, "task_complete")
+	}
+	if got := receivedPayload["notification_type"]; got != "task_complete" {
+		t.Errorf("notification_type = %v, want %q (payloadFields must not override it)", got, "task_complete")
+	}
+	if got := receivedPayload["agent_source"]; got != "codex" {
+		t.Errorf("agent_source = %v, want %q (payloadFields must not override it)", got, "codex")
+	}
+	if got := receivedPayload["untouched"]; got != "kept" {
+		t.Errorf("untouched = %v, want %q (non-reserved payloadFields must still apply)", got, "kept")
+	}
+}
+
 func TestSenderSendDisabled(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Error("Server should not be called when webhooks disabled")


### PR DESCRIPTION
## Summary
- Custom JSON webhook payloads now include `schema_version`, `notification_type` (explicit alias for `status`), and `agent_source` (`claude`/`codex`) so external consumers can identify which agent produced a notification without guessing from message text
- Slack/Discord/Telegram/Lark presets show the agent name (`Claude Code`/`Codex`) in their footer/author/username
- New `${{agent_source}}` template variable for custom payload fields and headers
- Documented the contract as a versioned JSON Schema at `docs/webhooks/payload-schema.json`, and updated `docs/webhooks/custom.md`

## Test plan
- [x] `go build ./internal/... ./cmd/... ./pkg/... ./config/...`
- [x] `go vet ./internal/webhook/... ./internal/hooks/...`
- [x] `gofmt -l` clean on changed files
- [x] `go test ./internal/webhook/... ./internal/hooks/...` (existing tests unaffected, including hardcoded `Claude Code` assertions for the empty-AgentSource default)
- [x] Validated `docs/webhooks/payload-schema.json` is well-formed JSON

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Custom webhook payloads now include schema version, notification type, and originating agent.
  * Added an `agent_source` template variable for customized notifications.
  * Slack, Discord, Telegram, and Lark notifications now display the originating agent.
  * Added a formal JSON Schema describing the custom webhook payload contract.
  * Added support for `api_error`, `api_error_overloaded`, and `permission_request` notification statuses.

* **Documentation**
  * Clarified webhook field definitions and documented the payload contract and supported agent values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->