### PR TITLE
feat(notifier): focus the originating Warp pane on notification click

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Warp: exact pane/chat click-to-focus** — notification clicks open Warp's session deep link (`WARP_FOCUS_URL` / `warp://session/<uuid>`) so the originating window, tab, and pane (including the agent chat in that pane) come to the front. Falls back to the previous AXTitle `focus-window` path when the URL is absent or Warp cannot resolve it. Also works on Linux (`xdg-open`) and Windows (toast protocol), and composes with tmux/zellij inside Warp.
+
 ## [1.42.0] - 2026-09-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - **Warp: exact pane/chat click-to-focus** — notification clicks open Warp's session deep link (`WARP_FOCUS_URL` / `warp://session/<uuid>`) so the originating window, tab, and pane (including the agent chat in that pane) come to the front. Falls back to the previous AXTitle `focus-window` path when the URL is absent or Warp cannot resolve it. Also works on Linux (`xdg-open`) and Windows (toast protocol), and composes with tmux/zellij inside Warp.
 
+### Fixed
+- Ignore inherited `WARP_FOCUS_URL` in Cursor/VS Code launched from Warp so notification clicks stay on the editor instead of stealing focus back to Warp.
+
 ## [1.42.0] - 2026-09-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Notifications for Claude Code and Codex CLI (beta), with sounds, git branch disp
 
 - **Cross-platform**: macOS (Intel & Apple Silicon), Linux (x64 & ARM64), Windows 10+ (x64)
 - **Claude notification types**: Task Complete, Review Complete, Question, Plan Ready, Session Limit, API Error
-- **Click-to-focus** (macOS, Linux, Windows): click notification to focus the exact project window and tab — Ghostty, VS Code, iTerm2, Warp (`WARP_FOCUS_URL`), kitty, WezTerm, Alacritty, Hyper, Apple Terminal, GNOME Terminal, Konsole, Tilix, Terminator, XFCE4 Terminal, MATE Terminal
+- **Click-to-focus** (macOS, Linux): click notification to focus the exact project window and tab — Ghostty, VS Code, iTerm2, Warp (`WARP_FOCUS_URL`), kitty, WezTerm, Alacritty, Hyper, Apple Terminal, GNOME Terminal, Konsole, Tilix, Terminator, XFCE4 Terminal, MATE Terminal. Windows focuses the originating window; Warp on Windows can still select the pane via `WARP_FOCUS_URL`.
 - **Multiplexers**: tmux (including iTerm2 -CC integration mode), zellij, WezTerm, kitty — click switches to the correct session/pane/tab
 - **Git branch in title**: `✅ Completed main [cat]`
 - **Sounds**: MP3/WAV/FLAC/OGG/AIFF, volume control, audio device selection

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Notifications for Claude Code and Codex CLI (beta), with sounds, git branch disp
 
 - **Cross-platform**: macOS (Intel & Apple Silicon), Linux (x64 & ARM64), Windows 10+ (x64)
 - **Claude notification types**: Task Complete, Review Complete, Question, Plan Ready, Session Limit, API Error
-- **Click-to-focus** (macOS, Linux): click notification to focus the exact project window and tab — Ghostty, VS Code, iTerm2, Warp, kitty, WezTerm, Alacritty, Hyper, Apple Terminal, GNOME Terminal, Konsole, Tilix, Terminator, XFCE4 Terminal, MATE Terminal
+- **Click-to-focus** (macOS, Linux, Windows): click notification to focus the exact project window and tab — Ghostty, VS Code, iTerm2, Warp (`WARP_FOCUS_URL`), kitty, WezTerm, Alacritty, Hyper, Apple Terminal, GNOME Terminal, Konsole, Tilix, Terminator, XFCE4 Terminal, MATE Terminal
 - **Multiplexers**: tmux (including iTerm2 -CC integration mode), zellij, WezTerm, kitty — click switches to the correct session/pane/tab
 - **Git branch in title**: `✅ Completed main [cat]`
 - **Sounds**: MP3/WAV/FLAC/OGG/AIFF, volume control, audio device selection
@@ -294,7 +294,8 @@ Clicking a notification activates your terminal window. Auto-detects terminal an
 | Ghostty | Exact tab focus via Ghostty AppleScript, with AXDocument fallback |
 | VS Code / Insiders / Cursor | AXTitle (focus-window subcommand) |
 | iTerm2 | Exact tab/pane targeting via iTerm2 Python API when available, otherwise app-level iTerm activation |
-| Warp, kitty, WezTerm, Alacritty, Hyper, Apple Terminal | AXTitle (focus-window subcommand) |
+| Warp | Exact window/tab/pane via `WARP_FOCUS_URL` (`warp://session/<uuid>`), AXTitle fallback on older Warp |
+| kitty, WezTerm, Alacritty, Hyper, Apple Terminal | AXTitle (focus-window subcommand) |
 | Any other (custom `terminalBundleId`) | AXTitle (focus-window subcommand) |
 
 **Linux** — via D-Bus daemon with automatic compositor detection:
@@ -302,10 +303,11 @@ Clicking a notification activates your terminal window. Auto-detects terminal an
 | Terminal | Supported compositors |
 |----------|----------------------|
 | VS Code | GNOME, KDE, Sway, X11 |
+| Warp | GNOME, KDE, Sway, X11 — exact pane via `WARP_FOCUS_URL` |
 | GNOME Terminal, Konsole, Alacritty, kitty, WezTerm, Tilix, Terminator, XFCE4 Terminal, MATE Terminal | GNOME, KDE, Sway, X11 |
 | Any other | Fallback by name |
 
-Linux focus methods (tried in order): GNOME extension, GNOME Shell Eval, GNOME FocusApp, wlrctl (Sway/wlroots), kdotool (KDE), xdotool (X11).
+Linux focus methods (tried in order): Warp session URL (`xdg-open`), GNOME extension, GNOME Shell Eval, GNOME FocusApp, wlrctl (Sway/wlroots), kdotool (KDE), xdotool (X11).
 
 **Multiplexers** (both platforms): tmux (including iTerm2 -CC integration mode), zellij, WezTerm, kitty — click switches to the correct pane/tab.
 

--- a/docs/CLICK_TO_FOCUS.md
+++ b/docs/CLICK_TO_FOCUS.md
@@ -33,7 +33,7 @@ Auto-detects your terminal via `TERM_PROGRAM` / `__CFBundleIdentifier`. Uses `te
 | Ghostty | Exact tab focus via Ghostty AppleScript, with AXDocument retry fallback |
 | VS Code / Insiders / Cursor | AXTitle via focus-window subcommand |
 | iTerm2 | Exact tab/pane targeting via iTerm2 Python API when available, otherwise app-level iTerm activation |
-| Warp | Exact window/tab/pane via `WARP_FOCUS_URL` (`open warp://session/<uuid>`), with AXTitle `focus-window` fallback on older Warp |
+| Warp | Exact window/tab/pane via `WARP_FOCUS_URL` (`open warp://session/<uuid>`) when the hook ran inside Warp, with AXTitle `focus-window` fallback on older Warp. Cursor/VS Code launched from Warp keep editor focus. |
 | kitty, WezTerm, Alacritty, Hyper, Apple Terminal | AXTitle via focus-window subcommand |
 | Any other (custom `terminalBundleId`) | AXTitle via focus-window subcommand |
 

--- a/docs/CLICK_TO_FOCUS.md
+++ b/docs/CLICK_TO_FOCUS.md
@@ -33,14 +33,17 @@ Auto-detects your terminal via `TERM_PROGRAM` / `__CFBundleIdentifier`. Uses `te
 | Ghostty | Exact tab focus via Ghostty AppleScript, with AXDocument retry fallback |
 | VS Code / Insiders / Cursor | AXTitle via focus-window subcommand |
 | iTerm2 | Exact tab/pane targeting via iTerm2 Python API when available, otherwise app-level iTerm activation |
-| Warp, kitty, WezTerm, Alacritty, Hyper, Apple Terminal | AXTitle via focus-window subcommand |
+| Warp | Exact window/tab/pane via `WARP_FOCUS_URL` (`open warp://session/<uuid>`), with AXTitle `focus-window` fallback on older Warp |
+| kitty, WezTerm, Alacritty, Hyper, Apple Terminal | AXTitle via focus-window subcommand |
 | Any other (custom `terminalBundleId`) | AXTitle via focus-window subcommand |
 
 To find your terminal's bundle ID: `osascript -e 'id of app "YourTerminal"'`
 
 ### Permissions
 
-All terminals with click-to-focus may require up to two permissions for window-level focus:
+Warp session deep links (`WARP_FOCUS_URL`) do not need Accessibility or Screen Recording — Warp handles window/tab/pane focus itself.
+
+All other terminals with click-to-focus may require up to two permissions for window-level focus:
 
 - **Accessibility** — to enumerate and raise the correct window via the AX API
 - **Screen Recording** — to read window titles across Spaces (macOS 10.15+)
@@ -58,15 +61,17 @@ Uses a background D-Bus daemon. Auto-detects terminal and compositor.
 | Terminal | Supported compositors |
 |----------|----------------------|
 | VS Code | GNOME, KDE, Sway, X11 |
+| Warp | GNOME, KDE, Sway, X11 — exact pane via `WARP_FOCUS_URL` |
 | GNOME Terminal, Konsole, Alacritty, kitty, WezTerm, Tilix, Terminator, XFCE4 Terminal, MATE Terminal | GNOME, KDE, Sway, X11 |
 | Any other | Fallback by name |
 
 Focus methods (tried in order):
 
-1. **GNOME**: `activate-window-by-title` extension, Shell Eval, FocusApp (GNOME 45+)
-2. **Sway / wlroots**: `wlrctl`
-3. **KDE Plasma**: `kdotool`
-4. **X11** (XFCE, MATE, Cinnamon, i3, bspwm): `xdotool`
+1. **Warp**: `xdg-open` of `$WARP_FOCUS_URL` (`warp://session/<uuid>`) when the hook ran inside Warp
+2. **GNOME**: `activate-window-by-title` extension, Shell Eval, FocusApp (GNOME 45+)
+3. **Sway / wlroots**: `wlrctl`
+4. **KDE Plasma**: `kdotool`
+5. **X11** (XFCE, MATE, Cinnamon, i3, bspwm): `xdotool`
 
 Falls back to standard notifications if no focus tool is available.
 
