### PR TITLE
fix(installer): self-heal marketplace declared under the retired repo name

### DIFF
--- a/bin/bootstrap.sh
+++ b/bin/bootstrap.sh
@@ -176,19 +176,19 @@ print_iterm2_python_api_notice() {
 marketplace_declared_repo() {
     local tmp
     tmp=$(mktemp "${TMPDIR:-/tmp}/marketplace-list-XXXXXX") || return 1
-    claude plugin marketplace list --json >"$tmp" 2>/dev/null
+    claude plugin marketplace list --json </dev/null >"$tmp" 2>/dev/null
     python3 -I - "$tmp" "$MARKETPLACE_NAME" <<'PY'
 import json, sys
 path, name = sys.argv[1], sys.argv[2]
 try:
     with open(path) as f:
         entries = json.load(f)
+    for e in entries:
+        if e.get('name') == name and e.get('repo'):
+            print(e['repo'])
+            break
 except Exception:
-    sys.exit(0)
-for e in entries:
-    if e.get('name') == name and e.get('repo'):
-        print(e['repo'])
-        break
+    pass
 PY
     rm -f "$tmp"
 }
@@ -232,7 +232,7 @@ setup_marketplace() {
             # user's saved notification settings (a separate file), and
             # the rest of this script reinstalls the plugin right after.
             echo -e "${BLUE}  Marketplace points at the retired repo name; re-registering...${NC}"
-            claude plugin marketplace remove "$MARKETPLACE_NAME" </dev/null >/dev/null 2>&1
+            claude plugin marketplace remove "$MARKETPLACE_NAME" </dev/null >/dev/null 2>&1 || true
             config_preflight || return 1
             if output=$(claude plugin marketplace add "$MARKETPLACE_SOURCE" </dev/null 2>&1); then
                 echo -e "${GREEN}✓${NC} Marketplace re-registered"

--- a/bin/bootstrap.sh
+++ b/bin/bootstrap.sh
@@ -20,6 +20,13 @@ PLUGIN_NAME="claude-notifications-go"
 PLUGIN_KEY="${PLUGIN_NAME}@${MARKETPLACE_NAME}"
 INSTALL_SCRIPT_URL="${INSTALL_SCRIPT_URL:-https://raw.githubusercontent.com/${REPO}/main/bin/install.sh}"
 
+# Retired GitHub repo name(s) this marketplace was previously declared under.
+# Users who added the marketplace before a rename have this baked into their
+# settings; Claude Code refuses to silently re-point a declared marketplace
+# at a different source, so `marketplace add` fails for them. See
+# setup_marketplace() and docs/CLAUDE_PLUGIN_IDENTITY.md.
+LEGACY_MARKETPLACE_REPOS="777genius/claude-notifications-go"
+
 # Paths — CLAUDE_CONFIG_DIR is the official Claude Code env var;
 # CLAUDE_HOME is a legacy fallback; default to ~/.claude
 CLAUDE_HOME="${CLAUDE_CONFIG_DIR:-${CLAUDE_HOME:-$HOME/.claude}}"
@@ -163,6 +170,38 @@ print_iterm2_python_api_notice() {
 
 # ──────────────────────────────────────────────
 
+# Reports (on stdout) the repo currently declared in settings for
+# $MARKETPLACE_NAME, or nothing if it isn't declared / can't be read.
+# `marketplace list` only reads local state — no network calls.
+marketplace_declared_repo() {
+    local tmp
+    tmp=$(mktemp "${TMPDIR:-/tmp}/marketplace-list-XXXXXX") || return 1
+    claude plugin marketplace list --json >"$tmp" 2>/dev/null
+    python3 -I - "$tmp" "$MARKETPLACE_NAME" <<'PY'
+import json, sys
+path, name = sys.argv[1], sys.argv[2]
+try:
+    with open(path) as f:
+        entries = json.load(f)
+except Exception:
+    sys.exit(0)
+for e in entries:
+    if e.get('name') == name and e.get('repo'):
+        print(e['repo'])
+        break
+PY
+    rm -f "$tmp"
+}
+
+# True if $1 (a repo slug) is one of our own retired marketplace sources.
+is_legacy_marketplace_repo() {
+    local repo="$1" candidate
+    for candidate in $LEGACY_MARKETPLACE_REPOS; do
+        [ "$repo" = "$candidate" ] && return 0
+    done
+    return 1
+}
+
 setup_marketplace() {
     echo ""
     echo -e "${BLUE}📦 Setting up marketplace...${NC}"
@@ -182,6 +221,24 @@ setup_marketplace() {
             else
                 # Update may fail if already up-to-date — that's OK
                 echo -e "${GREEN}✓${NC} Marketplace is up to date"
+            fi
+        elif echo "$output" | grep -qi "source differs" \
+            && is_legacy_marketplace_repo "$(marketplace_declared_repo)"; then
+            # Declared under a repo name we ourselves retired (rename
+            # migration). Claude Code won't silently re-point an existing
+            # declaration, and there's no other transparent migration path
+            # for a marketplace source change, so re-register it: this
+            # only drops the marketplace/plugin *registration*, not the
+            # user's saved notification settings (a separate file), and
+            # the rest of this script reinstalls the plugin right after.
+            echo -e "${BLUE}  Marketplace points at the retired repo name; re-registering...${NC}"
+            claude plugin marketplace remove "$MARKETPLACE_NAME" </dev/null >/dev/null 2>&1
+            config_preflight || return 1
+            if output=$(claude plugin marketplace add "$MARKETPLACE_SOURCE" </dev/null 2>&1); then
+                echo -e "${GREEN}✓${NC} Marketplace re-registered"
+            else
+                echo -e "${YELLOW}⚠ Marketplace add output: ${output}${NC}"
+                echo -e "${YELLOW}  Continuing anyway...${NC}"
             fi
         else
             echo -e "${YELLOW}⚠ Marketplace add output: ${output}${NC}"

--- a/bin/bootstrap_product_test.sh
+++ b/bin/bootstrap_product_test.sh
@@ -26,6 +26,46 @@ done
 for tag in v1.41.0 v0.99.0 v1.42.0-rc1 v01.42.0 v1.042.0 v1.42.00 v99999999999999999999.0.0 main; do
     if BOOTSTRAP_RELEASE_TAG="$tag" resolve_bootstrap_release; then exit 1; fi
 done
+# setup_marketplace self-heals a marketplace declared under a retired repo
+# name, but leaves an unrelated source conflict alone.
+(
+    # shellcheck disable=SC2034 # consumed by the sourced setup_marketplace
+    MARKETPLACE_SOURCE="new/repo"
+    # shellcheck disable=SC2034
+    MARKETPLACE_NAME="claude-notifications-go"
+    # shellcheck disable=SC2034
+    LEGACY_MARKETPLACE_REPOS="old/retired-repo"
+    config_preflight() { :; }
+    calls="$SANDBOX/marketplace-calls"; declared_repo="old/retired-repo"
+    claude() {
+        printf '%s\n' "$*" >> "$calls"
+        if [ "$1 $2 $3" = "plugin marketplace add" ]; then
+            if [ ! -f "$SANDBOX/marketplace-add-called" ]; then
+                touch "$SANDBOX/marketplace-add-called"
+                echo "Failed to add marketplace: its network source differs from the one declared for it in settings" >&2
+                return 1
+            fi
+            return 0
+        elif [ "$1 $2 $3" = "plugin marketplace list" ]; then
+            printf '[{"name":"claude-notifications-go","repo":"%s"}]\n' "$declared_repo"
+            return 0
+        elif [ "$1 $2 $3" = "plugin marketplace remove" ]; then
+            return 0
+        fi
+        return 0
+    }
+    : > "$calls"; rm -f "$SANDBOX/marketplace-add-called"
+    setup_marketplace
+    [ "$(grep -c '^plugin marketplace add' "$calls")" = 2 ] || { echo "expected retry add after self-heal"; exit 1; }
+    grep -q '^plugin marketplace remove claude-notifications-go$' "$calls" || { echo "expected self-heal remove"; exit 1; }
+
+    declared_repo="someone-else/unrelated-fork"
+    : > "$calls"; rm -f "$SANDBOX/marketplace-add-called"
+    setup_marketplace
+    [ "$(grep -c '^plugin marketplace add' "$calls")" = 1 ] || { echo "unrelated conflict must not retry add"; exit 1; }
+    if grep -q '^plugin marketplace remove' "$calls"; then echo "unrelated conflict must not self-heal"; exit 1; fi
+)
+echo "marketplace self-heal fixtures passed"
 # macOS resource refresh outside the cache must also protect explicit config.
 (
     PRODUCT=claude

--- a/docs/CLAUDE_PLUGIN_IDENTITY.md
+++ b/docs/CLAUDE_PLUGIN_IDENTITY.md
@@ -31,6 +31,29 @@ There is no documented alias or atomic rename mechanism that migrates existing m
 registrations, installed-plugin records, cache paths, enabled state, and command namespaces.
 The GitHub repository URL may change independently and does not require changing these IDs.
 
+## Repository renames still break existing installs
+
+Even though the marketplace/plugin *name* stays `claude-notifications-go`, users who declared
+that marketplace before a repository rename (e.g. the `claude-notifications-go` ->
+`agent-notifications` rename) get stuck: Claude Code stores the declared source
+(`extraKnownMarketplaces` in settings) and refuses to silently re-point an existing declaration
+at a different repo, failing `marketplace add` with `its network source differs from the one
+declared for it in settings`. There is no officially documented transparent migration for a
+marketplace *source* change (the `renames` map in `marketplace.json`, added in Claude Code
+2.1.193, only covers plugin name changes within a marketplace, not the marketplace's own
+repo). Confirmed against the official docs and reproduced end to end on 2026-09-11.
+
+`marketplace update` (the path used by the in-app "Update marketplace" action and Claude
+Code's periodic background check) is unaffected — it pulls the existing clone via git, which
+follows GitHub's redirect from the old repo name. Only `marketplace add` — which
+`bin/bootstrap.sh` always tries first, including on repeat runs — hits the conflict. `setup_marketplace()`
+in `bin/bootstrap.sh` detects this specific error, confirms the currently declared repo is one
+of our own retired names (`LEGACY_MARKETPLACE_REPOS`), and re-registers the marketplace
+(`remove` + `add`) automatically. This only resets the marketplace/plugin *registration*; the
+user's saved notification settings live in a separate config file and are untouched, and the
+rest of the script reinstalls the plugin right after. Any future repository rename must add the
+old repo slug to `LEGACY_MARKETPLACE_REPOS` in `bin/bootstrap.sh`.
+
 ## Rule for a future migration
 
 Do not change these identifiers unless a dedicated migration ships with disposable-profile

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -2,6 +2,33 @@
 
 Common installation and runtime issues.
 
+## `Failed to add marketplace: ... its network source differs from the one declared for it in settings`
+
+### Symptom
+
+Running the installer to update fails during "Setting up marketplace..." with an error
+mentioning the marketplace's network source differing from what's declared in settings.
+
+### Why it happens
+
+You installed before the project's GitHub repository was renamed from `claude-notifications-go`
+to `agent-notifications`. Claude Code remembers which repo you originally added the marketplace
+from and refuses to silently switch it to a different one under the same name — that's a
+deliberate safety check, not a bug in Claude Code.
+
+### Fix
+
+The installer (`bin/bootstrap.sh`) detects this specific case and re-registers the marketplace
+automatically; your saved notification settings are not affected. If you're still seeing this
+error (e.g. from a cached copy of an older installer script), fix it manually and re-run the
+installer:
+
+```bash
+/plugin marketplace remove claude-notifications-go
+```
+
+then run the [installer](../README.md#quick-install-recommended) again.
+
 ## macOS: VS Code click-to-focus focuses the wrong window
 
 ### Symptom


### PR DESCRIPTION
## Summary
- Users who added the `claude-notifications-go` marketplace before the GitHub repo was renamed to `agent-notifications` have the old repo baked into their local Claude Code settings. `marketplace add` (which `bin/bootstrap.sh` always tries first, including on repeat/update runs) then fails with `its network source differs from the one declared for it in settings`, and the install aborts.
- Confirmed against the official Claude Code docs: there's no transparent migration for a marketplace *source* change (the `renames` map in `marketplace.json` only covers plugin name changes within a marketplace, not the marketplace's own repo). The only documented path, even from Anthropic, is manual `marketplace remove` + `marketplace add`.
- `setup_marketplace()` now detects this specific failure, confirms via `marketplace list --json` that the currently-declared repo is one of our own retired names (`LEGACY_MARKETPLACE_REPOS`), and re-registers automatically. An unrelated source conflict (not our retired repo) is left alone, matching prior behavior.
- Not affected by the underlying bug at all: the in-app "Update marketplace" action and Claude Code's background auto-update (both call `marketplace update`, which pulls the existing clone via git and follows GitHub's redirect). Only the `add`-first path in `bootstrap.sh` hits it.
- Also updates `docs/CLAUDE_PLUGIN_IDENTITY.md` (this repo-rename gotcha wasn't documented there) and `docs/troubleshooting.md`.

## Test plan
- [x] `bash -n bin/bootstrap.sh`, `shellcheck` (0 warnings, same as baseline)
- [x] `bin/bootstrap_product_test.sh` and `bin/shell_review_test.sh` — all fixtures pass
- [x] Reproduced the bug from scratch in an isolated profile (marketplace added under the old repo name, plugin installed, realistic legacy config present), then ran the fixed `bootstrap.sh`: self-heals, plugin reinstalls at v1.42.0, config preserved byte for byte, marketplace source now correctly `777genius/agent-notifications`
- [x] Verified the safety guard: an isolated profile with an *unrelated* marketplace source conflict is left untouched (no auto-remove), same warning as before
- [x] Regression-checked a from-scratch fresh install and a repeat install on an already-correct marketplace — both unaffected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Installer updates now automatically recover marketplaces registered under retired repository names by re-registering them when needed.
  - Existing notification settings are preserved during marketplace migration.
  - Marketplace setup is more resilient to removal failures and malformed marketplace data.

- **Documentation**
  - Added guidance for resolving marketplace source mismatch errors.
  - Documented the effects of repository renames and provided a manual recovery command.

- **Tests**
  - Added coverage for automatic recovery and unrelated marketplace source conflicts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->