### PR TITLE
fix(notifier): drop garbage "[unknown .]" prefix on empty session/cwd

### DIFF
--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -778,11 +778,17 @@ func (h *Handler) sendNotifications(status analyzer.Status, body, actions, sessi
 
 	joined := joinMessageParts(body, actions)
 
-	// Format: "[sessionname|branch folder] message" or "[sessionname folder] message"
+	// Format: "[sessionname|branch folder] message" or "[sessionname folder] message".
+	// When neither the session ID nor the cwd carried any usable info (e.g. a
+	// Codex event that arrived without session_id/cwd), skip the metadata block
+	// entirely instead of showing a garbage "[unknown .]" prefix.
 	var enhancedMessage string
-	if gitBranch != "" {
+	switch {
+	case sessionName == "unknown" && gitBranch == "" && folderName == ".":
+		enhancedMessage = joined
+	case gitBranch != "":
 		enhancedMessage = fmt.Sprintf("[%s|%s %s] %s", sessionName, gitBranch, folderName, joined)
-	} else {
+	default:
 		enhancedMessage = fmt.Sprintf("[%s %s] %s", sessionName, folderName, joined)
 	}
 


### PR DESCRIPTION
## Summary
- When a hook event (e.g. a Codex `permission_request`) arrives without `session_id`/`cwd`, the desktop notification title showed a literal `[unknown .]` metadata block instead of just the message.
- Now the metadata block is skipped entirely when neither the session name nor the folder carry any usable info.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/hooks/...`