@@ -89,7 +94,7 @@ Review the file before sharing it publicly, because it may include local paths a
 
 ## Multiplexers
 
-On both macOS and Linux, click-to-focus supports **tmux**, **zellij**, **WezTerm**, and **kitty** — clicking a notification switches to the correct session/pane/tab.
+On both macOS and Linux, click-to-focus supports **tmux**, **zellij**, **WezTerm**, and **kitty** — clicking a notification switches to the correct session/pane/tab. Inside Warp, the Warp session URL is opened first so the right Warp window/tab is raised, then the multiplexer target is selected.
 
 ### iTerm2 + tmux Control Mode (-CC)
 
@@ -120,7 +125,7 @@ If the Python API is not available, the plugin falls back to standard `tmux sele
 
 ## Windows
 
-Clicking a notification raises the terminal **window** that started the task. Enabled by the same `clickToFocus` flag; no extra configuration.
+Clicking a notification raises the terminal **window** that started the task. Enabled by the same `clickToFocus` flag; no extra configuration. In Warp, the toast also carries `WARP_FOCUS_URL`, and the click handler opens that session deep link first so the originating tab/pane is selected before the generic HWND fallback.
 
 How it works (no admin rights, no COM server):
 

--- a/docs/LOCAL_DEVELOPMENT.md
+++ b/docs/LOCAL_DEVELOPMENT.md
@@ -153,6 +153,13 @@ What to verify manually:
 2. Clicking it focuses the exact Claude terminal/window that triggered the hook.
 3. On Linux, verify it does not jump to a stale Terminator/X11 window.
 4. On macOS, verify the right app/window becomes frontmost.
+5. In Warp (v0.2026.05.27+): with two Warp tabs/panes, the click must land on the originating pane (and its agent chat), not merely bring Warp to the front. From a Warp pane:
+
+```bash
+scripts/warp-focus-check.sh notify
+```
+
+Then switch to another Warp tab and click the notification. `scripts/warp-focus-check.sh open` only checks Warp's URL handler, not the notification click path.
 
 ### Status / targeting
 

--- a/internal/daemon/client.go
+++ b/internal/daemon/client.go
@@ -38,6 +38,7 @@ func NewClient() (*Client, error) {
 // focusFolder is the project folder name for window-specific focus (may be empty).
 // focusWindowID and focusWindowTitle are optional exact window hints captured in the hook process.
 // wezTermPaneID and wezTermSocket are WezTerm-specific hints for tab-level focus (may be empty).
+// warpFocusURL is a Warp session deep link that focuses the originating pane (may be empty).
 func (c *Client) SendNotification(
 	title,
 	body,
@@ -46,7 +47,8 @@ func (c *Client) SendNotification(
 	focusWindowID,
 	focusWindowTitle,
 	wezTermPaneID,
-	wezTermSocket string,
+	wezTermSocket,
+	warpFocusURL string,
 	timeout int,
 ) (*NotifyResponse, error) {
 	req := Request{
@@ -61,6 +63,7 @@ func (c *Client) SendNotification(
 			FocusWindowTitle:   focusWindowTitle,
 			FocusWezTermPaneID: wezTermPaneID,
 			FocusWezTermSocket: wezTermSocket,
+			FocusWarpURL:       warpFocusURL,
 			Timeout:            timeout,
 		},
 	}

--- a/internal/daemon/focus.go
+++ b/internal/daemon/focus.go
@@ -13,6 +13,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/777genius/agent-notifications/internal/warpfocus"
 )
 
 // FocusMethod represents a method for focusing a window
@@ -34,21 +36,24 @@ func GetFocusMethods() []FocusMethod {
 	}
 }
 
+var openFocusURL = warpfocus.Open
+
 // TryFocus attempts to focus a window using available tools.
 // folderName is the project folder name used for title-based window search (may be empty).
 // It tries each method in order until one succeeds.
 func TryFocus(terminalName, folderName string) error {
-	return TryFocusWithHints(terminalName, folderName, "", "", "", "")
+	return TryFocusWithHints(terminalName, folderName, "", "", "", "", "")
 }
 
 // TryFocusWithWindowID preserves the previous API for callers that only have an exact X11 window ID.
 func TryFocusWithWindowID(terminalName, folderName, windowID string) error {
-	return TryFocusWithHints(terminalName, folderName, windowID, "", "", "")
+	return TryFocusWithHints(terminalName, folderName, windowID, "", "", "", "")
 }
 
 // TryFocusWithHints attempts exact focus using hook-time hints first, then falls back to
 // compositor-specific methods.
 // wezTermPaneID and wezTermSocket enable tab-level focus for WezTerm.
+// warpFocusURL is a Warp session deep link that focuses the originating window/tab/pane.
 //
 // For WezTerm, window-level focus runs first, then the pane switch runs after a short
 // delay. This ordering matters: GNOME's XDG Activation Token is processed asynchronously
@@ -56,7 +61,13 @@ func TryFocusWithWindowID(terminalName, folderName, windowID string) error {
 // switch runs first. Running the pane switch last ensures it wins.
 // If all window-level methods fail but a pane ID is available, TryWezTermPane is tried
 // as a last resort (activate-pane also raises the window on WezTerm).
-func TryFocusWithHints(terminalName, folderName, windowID, windowTitle, wezTermPaneID, wezTermSocket string) error {
+func TryFocusWithHints(terminalName, folderName, windowID, windowTitle, wezTermPaneID, wezTermSocket, warpFocusURL string) error {
+	if url := warpfocus.Normalize(warpFocusURL); url != "" {
+		if err := openFocusURL(url); err == nil {
+			return nil
+		}
+	}
+
 	wezTermPaneID, wezTermSocket = normalizeWezTermFocusHints(terminalName, wezTermPaneID, wezTermSocket)
 	windowFocused := false
 	var exactErr, lastErr error

--- a/internal/daemon/focus_test.go
+++ b/internal/daemon/focus_test.go
@@ -108,3 +108,33 @@ func TestSplitWindowIDs_TrimsBlankLines(t *testing.T) {
 		t.Errorf("splitWindowIDs() = %#v, want %#v", got, want)
 	}
 }
+
+func TestTryFocusWithHints_WarpURLShortCircuits(t *testing.T) {
+	const hex = "6b7be92641ae8ced80188a4d87e4b200"
+	opened := ""
+	orig := openFocusURL
+	t.Cleanup(func() { openFocusURL = orig })
+	openFocusURL = func(url string) error {
+		opened = url
+		return nil
+	}
+
+	if err := TryFocusWithHints("WarpTerminal", "proj", "", "", "", "", "warp://session/"+hex); err != nil {
+		t.Fatalf("TryFocusWithHints: %v", err)
+	}
+	if opened != "warp://session/"+hex {
+		t.Fatalf("opened %q, want warp session URL", opened)
+	}
+}
+
+func TestTryFocusWithHints_RejectsNonSessionWarpURL(t *testing.T) {
+	orig := openFocusURL
+	t.Cleanup(func() { openFocusURL = orig })
+	openFocusURL = func(url string) error {
+		t.Fatalf("should not open non-session Warp URL %q", url)
+		return nil
+	}
+
+	// Invalid URL must fall through to the compositor chain instead of xdg-open.
+	_ = TryFocusWithHints("WarpTerminal", "proj", "", "", "", "", "warp://action/new_tab")
+}

--- a/internal/daemon/mappings.go
+++ b/internal/daemon/mappings.go
@@ -43,6 +43,8 @@ func GetAppID(terminalName string) string {
 		return "com.gexperts.Tilix.desktop"
 	case "terminator":
 		return "terminator.desktop"
+	case "warpterminal", "warp":
+		return "dev.warp.Warp.desktop"
 	default:
 		return strings.ToLower(terminalName) + ".desktop"
 	}
@@ -131,6 +133,8 @@ func GetGnomeWmClass(terminalName string) string {
 		return "Xfce4-terminal"
 	case "mate-terminal":
 		return "Mate-terminal"
+	case "warpterminal", "warp":
+		return "dev.warp.Warp"
 	default:
 		return terminalName
 	}
@@ -153,6 +157,8 @@ func GetWlrctlAppID(terminalName string) string {
 		return "org.gnome.Terminal"
 	case "konsole":
 		return "org.kde.konsole"
+	case "warpterminal", "warp":
+		return "dev.warp.Warp"
 	default:
 		return strings.ToLower(terminalName)
 	}
@@ -173,6 +179,8 @@ func GetKdotoolClass(terminalName string) string {
 		return "gnome-terminal-server"
 	case "konsole":
 		return "konsole"
+	case "warpterminal", "warp":
+		return "dev.warp.Warp"
 	default:
 		return strings.ToLower(terminalName)
 	}
@@ -201,6 +209,8 @@ func GetXdotoolClass(terminalName string) string {
 		return "Tilix"
 	case "terminator":
 		return "Terminator"
+	case "warpterminal", "warp":
+		return "dev.warp.Warp"
 	default:
 		return terminalName
 	}
@@ -213,6 +223,8 @@ func GetSearchTerm(terminalName string) string {
 		return "Visual Studio Code"
 	case "gnome-terminal":
 		return "Terminal"
+	case "warpterminal", "warp":
+		return "Warp"
 	default:
 		return terminalName
 	}
@@ -262,6 +274,10 @@ func GetTerminalName() string {
 	// more specific indicator wins when a supported terminal is nested inside it.
 	if os.Getenv("ALACRITTY_WINDOW_ID") != "" {
 		return "alacritty"
+	}
+
+	if os.Getenv("WARP_FOCUS_URL") != "" || os.Getenv("WARP_TERMINAL_SESSION_UUID") != "" || os.Getenv("WARP_IS_LOCAL_SHELL_SESSION") != "" {
+		return "WarpTerminal"
 	}
 
 	// Fallback to generic terminal

--- a/internal/daemon/mappings.go
+++ b/internal/daemon/mappings.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+
+	"github.com/777genius/agent-notifications/internal/warpfocus"
 )
 
 const claudeNotificationsDesktopEntryID = "claude-notifications"
@@ -244,9 +246,12 @@ func GetSearchTermWithFolder(terminalName, folderName string) string {
 
 // GetTerminalName detects the current terminal from environment variables.
 func GetTerminalName() string {
-	// Try TERM_PROGRAM first (set by many terminals)
+	// Try TERM_PROGRAM first (set by many terminals). Skip an inherited
+	// WarpTerminal value when this process is Cursor/VS Code/etc.
 	if termProg := os.Getenv("TERM_PROGRAM"); termProg != "" {
-		return termProg
+		if termProg != "WarpTerminal" || warpfocus.IsWarpHost() {
+			return termProg
+		}
 	}
 
 	// Check VS Code indicators
@@ -276,7 +281,7 @@ func GetTerminalName() string {
 		return "alacritty"
 	}
 
-	if os.Getenv("WARP_FOCUS_URL") != "" || os.Getenv("WARP_TERMINAL_SESSION_UUID") != "" || os.Getenv("WARP_IS_LOCAL_SHELL_SESSION") != "" {
+	if warpfocus.IsWarpHost() && (os.Getenv("WARP_FOCUS_URL") != "" || os.Getenv("WARP_TERMINAL_SESSION_UUID") != "" || os.Getenv("WARP_IS_LOCAL_SHELL_SESSION") != "") {
 		return "WarpTerminal"
 	}
 

--- a/internal/daemon/mappings_test.go
+++ b/internal/daemon/mappings_test.go
@@ -26,6 +26,9 @@ func saveTerminalEnv(t *testing.T) func() {
 		"WEZTERM_PANE",
 		"WEZTERM_UNIX_SOCKET",
 		"ALACRITTY_WINDOW_ID",
+		"WARP_FOCUS_URL",
+		"WARP_TERMINAL_SESSION_UUID",
+		"WARP_IS_LOCAL_SHELL_SESSION",
 	}
 	type envState struct {
 		value string
@@ -545,6 +548,24 @@ func TestGetTerminalName_Fallback(t *testing.T) {
 	result := GetTerminalName()
 	if result != "Terminal" {
 		t.Errorf("GetTerminalName() fallback = %q, want %q", result, "Terminal")
+	}
+}
+
+func TestGetTerminalName_WarpFocusURL(t *testing.T) {
+	restore := saveTerminalEnv(t)
+	defer restore()
+
+	os.Setenv("WARP_FOCUS_URL", "warp://session/6b7be92641ae8ced80188a4d87e4b200")
+
+	result := GetTerminalName()
+	if result != "WarpTerminal" {
+		t.Errorf("GetTerminalName() with WARP_FOCUS_URL = %q, want %q", result, "WarpTerminal")
+	}
+}
+
+func TestGetGnomeWmClass_Warp(t *testing.T) {
+	if got := GetGnomeWmClass("WarpTerminal"); got != "dev.warp.Warp" {
+		t.Errorf("GetGnomeWmClass(WarpTerminal) = %q, want dev.warp.Warp", got)
 	}
 }
 

--- a/internal/daemon/mappings_test.go
+++ b/internal/daemon/mappings_test.go
@@ -12,6 +12,9 @@ func saveTerminalEnv(t *testing.T) func() {
 	t.Helper()
 	vars := []string{
 		"TERM_PROGRAM",
+		"__CFBundleIdentifier",
+		"TMUX",
+		"ZELLIJ",
 		"VSCODE_INJECTION",
 		"VSCODE_GIT_IPC_HANDLE",
 		"GNOME_TERMINAL_SCREEN",
@@ -555,11 +558,27 @@ func TestGetTerminalName_WarpFocusURL(t *testing.T) {
 	restore := saveTerminalEnv(t)
 	defer restore()
 
+	os.Setenv("TERM_PROGRAM", "WarpTerminal")
 	os.Setenv("WARP_FOCUS_URL", "warp://session/6b7be92641ae8ced80188a4d87e4b200")
 
 	result := GetTerminalName()
 	if result != "WarpTerminal" {
 		t.Errorf("GetTerminalName() with WARP_FOCUS_URL = %q, want %q", result, "WarpTerminal")
+	}
+}
+
+func TestGetTerminalName_IgnoresInheritedWarpInCursor(t *testing.T) {
+	restore := saveTerminalEnv(t)
+	defer restore()
+
+	os.Setenv("TERM_PROGRAM", "WarpTerminal")
+	os.Setenv("VSCODE_INJECTION", "1")
+	os.Setenv("__CFBundleIdentifier", "com.todesktop.230313mzl4w4u92")
+	os.Setenv("WARP_FOCUS_URL", "warp://session/6b7be92641ae8ced80188a4d87e4b200")
+
+	result := GetTerminalName()
+	if result != "Code" {
+		t.Errorf("GetTerminalName() for Cursor-from-Warp = %q, want %q", result, "Code")
 	}
 }
 

--- a/internal/daemon/protocol.go
+++ b/internal/daemon/protocol.go
@@ -54,6 +54,7 @@ type NotifyRequest struct {
 	FocusWindowTitle   string `json:"focus_window_title,omitempty"`    // Exact window title captured in the hook process when available
 	FocusWezTermPaneID string `json:"focus_wezterm_pane_id,omitempty"` // WezTerm pane ID ($WEZTERM_PANE)
 	FocusWezTermSocket string `json:"focus_wezterm_socket,omitempty"`  // WezTerm unix socket ($WEZTERM_UNIX_SOCKET)
+	FocusWarpURL       string `json:"focus_warp_url,omitempty"`        // Warp pane deep link ($WARP_FOCUS_URL)
 	Timeout            int    `json:"timeout"`                         // Notification timeout in seconds
 }
 

--- a/internal/daemon/protocol_test.go
+++ b/internal/daemon/protocol_test.go
@@ -123,6 +123,7 @@ func TestRequest_JSONRoundtrip_Notify(t *testing.T) {
 			FocusTarget:      "code",
 			FocusWindowID:    "12345",
 			FocusWindowTitle: "project - Terminator",
+			FocusWarpURL:     "warp://session/6b7be92641ae8ced80188a4d87e4b200",
 			Timeout:          30,
 		},
 	}
@@ -160,6 +161,9 @@ func TestRequest_JSONRoundtrip_Notify(t *testing.T) {
 	}
 	if decoded.Notify.FocusWindowTitle != "project - Terminator" {
 		t.Errorf("FocusWindowTitle = %q, want %q", decoded.Notify.FocusWindowTitle, "project - Terminator")
+	}
+	if decoded.Notify.FocusWarpURL != "warp://session/6b7be92641ae8ced80188a4d87e4b200" {
+		t.Errorf("FocusWarpURL = %q, want session URL", decoded.Notify.FocusWarpURL)
 	}
 	if decoded.Notify.Timeout != 30 {
 		t.Errorf("Timeout = %d, want %d", decoded.Notify.Timeout, 30)

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -27,6 +27,7 @@ type focusInfo struct {
 	windowTitle   string
 	wezTermPaneID string
 	wezTermSocket string
+	warpFocusURL  string
 }
 
 // Server is the notification daemon server
@@ -288,6 +289,7 @@ func (s *Server) handleNotification(req *NotifyRequest) (*NotifyResponse, error)
 		windowTitle:   req.FocusWindowTitle,
 		wezTermPaneID: req.FocusWezTermPaneID,
 		wezTermSocket: req.FocusWezTermSocket,
+		warpFocusURL:  req.FocusWarpURL,
 	}
 	s.focusCtxMu.Unlock()
 
@@ -318,6 +320,7 @@ func (s *Server) onActionInvoked(sig *notify.ActionInvokedSignal) {
 	focusWindowTitle := info.windowTitle
 	wezTermPaneID := info.wezTermPaneID
 	wezTermSocket := info.wezTermSocket
+	warpFocusURL := info.warpFocusURL
 
 	if !exists {
 		log.Printf("[WARN] No focus context for notification %d", sig.ID)
@@ -325,9 +328,9 @@ func (s *Server) onActionInvoked(sig *notify.ActionInvokedSignal) {
 	}
 
 	// Attempt to focus
-	log.Printf("[INFO] Attempting to focus: %s (folder: %s, window_id: %s, window_title: %q, wezterm_pane: %s)",
-		focusTarget, focusFolder, focusWindowID, focusWindowTitle, wezTermPaneID)
-	if err := TryFocusWithHints(focusTarget, focusFolder, focusWindowID, focusWindowTitle, wezTermPaneID, wezTermSocket); err != nil {
+	log.Printf("[INFO] Attempting to focus: %s (folder: %s, window_id: %s, window_title: %q, wezterm_pane: %s, warp_url: %s)",
+		focusTarget, focusFolder, focusWindowID, focusWindowTitle, wezTermPaneID, warpFocusURL)
+	if err := TryFocusWithHints(focusTarget, focusFolder, focusWindowID, focusWindowTitle, wezTermPaneID, wezTermSocket, warpFocusURL); err != nil {
 		log.Printf("[ERROR] Focus failed: %v", err)
 	} else {
 		log.Printf("[INFO] Focus succeeded")

--- a/internal/notifier/multiplexer.go
+++ b/internal/notifier/multiplexer.go
@@ -36,7 +36,7 @@ func detectMultiplexerArgs(title, message, bundleID string) ([]string, string) {
 			logging.Debug("%s detected but buildArgs failed: %v", mux.name, err)
 			return nil, mux.name
 		}
-		return args, mux.name
+		return injectWarpFocusURL(args), mux.name
 	}
 	return nil, ""
 }

--- a/internal/notifier/notifier.go
+++ b/internal/notifier/notifier.go
@@ -347,12 +347,14 @@ func buildTerminalNotifierArgsWithOptions(title, message, bundleID, cwd, ghostty
 }
 
 // buildFocusScript returns the shell command for -execute in terminal-notifier.
+// For Warp: opens WARP_FOCUS_URL so Warp raises the originating window/tab/pane.
 // For Ghostty: uses AXDocument attribute (OSC 7 CWD) via Accessibility API,
 // falling back to plain app activation.
 // For all apps (including Electron editors and regular terminals): invokes the
 // binary's focus-window subcommand which uses CGS + AXTitle APIs to find and
 // raise the correct window across Spaces.
-// Returns "" when cwd is empty or unusable (caller should use -activate instead).
+// Returns "" when cwd is empty or unusable (caller should use -activate instead),
+// except Warp/iTerm2 session targeting which can work without cwd.
 func buildFocusScript(bundleID, cwd string) string {
 	return buildFocusScriptWithOptions(bundleID, cwd, "")
 }
@@ -360,6 +362,10 @@ func buildFocusScript(bundleID, cwd string) string {
 func buildFocusScriptWithOptions(bundleID, cwd, ghosttyTerminalID string) string {
 	if isIterm2BundleID(bundleID) {
 		return buildIterm2FocusScript(cwd)
+	}
+
+	if focusURL := warpFocusURL(); focusURL != "" {
+		return buildWarpFocusScript(focusURL, bundleID, cwd)
 	}
 
 	if isGhosttyBundleID(bundleID) {

--- a/internal/notifier/notifier_test.go
+++ b/internal/notifier/notifier_test.go
@@ -1419,6 +1419,7 @@ func TestCwdToFileURL(t *testing.T) {
 
 func TestBuildFocusScript_RegularTerminal_UsesFocusWindow(t *testing.T) {
 	t.Setenv(iTerm2SessionIDEnv, "")
+	clearWarpFocusEnv(t)
 	script := buildFocusScript("dev.warp.Warp-Stable", "/home/user/my-project")
 	// Regular terminals now use focus-window subcommand instead of AppleScript.
 	// This avoids the Automation permission issue on macOS Tahoe (26.x).
@@ -1598,6 +1599,7 @@ func TestBuildTerminalNotifierArgs_WithCWD_UsesExecute(t *testing.T) {
 
 func TestBuildTerminalNotifierArgs_WithCWD_NonItermTerminalUsesFocusWindow(t *testing.T) {
 	t.Setenv(iTerm2SessionIDEnv, "")
+	clearWarpFocusEnv(t)
 	args := buildTerminalNotifierArgs("Title", "Message", "dev.warp.Warp-Stable", "/home/user/my-project", true)
 	execVal := getArgValue(args, "-execute")
 	if execVal == "" {

--- a/internal/notifier/terminal_linux.go
+++ b/internal/notifier/terminal_linux.go
@@ -12,6 +12,7 @@ import (
 	"github.com/777genius/agent-notifications/internal/config"
 	"github.com/777genius/agent-notifications/internal/daemon"
 	"github.com/777genius/agent-notifications/internal/logging"
+	"github.com/777genius/agent-notifications/internal/warpfocus"
 	"github.com/gen2brain/beeep"
 )
 
@@ -101,8 +102,9 @@ func sendViaDaemon(title, body, cwd string) error {
 
 	// Capture WezTerm pane info only when the focus target is actually WezTerm.
 	wezTermPaneID, wezTermSocket := daemon.GetWezTermFocusHints(focusTarget)
+	warpFocusURL := warpfocus.FromEnv()
 
-	_, err = client.SendNotification(title, body, focusTarget, folderName, focusWindowID, focusWindowTitle, wezTermPaneID, wezTermSocket, 30)
+	_, err = client.SendNotification(title, body, focusTarget, folderName, focusWindowID, focusWindowTitle, wezTermPaneID, wezTermSocket, warpFocusURL, 30)
 	return err
 }
 

--- a/internal/notifier/warp_focus.go
+++ b/internal/notifier/warp_focus.go
@@ -1,0 +1,52 @@
+package notifier
+
+import (
+	"strings"
+
+	"github.com/777genius/agent-notifications/internal/warpfocus"
+)
+
+// warpFocusURL returns the originating Warp pane deep link when the current
+// process (or its tmux session) exported one. Empty when not running in Warp
+// or when the Warp build predates WARP_FOCUS_URL.
+func warpFocusURL() string {
+	return warpfocus.FromEnv()
+}
+
+// buildWarpFocusScript opens Warp's session URL on click so Warp itself
+// raises the originating window, tab, and pane (including Agent chat in that
+// pane). Falls back to the existing AXTitle focus-window path if open fails.
+func buildWarpFocusScript(focusURL, bundleID, cwd string) string {
+	openCmd := "open " + shellQuote(focusURL)
+	if isUsableFocusCWD(cwd) {
+		if fallback := buildBinaryFocusScript(bundleID, cwd, ""); fallback != "" {
+			return openCmd + " >/dev/null 2>&1 || " + fallback
+		}
+	}
+	return openCmd
+}
+
+// injectWarpFocusURL prepends `open <WARP_FOCUS_URL>` to a multiplexer
+// -execute command so Warp+tmux/zellij still land on the originating Warp
+// pane, then switch the inner multiplexer target.
+func injectWarpFocusURL(args []string) []string {
+	focusURL := warpFocusURL()
+	if focusURL == "" {
+		return args
+	}
+	openCmd := "open " + shellQuote(focusURL) + " >/dev/null 2>&1"
+	out := make([]string, len(args))
+	copy(out, args)
+	for i := 0; i < len(out)-1; i++ {
+		if out[i] == "-execute" {
+			existing := strings.TrimSpace(out[i+1])
+			if existing == "" {
+				out[i+1] = openCmd
+			} else {
+				out[i+1] = openCmd + "; " + existing
+			}
+			return out
+		}
+	}
+	return append(out, "-execute", openCmd)
+}

--- a/internal/notifier/warp_focus_test.go
+++ b/internal/notifier/warp_focus_test.go
@@ -131,12 +131,15 @@ func TestInjectWarpFocusURL_NoopWithoutWarp(t *testing.T) {
 }
 
 func TestWarpFocusExecute_IsValidShell(t *testing.T) {
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("sh is not available")
+	}
 	clearWarpFocusEnv(t)
 	t.Setenv(warpfocus.FocusURLEnv, warpTestFocusURL)
 	t.Setenv(iTerm2SessionIDEnv, "")
 
 	script := buildFocusScript("dev.warp.Warp-Stable", "/home/user/my-project")
-	cmd := exec.Command("/bin/sh", "-n", "-c", script)
+	cmd := exec.Command("sh", "-n", "-c", script)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("Warp execute script is not valid shell: %v\n%s\nscript: %s", err, out, script)
 	}

--- a/internal/notifier/warp_focus_test.go
+++ b/internal/notifier/warp_focus_test.go
@@ -1,0 +1,158 @@
+package notifier
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/777genius/agent-notifications/internal/warpfocus"
+)
+
+var hostWarpFocusURL string
+
+func TestMain(m *testing.M) {
+	// Host shells inside Warp export WARP_FOCUS_URL; generic click-to-focus
+	// tests must not inherit it or they assert the wrong execute path.
+	hostWarpFocusURL = os.Getenv(warpfocus.FocusURLEnv)
+	_ = os.Unsetenv(warpfocus.FocusURLEnv)
+	_ = os.Unsetenv(warpfocus.SessionUUIDEnv)
+	os.Exit(m.Run())
+}
+
+const warpTestSessionHex = "6b7be92641ae8ced80188a4d87e4b200"
+const warpTestFocusURL = "warp://session/" + warpTestSessionHex
+
+func clearWarpFocusEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv(warpfocus.FocusURLEnv, "")
+	t.Setenv(warpfocus.SessionUUIDEnv, "")
+}
+
+func TestBuildFocusScript_WarpUsesSessionURL(t *testing.T) {
+	clearWarpFocusEnv(t)
+	t.Setenv(warpfocus.FocusURLEnv, warpTestFocusURL)
+	t.Setenv(iTerm2SessionIDEnv, "")
+
+	script := buildFocusScript("dev.warp.Warp-Stable", "/home/user/my-project")
+	if !strings.Contains(script, "open '"+warpTestFocusURL+"'") {
+		t.Fatalf("Warp click should open the session URL, got: %s", script)
+	}
+	if !strings.Contains(script, "||") {
+		t.Fatalf("Warp click should fall back to focus-window, got: %s", script)
+	}
+	if !strings.Contains(script, "focus-window") {
+		t.Fatalf("Warp fallback should keep focus-window, got: %s", script)
+	}
+	if strings.Contains(script, "osascript") {
+		t.Errorf("Warp click should not use osascript, got: %s", script)
+	}
+}
+
+func TestBuildFocusScript_WarpURLWorksWithoutCWD(t *testing.T) {
+	clearWarpFocusEnv(t)
+	t.Setenv(warpfocus.FocusURLEnv, "warposs://session/"+warpTestSessionHex)
+	t.Setenv(iTerm2SessionIDEnv, "")
+
+	script := buildFocusScript("dev.warp.Warp-Stable", "")
+	if script != "open 'warposs://session/"+warpTestSessionHex+"'" {
+		t.Fatalf("Warp without cwd should only open the session URL, got: %s", script)
+	}
+	if strings.Contains(script, "focus-window") {
+		t.Errorf("Warp without cwd should not add focus-window, got: %s", script)
+	}
+}
+
+func TestBuildFocusScript_WarpUUIDFallback(t *testing.T) {
+	clearWarpFocusEnv(t)
+	t.Setenv(warpfocus.FocusURLEnv, "")
+	t.Setenv(warpfocus.SessionUUIDEnv, warpTestSessionHex)
+	t.Setenv(iTerm2SessionIDEnv, "")
+
+	script := buildFocusScript("dev.warp.Warp-Stable", "/tmp/proj")
+	if !strings.Contains(script, "open '"+warpTestFocusURL+"'") {
+		t.Fatalf("UUID-only Warp env should build warp://session URL, got: %s", script)
+	}
+}
+
+func TestBuildFocusScript_WarpIgnoresConversationURL(t *testing.T) {
+	clearWarpFocusEnv(t)
+	t.Setenv(warpfocus.FocusURLEnv, "warp://conversation/"+warpTestSessionHex)
+	t.Setenv(iTerm2SessionIDEnv, "")
+
+	script := buildFocusScript("dev.warp.Warp-Stable", "/home/user/my-project")
+	if strings.Contains(script, "open '") {
+		t.Fatalf("conversation URLs must not be used for click-to-focus, got: %s", script)
+	}
+	if !strings.Contains(script, "focus-window") {
+		t.Fatalf("invalid Warp URL should fall back to focus-window, got: %s", script)
+	}
+}
+
+func TestBuildTerminalNotifierArgs_WarpSessionURL(t *testing.T) {
+	clearWarpFocusEnv(t)
+	t.Setenv(warpfocus.FocusURLEnv, warpTestFocusURL)
+	t.Setenv(iTerm2SessionIDEnv, "")
+
+	args := buildTerminalNotifierArgs("Title", "Message", "dev.warp.Warp-Stable", "/home/user/my-project", true)
+	execVal := getArgValue(args, "-execute")
+	if !strings.Contains(execVal, "open '"+warpTestFocusURL+"'") {
+		t.Fatalf("-execute should open Warp session URL, got: %s", execVal)
+	}
+}
+
+func TestInjectWarpFocusURL_PrependsOpenToTmuxExecute(t *testing.T) {
+	clearWarpFocusEnv(t)
+	t.Setenv(warpfocus.FocusURLEnv, warpTestFocusURL)
+
+	args := []string{
+		"-title", "Title",
+		"-message", "Message",
+		"-activate", "dev.warp.Warp-Stable",
+		"-execute", "'/usr/bin/tmux' select-window -t '%42'",
+	}
+	got := injectWarpFocusURL(args)
+	execVal := getArgValue(got, "-execute")
+	if !strings.HasPrefix(execVal, "open '"+warpTestFocusURL+"' >/dev/null 2>&1; ") {
+		t.Fatalf("Warp URL should be opened before tmux select, got: %s", execVal)
+	}
+	if !strings.Contains(execVal, "select-window -t '%42'") {
+		t.Fatalf("tmux command should be preserved, got: %s", execVal)
+	}
+}
+
+func TestInjectWarpFocusURL_NoopWithoutWarp(t *testing.T) {
+	clearWarpFocusEnv(t)
+	args := []string{"-execute", "tmux select-pane"}
+	got := injectWarpFocusURL(args)
+	if getArgValue(got, "-execute") != "tmux select-pane" {
+		t.Fatalf("inject without Warp env should be a no-op, got: %v", got)
+	}
+}
+
+func TestWarpFocusExecute_IsValidShell(t *testing.T) {
+	clearWarpFocusEnv(t)
+	t.Setenv(warpfocus.FocusURLEnv, warpTestFocusURL)
+	t.Setenv(iTerm2SessionIDEnv, "")
+
+	script := buildFocusScript("dev.warp.Warp-Stable", "/home/user/my-project")
+	cmd := exec.Command("/bin/sh", "-n", "-c", script)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("Warp execute script is not valid shell: %v\n%s\nscript: %s", err, out, script)
+	}
+}
+
+func TestWarpFocusURL_LiveHostEnvIsSessionLink(t *testing.T) {
+	if hostWarpFocusURL == "" {
+		t.Skip("host process did not export WARP_FOCUS_URL")
+	}
+	got := warpfocus.Normalize(hostWarpFocusURL)
+	if got == "" {
+		t.Fatalf("host WARP_FOCUS_URL is not a session deep link: %q", hostWarpFocusURL)
+	}
+	t.Setenv(warpfocus.FocusURLEnv, hostWarpFocusURL)
+	script := buildFocusScript("dev.warp.Warp-Stable", "/tmp/proj")
+	if !strings.Contains(script, "open '"+got+"'") {
+		t.Fatalf("live Warp env should bake session URL into click handler, got: %s", script)
+	}
+}

--- a/internal/notifier/warp_focus_test.go
+++ b/internal/notifier/warp_focus_test.go
@@ -27,10 +27,20 @@ func clearWarpFocusEnv(t *testing.T) {
 	t.Helper()
 	t.Setenv(warpfocus.FocusURLEnv, "")
 	t.Setenv(warpfocus.SessionUUIDEnv, "")
+	t.Setenv("TMUX", "")
+}
+
+func setWarpHost(t *testing.T) {
+	t.Helper()
+	t.Setenv("__CFBundleIdentifier", "dev.warp.Warp-Stable")
+	t.Setenv("TERM_PROGRAM", "WarpTerminal")
+	t.Setenv("VSCODE_INJECTION", "")
+	t.Setenv("VSCODE_GIT_IPC_HANDLE", "")
 }
 
 func TestBuildFocusScript_WarpUsesSessionURL(t *testing.T) {
 	clearWarpFocusEnv(t)
+	setWarpHost(t)
 	t.Setenv(warpfocus.FocusURLEnv, warpTestFocusURL)
 	t.Setenv(iTerm2SessionIDEnv, "")
 
@@ -51,6 +61,7 @@ func TestBuildFocusScript_WarpUsesSessionURL(t *testing.T) {
 
 func TestBuildFocusScript_WarpURLWorksWithoutCWD(t *testing.T) {
 	clearWarpFocusEnv(t)
+	setWarpHost(t)
 	t.Setenv(warpfocus.FocusURLEnv, "warposs://session/"+warpTestSessionHex)
 	t.Setenv(iTerm2SessionIDEnv, "")
 
@@ -65,6 +76,7 @@ func TestBuildFocusScript_WarpURLWorksWithoutCWD(t *testing.T) {
 
 func TestBuildFocusScript_WarpUUIDFallback(t *testing.T) {
 	clearWarpFocusEnv(t)
+	setWarpHost(t)
 	t.Setenv(warpfocus.FocusURLEnv, "")
 	t.Setenv(warpfocus.SessionUUIDEnv, warpTestSessionHex)
 	t.Setenv(iTerm2SessionIDEnv, "")
@@ -77,6 +89,7 @@ func TestBuildFocusScript_WarpUUIDFallback(t *testing.T) {
 
 func TestBuildFocusScript_WarpIgnoresConversationURL(t *testing.T) {
 	clearWarpFocusEnv(t)
+	setWarpHost(t)
 	t.Setenv(warpfocus.FocusURLEnv, "warp://conversation/"+warpTestSessionHex)
 	t.Setenv(iTerm2SessionIDEnv, "")
 
@@ -91,6 +104,7 @@ func TestBuildFocusScript_WarpIgnoresConversationURL(t *testing.T) {
 
 func TestBuildTerminalNotifierArgs_WarpSessionURL(t *testing.T) {
 	clearWarpFocusEnv(t)
+	setWarpHost(t)
 	t.Setenv(warpfocus.FocusURLEnv, warpTestFocusURL)
 	t.Setenv(iTerm2SessionIDEnv, "")
 
@@ -103,6 +117,7 @@ func TestBuildTerminalNotifierArgs_WarpSessionURL(t *testing.T) {
 
 func TestInjectWarpFocusURL_PrependsOpenToTmuxExecute(t *testing.T) {
 	clearWarpFocusEnv(t)
+	setWarpHost(t)
 	t.Setenv(warpfocus.FocusURLEnv, warpTestFocusURL)
 
 	args := []string{
@@ -130,11 +145,29 @@ func TestInjectWarpFocusURL_NoopWithoutWarp(t *testing.T) {
 	}
 }
 
+func TestBuildFocusScript_IgnoresInheritedWarpURLForCursor(t *testing.T) {
+	clearWarpFocusEnv(t)
+	t.Setenv("__CFBundleIdentifier", "com.todesktop.230313mzl4w4u92")
+	t.Setenv("TERM_PROGRAM", "WarpTerminal")
+	t.Setenv("VSCODE_INJECTION", "1")
+	t.Setenv(warpfocus.FocusURLEnv, warpTestFocusURL)
+	t.Setenv(iTerm2SessionIDEnv, "")
+
+	script := buildFocusScript("com.todesktop.230313mzl4w4u92", "/home/user/proj")
+	if strings.Contains(script, "open '") {
+		t.Fatalf("Cursor launched from Warp must not open WARP_FOCUS_URL, got: %s", script)
+	}
+	if !strings.Contains(script, "focus-window") {
+		t.Fatalf("Cursor click should keep focus-window, got: %s", script)
+	}
+}
+
 func TestWarpFocusExecute_IsValidShell(t *testing.T) {
 	if _, err := exec.LookPath("sh"); err != nil {
 		t.Skip("sh is not available")
 	}
 	clearWarpFocusEnv(t)
+	setWarpHost(t)
 	t.Setenv(warpfocus.FocusURLEnv, warpTestFocusURL)
 	t.Setenv(iTerm2SessionIDEnv, "")
 
@@ -153,6 +186,7 @@ func TestWarpFocusURL_LiveHostEnvIsSessionLink(t *testing.T) {
 	if got == "" {
 		t.Fatalf("host WARP_FOCUS_URL is not a session deep link: %q", hostWarpFocusURL)
 	}
+	setWarpHost(t)
 	t.Setenv(warpfocus.FocusURLEnv, hostWarpFocusURL)
 	script := buildFocusScript("dev.warp.Warp-Stable", "/tmp/proj")
 	if !strings.Contains(script, "open '"+got+"'") {

--- a/internal/warpfocus/open.go
+++ b/internal/warpfocus/open.go
@@ -1,0 +1,11 @@
+package warpfocus
+
+// Open launches a validated Warp session focus URL with the platform handler
+// (open / xdg-open / rundll32). Callers must pass Normalize/FromEnv output.
+func Open(focusURL string) error {
+	url := Normalize(focusURL)
+	if url == "" {
+		return errInvalidFocusURL
+	}
+	return openURL(url)
+}

--- a/internal/warpfocus/open_darwin.go
+++ b/internal/warpfocus/open_darwin.go
@@ -1,0 +1,9 @@
+//go:build darwin
+
+package warpfocus
+
+import "os/exec"
+
+func openURL(focusURL string) error {
+	return exec.Command("open", focusURL).Run()
+}

--- a/internal/warpfocus/open_linux.go
+++ b/internal/warpfocus/open_linux.go
@@ -1,0 +1,18 @@
+//go:build linux
+
+package warpfocus
+
+import (
+	"fmt"
+	"os/exec"
+)
+
+func openURL(focusURL string) error {
+	if _, err := exec.LookPath("xdg-open"); err == nil {
+		return exec.Command("xdg-open", focusURL).Run()
+	}
+	if _, err := exec.LookPath("gio"); err == nil {
+		return exec.Command("gio", "open", focusURL).Run()
+	}
+	return fmt.Errorf("warpfocus: xdg-open/gio not found")
+}

--- a/internal/warpfocus/open_other.go
+++ b/internal/warpfocus/open_other.go
@@ -1,0 +1,9 @@
+//go:build !darwin && !linux && !windows
+
+package warpfocus
+
+import "fmt"
+
+func openURL(focusURL string) error {
+	return fmt.Errorf("warpfocus: opening %s is not supported on this platform", focusURL)
+}

--- a/internal/warpfocus/open_windows.go
+++ b/internal/warpfocus/open_windows.go
@@ -1,0 +1,9 @@
+//go:build windows
+
+package warpfocus
+
+import "os/exec"
+
+func openURL(focusURL string) error {
+	return exec.Command("rundll32", "url.dll,FileProtocolHandler", focusURL).Run()
+}

--- a/internal/warpfocus/warpfocus.go
+++ b/internal/warpfocus/warpfocus.go
@@ -30,8 +30,13 @@ var allowedSchemes = map[string]bool{
 // FromEnv returns a validated Warp session focus URL from the current process
 // environment. Prefers WARP_FOCUS_URL (channel-aware). Falls back to
 // WARP_TERMINAL_SESSION_UUID as warp://session/<hex>, then to tmux's copy of
-// those variables when the process is inside tmux.
+// those variables when the process is inside tmux. Empty when this process is
+// not a Warp host (for example Cursor or VS Code launched from a Warp pane,
+// which inherit Warp's environment).
 func FromEnv() string {
+	if !IsWarpHost() {
+		return ""
+	}
 	if url := Normalize(os.Getenv(FocusURLEnv)); url != "" {
 		return url
 	}
@@ -45,6 +50,44 @@ func FromEnv() string {
 		return url
 	}
 	return FromSessionUUID(tmuxEnvironment(SessionUUIDEnv))
+}
+
+// IsWarpHost reports whether this process is running in a Warp terminal
+// session, as opposed to an app that merely inherited Warp's environment
+// (Cursor, VS Code, Ghostty launched from a Warp pane).
+func IsWarpHost() bool {
+	if isEditorHost() {
+		return false
+	}
+	if bundleID := strings.TrimSpace(os.Getenv("__CFBundleIdentifier")); bundleID != "" {
+		return strings.HasPrefix(bundleID, "dev.warp.Warp")
+	}
+	switch os.Getenv("TERM_PROGRAM") {
+	case "WarpTerminal":
+		return true
+	case "tmux", "zellij":
+		return os.Getenv("TMUX") != "" || os.Getenv("ZELLIJ") != ""
+	case "":
+		if os.Getenv("TMUX") != "" || os.Getenv("ZELLIJ") != "" {
+			return true
+		}
+		return os.Getenv(FocusURLEnv) != "" || os.Getenv(SessionUUIDEnv) != "" || os.Getenv("WARP_IS_LOCAL_SHELL_SESSION") != ""
+	default:
+		return false
+	}
+}
+
+func isEditorHost() bool {
+	if os.Getenv("VSCODE_INJECTION") != "" || os.Getenv("VSCODE_GIT_IPC_HANDLE") != "" {
+		return true
+	}
+	if os.Getenv("TERM_PROGRAM") == "vscode" {
+		return true
+	}
+	bundleID := os.Getenv("__CFBundleIdentifier")
+	return strings.HasPrefix(bundleID, "com.todesktop.") ||
+		strings.HasPrefix(bundleID, "com.microsoft.VSCode") ||
+		strings.HasPrefix(bundleID, "com.visualstudio.code")
 }
 
 // FromSessionUUID builds warp://session/<hex> from a 32-char hex UUID or a

--- a/internal/warpfocus/warpfocus.go
+++ b/internal/warpfocus/warpfocus.go
@@ -1,0 +1,153 @@
+// ABOUTME: Warp session deep-link capture for click-to-focus.
+// ABOUTME: Validates WARP_FOCUS_URL / WARP_TERMINAL_SESSION_UUID and rejects unrelated Warp URIs.
+package warpfocus
+
+import (
+	"errors"
+	"net/url"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+var errInvalidFocusURL = errors.New("warpfocus: not a Warp session focus URL")
+
+const (
+	// FocusURLEnv is the channel-aware deep link Warp injects into each pane.
+	FocusURLEnv = "WARP_FOCUS_URL"
+	// SessionUUIDEnv is the 32-char hex UUID of the originating Warp pane.
+	SessionUUIDEnv = "WARP_TERMINAL_SESSION_UUID"
+)
+
+const stableSessionScheme = "warp"
+
+var allowedSchemes = map[string]bool{
+	"warp":        true,
+	"warppreview": true,
+	"warposs":     true,
+}
+
+// FromEnv returns a validated Warp session focus URL from the current process
+// environment. Prefers WARP_FOCUS_URL (channel-aware). Falls back to
+// WARP_TERMINAL_SESSION_UUID as warp://session/<hex>, then to tmux's copy of
+// those variables when the process is inside tmux.
+func FromEnv() string {
+	if url := Normalize(os.Getenv(FocusURLEnv)); url != "" {
+		return url
+	}
+	if url := FromSessionUUID(os.Getenv(SessionUUIDEnv)); url != "" {
+		return url
+	}
+	if os.Getenv("TMUX") == "" {
+		return ""
+	}
+	if url := Normalize(tmuxEnvironment(FocusURLEnv)); url != "" {
+		return url
+	}
+	return FromSessionUUID(tmuxEnvironment(SessionUUIDEnv))
+}
+
+// FromSessionUUID builds warp://session/<hex> from a 32-char hex UUID or a
+// dashed UUID. Preview/OSS channels cannot be inferred from the UUID alone.
+func FromSessionUUID(raw string) string {
+	hexID := normalizeSessionID(raw)
+	if hexID == "" {
+		return ""
+	}
+	return stableSessionScheme + "://session/" + hexID
+}
+
+// Normalize accepts an opaque Warp focus URL and returns a canonical
+// scheme://session/<32-hex> form, or "" if the value is not a session deep link.
+// Action, conversation, settings, and launch URIs are rejected.
+func Normalize(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	u, err := url.Parse(raw)
+	if err != nil || u == nil {
+		return ""
+	}
+	scheme := strings.ToLower(u.Scheme)
+	if !allowedSchemes[scheme] {
+		return ""
+	}
+	if u.User != nil || u.Opaque != "" {
+		return ""
+	}
+	if strings.ToLower(u.Host) != "session" {
+		return ""
+	}
+	path := strings.Trim(u.Path, "/")
+	if path == "" || strings.Contains(path, "/") {
+		return ""
+	}
+	hexID := normalizeSessionID(path)
+	if hexID == "" {
+		return ""
+	}
+	return scheme + "://session/" + hexID
+}
+
+func normalizeSessionID(raw string) string {
+	raw = strings.TrimSpace(strings.ToLower(raw))
+	if raw == "" {
+		return ""
+	}
+	var b strings.Builder
+	b.Grow(len(raw))
+	for _, r := range raw {
+		if r == '-' {
+			continue
+		}
+		if r < '0' || r > 'f' || (r > '9' && r < 'a') {
+			return ""
+		}
+		b.WriteRune(r)
+	}
+	id := b.String()
+	if len(id) != 32 {
+		return ""
+	}
+	return id
+}
+
+func tmuxEnvironment(name string) string {
+	tmuxPath := "tmux"
+	if path, err := exec.LookPath("tmux"); err == nil {
+		tmuxPath = path
+	}
+	socket := tmuxSocketPath()
+	for _, extra := range [][]string{{}, {"-g"}} {
+		args := []string{}
+		if socket != "" {
+			args = append(args, "-S", socket)
+		}
+		args = append(args, "show-environment")
+		args = append(args, extra...)
+		args = append(args, name)
+		cmd := exec.Command(tmuxPath, args...)
+		output, err := cmd.Output()
+		if err != nil {
+			continue
+		}
+		line := strings.TrimSpace(string(output))
+		prefix := name + "="
+		if strings.HasPrefix(line, prefix) {
+			return strings.TrimSpace(line[len(prefix):])
+		}
+	}
+	return ""
+}
+
+func tmuxSocketPath() string {
+	tmuxEnv := os.Getenv("TMUX")
+	if tmuxEnv == "" {
+		return ""
+	}
+	if idx := strings.IndexByte(tmuxEnv, ','); idx > 0 {
+		return tmuxEnv[:idx]
+	}
+	return tmuxEnv
+}

--- a/internal/warpfocus/warpfocus_test.go
+++ b/internal/warpfocus/warpfocus_test.go
@@ -1,0 +1,97 @@
+package warpfocus
+
+import (
+	"strings"
+	"testing"
+)
+
+const validHex = "6b7be92641ae8ced80188a4d87e4b200"
+
+func TestNormalize_SessionURLs(t *testing.T) {
+	tests := []struct {
+		in, want string
+	}{
+		{"warp://session/" + validHex, "warp://session/" + validHex},
+		{"WARP://SESSION/" + strings.ToUpper(validHex), "warp://session/" + validHex},
+		{"warppreview://session/" + validHex, "warppreview://session/" + validHex},
+		{"warposs://session/" + validHex, "warposs://session/" + validHex},
+		{"  warp://session/" + validHex + " \n", "warp://session/" + validHex},
+		{"warp://session/6b7be926-41ae-8ced-8018-8a4d87e4b200", "warp://session/" + validHex},
+	}
+	for _, tt := range tests {
+		if got := Normalize(tt.in); got != tt.want {
+			t.Errorf("Normalize(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestNormalize_RejectsNonSessionURLs(t *testing.T) {
+	rejected := []string{
+		"",
+		"https://example.com",
+		"javascript:alert(1)",
+		"file:///etc/passwd",
+		"warp://action/new_tab",
+		"warp://action/new_window?path=/tmp",
+		"warp://conversation/" + validHex,
+		"warp://settings",
+		"warp://launch/foo",
+		"warp://session/",
+		"warp://session/not-hex",
+		"warp://session/abc",
+		"warp://session/" + validHex + "/extra",
+		"warp://session/" + validHex + "@evil",
+		"http://session/" + validHex,
+	}
+	for _, in := range rejected {
+		if got := Normalize(in); got != "" {
+			t.Errorf("Normalize(%q) = %q, want empty", in, got)
+		}
+	}
+}
+
+func TestFromSessionUUID(t *testing.T) {
+	if got := FromSessionUUID(validHex); got != "warp://session/"+validHex {
+		t.Errorf("FromSessionUUID(hex) = %q", got)
+	}
+	dashed := "6b7be926-41ae-8ced-8018-8a4d87e4b200"
+	if got := FromSessionUUID(dashed); got != "warp://session/"+validHex {
+		t.Errorf("FromSessionUUID(dashed) = %q", got)
+	}
+	if got := FromSessionUUID("nope"); got != "" {
+		t.Errorf("FromSessionUUID(invalid) = %q, want empty", got)
+	}
+}
+
+func TestFromEnv_PrefersFocusURL(t *testing.T) {
+	t.Setenv(FocusURLEnv, "warposs://session/"+validHex)
+	t.Setenv(SessionUUIDEnv, "ffffffffffffffffffffffffffffffff")
+	t.Setenv("TMUX", "")
+	if got := FromEnv(); got != "warposs://session/"+validHex {
+		t.Errorf("FromEnv() = %q, want channel-aware focus URL", got)
+	}
+}
+
+func TestFromEnv_UUIDFallback(t *testing.T) {
+	t.Setenv(FocusURLEnv, "")
+	t.Setenv(SessionUUIDEnv, validHex)
+	t.Setenv("TMUX", "")
+	if got := FromEnv(); got != "warp://session/"+validHex {
+		t.Errorf("FromEnv() = %q, want UUID-derived stable URL", got)
+	}
+}
+
+func TestFromEnv_Empty(t *testing.T) {
+	t.Setenv(FocusURLEnv, "")
+	t.Setenv(SessionUUIDEnv, "")
+	t.Setenv("TMUX", "")
+	if got := FromEnv(); got != "" {
+		t.Errorf("FromEnv() = %q, want empty", got)
+	}
+}
+
+func TestOpen_RejectsInvalid(t *testing.T) {
+	if err := Open("warp://action/new_tab"); err == nil {
+		t.Fatal("Open should reject non-session URLs")
+	}
+}

--- a/internal/warpfocus/warpfocus_test.go
+++ b/internal/warpfocus/warpfocus_test.go
@@ -63,7 +63,16 @@ func TestFromSessionUUID(t *testing.T) {
 	}
 }
 
+func setWarpHost(t *testing.T) {
+	t.Helper()
+	t.Setenv("__CFBundleIdentifier", "dev.warp.Warp-Stable")
+	t.Setenv("TERM_PROGRAM", "WarpTerminal")
+	t.Setenv("VSCODE_INJECTION", "")
+	t.Setenv("VSCODE_GIT_IPC_HANDLE", "")
+}
+
 func TestFromEnv_PrefersFocusURL(t *testing.T) {
+	setWarpHost(t)
 	t.Setenv(FocusURLEnv, "warposs://session/"+validHex)
 	t.Setenv(SessionUUIDEnv, "ffffffffffffffffffffffffffffffff")
 	t.Setenv("TMUX", "")
@@ -73,6 +82,7 @@ func TestFromEnv_PrefersFocusURL(t *testing.T) {
 }
 
 func TestFromEnv_UUIDFallback(t *testing.T) {
+	setWarpHost(t)
 	t.Setenv(FocusURLEnv, "")
 	t.Setenv(SessionUUIDEnv, validHex)
 	t.Setenv("TMUX", "")
@@ -82,11 +92,57 @@ func TestFromEnv_UUIDFallback(t *testing.T) {
 }
 
 func TestFromEnv_Empty(t *testing.T) {
+	setWarpHost(t)
 	t.Setenv(FocusURLEnv, "")
 	t.Setenv(SessionUUIDEnv, "")
 	t.Setenv("TMUX", "")
 	if got := FromEnv(); got != "" {
 		t.Errorf("FromEnv() = %q, want empty", got)
+	}
+}
+
+func TestFromEnv_IgnoresInheritedURLOutsideWarp(t *testing.T) {
+	t.Setenv("__CFBundleIdentifier", "com.todesktop.230313mzl4w4u92")
+	t.Setenv("TERM_PROGRAM", "WarpTerminal")
+	t.Setenv("VSCODE_INJECTION", "1")
+	t.Setenv(FocusURLEnv, "warp://session/"+validHex)
+	t.Setenv(SessionUUIDEnv, validHex)
+	t.Setenv("TMUX", "")
+	if got := FromEnv(); got != "" {
+		t.Errorf("FromEnv() = %q, want empty when Cursor inherited Warp env", got)
+	}
+}
+
+func TestFromEnv_TmuxInsideWarp(t *testing.T) {
+	t.Setenv("__CFBundleIdentifier", "dev.warp.Warp-Stable")
+	t.Setenv("TERM_PROGRAM", "tmux")
+	t.Setenv("TMUX", "/tmp/tmux-1000/default,123,0")
+	t.Setenv(FocusURLEnv, "warp://session/"+validHex)
+	t.Setenv(SessionUUIDEnv, "")
+	if got := FromEnv(); got != "warp://session/"+validHex {
+		t.Errorf("FromEnv() inside Warp tmux = %q, want session URL", got)
+	}
+}
+
+func TestFromEnv_LinuxWarpWithoutBundle(t *testing.T) {
+	t.Setenv("__CFBundleIdentifier", "")
+	t.Setenv("TERM_PROGRAM", "WarpTerminal")
+	t.Setenv("VSCODE_INJECTION", "")
+	t.Setenv("VSCODE_GIT_IPC_HANDLE", "")
+	t.Setenv("TMUX", "")
+	t.Setenv(FocusURLEnv, "warp://session/"+validHex)
+	t.Setenv(SessionUUIDEnv, "")
+	if got := FromEnv(); got != "warp://session/"+validHex {
+		t.Errorf("FromEnv() on Linux Warp = %q, want session URL", got)
+	}
+}
+
+func TestIsWarpHost_CursorBundle(t *testing.T) {
+	t.Setenv("__CFBundleIdentifier", "com.todesktop.230313mzl4w4u92")
+	t.Setenv("TERM_PROGRAM", "WarpTerminal")
+	t.Setenv("VSCODE_INJECTION", "")
+	if IsWarpHost() {
+		t.Fatal("Cursor launched from Warp is not a Warp host")
 	}
 }
 

--- a/internal/winfocus/winfocus.go
+++ b/internal/winfocus/winfocus.go
@@ -18,15 +18,16 @@ const ProtocolScheme = "claude-notify-focus"
 // activation argument at notify time and decoded when the user clicks the toast.
 // JSON keys are kept short because the whole struct rides inside a URI.
 type FocusContext struct {
-	HWND   int64  `json:"h,omitempty"` // top-level window handle captured at notify time
-	PID    uint32 `json:"p,omitempty"` // owning process id (validates HWND against handle reuse)
-	Title  string `json:"t,omitempty"` // window title at notify time (fallback match)
-	Folder string `json:"f,omitempty"` // project folder name (fallback match)
+	HWND    int64  `json:"h,omitempty"` // top-level window handle captured at notify time
+	PID     uint32 `json:"p,omitempty"` // owning process id (validates HWND against handle reuse)
+	Title   string `json:"t,omitempty"` // window title at notify time (fallback match)
+	Folder  string `json:"f,omitempty"` // project folder name (fallback match)
+	WarpURL string `json:"u,omitempty"` // Warp session deep link ($WARP_FOCUS_URL)
 }
 
 // HasTarget reports whether the context carries any usable focus hint.
 func (c FocusContext) HasTarget() bool {
-	return c.HWND != 0 || c.PID != 0 || c.Title != "" || c.Folder != ""
+	return c.HWND != 0 || c.PID != 0 || c.Title != "" || c.Folder != "" || c.WarpURL != ""
 }
 
 // EncodeURI renders the context as "claude-notify-focus:<base64url-json>".

--- a/internal/winfocus/winfocus_test.go
+++ b/internal/winfocus/winfocus_test.go
@@ -9,6 +9,7 @@ func TestEncodeDecodeURIRoundTrip(t *testing.T) {
 	cases := []FocusContext{
 		{HWND: 123456, PID: 4242, Title: "✳ Claude Code", Folder: "my-project"},
 		{HWND: 0, PID: 0, Title: "", Folder: "only-folder"},
+		{WarpURL: "warp://session/6b7be92641ae8ced80188a4d87e4b200"},
 		{Title: "spaces and / slashes & ampersands"},
 		{HWND: 9007199254740991}, // large handle value
 		{},
@@ -75,7 +76,7 @@ func TestHasTarget(t *testing.T) {
 	if (FocusContext{}).HasTarget() {
 		t.Error("zero context should not have a target")
 	}
-	for _, c := range []FocusContext{{HWND: 1}, {PID: 1}, {Title: "x"}, {Folder: "x"}} {
+	for _, c := range []FocusContext{{HWND: 1}, {PID: 1}, {Title: "x"}, {Folder: "x"}, {WarpURL: "warp://session/6b7be92641ae8ced80188a4d87e4b200"}} {
 		if !c.HasTarget() {
 			t.Errorf("%+v should have a target", c)
 		}

--- a/internal/winfocus/winfocus_windows.go
+++ b/internal/winfocus/winfocus_windows.go
@@ -10,6 +10,7 @@ import (
 	"syscall"
 	"unsafe"
 
+	"github.com/777genius/agent-notifications/internal/warpfocus"
 	"golang.org/x/sys/windows"
 	"golang.org/x/sys/windows/registry"
 )
@@ -189,26 +190,30 @@ func CaptureFocusContext(cwd string) (FocusContext, bool) {
 	// that shared PID owns windows for other projects too.
 	fg, _, _ := procGetForegroundWindow.Call()
 
+	ctx := FocusContext{
+		Folder:  folder,
+		WarpURL: warpfocus.FromEnv(),
+	}
+
 	pid := windows.GetCurrentProcessId()
 	seen := map[uint32]bool{}
 	for i := 0; i < 32 && pid != 0 && !seen[pid]; i++ {
 		seen[pid] = true
 
 		if hwnd := windowForPID(list, pid, folder, fg); hwnd != 0 {
-			return FocusContext{
-				HWND:   int64(hwnd),
-				PID:    pid,
-				Title:  windowText(hwnd),
-				Folder: folder,
-			}, true
+			ctx.HWND = int64(hwnd)
+			ctx.PID = pid
+			ctx.Title = windowText(hwnd)
+			return ctx, true
 		}
 		pid = parents[pid]
 	}
 
 	// No ancestor owns a window (fully detached hook). Still hand back a
 	// folder-only context so the click handler can attempt a title match.
-	if folder != "" {
-		return FocusContext{Folder: folder}, true
+	// A Warp session URL is enough on its own to focus the originating pane.
+	if ctx.HasTarget() {
+		return ctx, true
 	}
 	return FocusContext{}, false
 }
@@ -249,6 +254,11 @@ func HideConsole() {
 
 // Focus raises the terminal window described by ctx to the foreground.
 func Focus(ctx FocusContext) error {
+	if url := warpfocus.Normalize(ctx.WarpURL); url != "" {
+		if err := warpfocus.Open(url); err == nil {
+			return nil
+		}
+	}
 	hwnd := resolveWindow(ctx)
 	if hwnd == 0 {
 		return fmt.Errorf("winfocus: no matching window for %+v", ctx)

--- a/scripts/warp-focus-check.sh
+++ b/scripts/warp-focus-check.sh
@@ -25,7 +25,38 @@ EOF
 focus_url="${WARP_FOCUS_URL:-}"
 uuid="${WARP_TERMINAL_SESSION_UUID:-}"
 
+open_focus_url() {
+	case "$(uname -s)" in
+	Darwin)
+		open "$1"
+		;;
+	Linux)
+		if ! command -v xdg-open >/dev/null 2>&1; then
+			echo "xdg-open not found. Install xdg-utils, or open this URL yourself: $1" >&2
+			exit 1
+		fi
+		xdg-open "$1"
+		;;
+	*)
+		echo "open is supported on macOS and Linux. URL: $1" >&2
+		exit 1
+		;;
+	esac
+}
+
 require_warp() {
+	case "${__CFBundleIdentifier:-}" in
+	com.todesktop.* | com.microsoft.VSCode* | com.visualstudio.code*)
+		echo "This looks like Cursor/VS Code that inherited Warp's environment." >&2
+		echo "Run this script inside a Warp pane, not from an editor launched from Warp." >&2
+		exit 1
+		;;
+	esac
+	if [[ "${TERM_PROGRAM:-}" == "vscode" || -n "${VSCODE_INJECTION:-}" ]]; then
+		echo "This looks like VS Code/Cursor that inherited Warp's environment." >&2
+		echo "Run this script inside a Warp pane, not from an editor launched from Warp." >&2
+		exit 1
+	fi
 	if [[ -z "$focus_url" ]]; then
 		echo "WARP_FOCUS_URL is empty. This shell is not a Warp pane (or Warp is older than v0.2026.05.27)." >&2
 		echo "TERM_PROGRAM=${TERM_PROGRAM:-}  __CFBundleIdentifier=${__CFBundleIdentifier:-}" >&2
@@ -57,10 +88,14 @@ env | "")
 open)
 	require_warp
 	echo "Opening $focus_url"
-	open "$focus_url"
+	open_focus_url "$focus_url"
 	;;
 notify)
 	require_warp
+	if [[ "$(uname -s)" != Darwin ]]; then
+		echo "notify sends a macOS clickable banner. On this OS use: $0 open" >&2
+		exit 1
+	fi
 	execute_cmd="open '$focus_url'"
 	echo "Sending notification."
 	echo "Click action: $execute_cmd"
@@ -86,9 +121,10 @@ notify)
 	fi
 
 	echo "No terminal-notifier / ClaudeNotifier.app found." >&2
-	echo "Falling back to Warp URL only (no banner). This still proves session focus:" >&2
-	open "$focus_url"
-	echo "If this pane just came to the front, Warp's deep link works. For a clickable banner, brew install terminal-notifier and rerun: $0 notify" >&2
+	echo "notify needs a macOS notifier binary; not opening the Warp URL as a silent fallback." >&2
+	echo "Install terminal-notifier (brew install terminal-notifier) and rerun: $0 notify" >&2
+	echo "To prove the session URL without a banner: $0 open" >&2
+	exit 1
 	;;
 -h | --help | help)
 	usage

--- a/scripts/warp-focus-check.sh
+++ b/scripts/warp-focus-check.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# ABOUTME: Manual Warp click-to-focus check. Run this inside a Warp pane.
+# ABOUTME: `open` proves Warp's session URL; `notify` sends a clickable banner.
+
+set -euo pipefail
+
+usage() {
+	cat <<'EOF'
+Usage: scripts/warp-focus-check.sh <env|open|notify>
+
+Run these from Warp, not from Cursor/iTerm.
+
+  env     Print WARP_FOCUS_URL / session UUID
+  open    Focus THIS Warp pane via the session URL
+  notify  Send a desktop notification whose click opens THIS pane
+
+Two-tab check:
+  1. In tab A:  scripts/warp-focus-check.sh notify
+  2. Switch to tab B (or another Warp window)
+  3. Click the notification
+  4. Tab A (and its agent chat) should come to the front
+EOF
+}
+
+focus_url="${WARP_FOCUS_URL:-}"
+uuid="${WARP_TERMINAL_SESSION_UUID:-}"
+
+require_warp() {
+	if [[ -z "$focus_url" ]]; then
+		echo "WARP_FOCUS_URL is empty. This shell is not a Warp pane (or Warp is older than v0.2026.05.27)." >&2
+		echo "TERM_PROGRAM=${TERM_PROGRAM:-}  __CFBundleIdentifier=${__CFBundleIdentifier:-}" >&2
+		exit 1
+	fi
+	case "$focus_url" in
+	warp://session/* | warppreview://session/* | warposs://session/*) ;;
+	*)
+		echo "WARP_FOCUS_URL is not a session deep link: $focus_url" >&2
+		echo "Action/conversation/settings URLs cannot focus an existing pane." >&2
+		exit 1
+		;;
+	esac
+}
+
+cmd="${1:-}"
+case "$cmd" in
+env | "")
+	require_warp
+	echo "TERM_PROGRAM=${TERM_PROGRAM:-}"
+	echo "__CFBundleIdentifier=${__CFBundleIdentifier:-}"
+	echo "WARP_TERMINAL_SESSION_UUID=${uuid:-}"
+	echo "WARP_FOCUS_URL=$focus_url"
+	if [[ "${1:-}" == "" ]]; then
+		echo
+		usage
+	fi
+	;;
+open)
+	require_warp
+	echo "Opening $focus_url"
+	open "$focus_url"
+	;;
+notify)
+	require_warp
+	execute_cmd="open '$focus_url'"
+	echo "Sending notification."
+	echo "Click action: $execute_cmd"
+	echo "Switch to another Warp tab/window, then click the banner."
+
+	if command -v terminal-notifier >/dev/null 2>&1; then
+		terminal-notifier \
+			-title "Warp focus check" \
+			-message "Click to return to this Warp pane/chat" \
+			-execute "$execute_cmd"
+		exit 0
+	fi
+
+	plugin_root="$(cd "$(dirname "$0")/.." && pwd)"
+	notifier_bin="$plugin_root/bin/ClaudeNotifier.app/Contents/MacOS/terminal-notifier-modern"
+	if [[ -x "$notifier_bin" ]]; then
+		"$notifier_bin" \
+			-title "Warp focus check" \
+			-message "Click to return to this Warp pane/chat" \
+			-execute "$execute_cmd" \
+			-nosound
+		exit 0
+	fi
+
+	echo "No terminal-notifier / ClaudeNotifier.app found." >&2
+	echo "Falling back to Warp URL only (no banner). This still proves session focus:" >&2
+	open "$focus_url"
+	echo "If this pane just came to the front, Warp's deep link works. For a clickable banner, brew install terminal-notifier and rerun: $0 notify" >&2
+	;;
+-h | --help | help)
+	usage
+	;;
+*)
+	usage >&2
+	exit 2
+	;;
+esac


### PR DESCRIPTION
## Summary
- Notification clicks from Warp open `WARP_FOCUS_URL` (`warp://session/<uuid>`) so the originating window, tab, and pane/chat come to the front.
- Falls back to the existing AXTitle `focus-window` path when Warp is older or the URL is missing; Linux uses `xdg-open`, Windows opens the URL from the toast handler.
- Warp+tmux/zellij opens the Warp session first, then selects the inner multiplexer target.

## Test plan
- [x] `go test ./internal/warpfocus ./internal/notifier ./internal/winfocus`
- [x] Linux daemon / Windows winfocus packages cross-compile
- [x] Live `WARP_FOCUS_URL` from Warp normalizes and is baked into the click handler
- [x] Manual: `open "$WARP_FOCUS_URL"` from another Warp tab focused the originating pane
- [ ] Optional: `scripts/warp-focus-check.sh notify` from a Warp pane, switch tabs, click the banner


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added click-to-focus support for Warp, bringing the originating window, tab, pane, and agent chat forward when a notification is selected.
  * Supports Warp on macOS, Linux, and Windows, including sessions inside tmux or zellij.
  * Uses Warp session links for precise focusing, with fallback behavior when links are unavailable.

* **Bug Fixes**
  * Prevented notifications from moving focus back to Warp when triggered from Cursor or VS Code.

* **Documentation**
  * Updated platform support, focus behavior, permissions, multiplexer guidance, and manual validation instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->