### PR TITLE
chore(release): v1.43.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,14 +7,14 @@
     },
     "metadata": {
         "description": "Agent Notifications marketplace for coding agents (Go implementation)",
-        "version": "1.42.0"
+        "version": "1.43.0"
     },
     "plugins": [{
         "name": "claude-notifications-go",
         "displayName": "Agent Notifications",
         "source": "./",
         "description": "Agent Notifications for Claude Code and Codex CLI (Go implementation)",
-        "version": "1.42.0",
+        "version": "1.43.0",
         "author": {
             "name": "777genius",
             "email": "iliyazelenkog@gmail.com"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
     "name": "claude-notifications-go",
     "displayName": "Agent Notifications",
-    "version": "1.42.0",
+    "version": "1.43.0",
     "description": "Agent Notifications for Claude Code and Codex CLI (Go implementation)",
     "author": {
         "name": "777genius",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
     "name": "claude-notifications-go",
-    "version": "1.42.0",
+    "version": "1.43.0",
     "hooks": "./hooks/hooks-codex.json"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.43.0] - 2026-09-11
+
 ### Added
-- **Warp: exact pane/chat click-to-focus** — notification clicks open Warp's session deep link (`WARP_FOCUS_URL` / `warp://session/<uuid>`) so the originating window, tab, and pane (including the agent chat in that pane) come to the front. Falls back to the previous AXTitle `focus-window` path when the URL is absent or Warp cannot resolve it. Also works on Linux (`xdg-open`) and Windows (toast protocol), and composes with tmux/zellij inside Warp.
+- **Warp: exact pane/chat click-to-focus** — notification clicks open Warp's session deep link (`WARP_FOCUS_URL` / `warp://session/<uuid>`) so the originating window, tab, and pane (including the agent chat in that pane) come to the front. Falls back to the previous AXTitle `focus-window` path when the URL is absent or Warp cannot resolve it. Also works on Linux (`xdg-open`) and Windows (toast protocol), and composes with tmux/zellij inside Warp ([#175](https://github.com/777genius/agent-notifications/pull/175)).
+- **Webhook agent identity** — custom JSON payloads include `schema_version`, `notification_type`, and `agent_source` (`claude`/`codex`); Slack, Discord, Telegram, and Lark show the agent name; custom templates can use `${{agent_source}}` ([#170](https://github.com/777genius/agent-notifications/pull/170)).
+- **Landing: flag images in the language switcher** ([#173](https://github.com/777genius/agent-notifications/pull/173)).
+
+### Changed
+- Document the frozen `claude-notifications-go` Claude Code plugin identity ([#166](https://github.com/777genius/agent-notifications/pull/166)).
+- Add Uninstall instructions to the README ([#167](https://github.com/777genius/agent-notifications/pull/167)).
 
 ### Fixed
-- Ignore inherited `WARP_FOCUS_URL` in Cursor/VS Code launched from Warp so notification clicks stay on the editor instead of stealing focus back to Warp.
+- Ignore inherited `WARP_FOCUS_URL` in Cursor/VS Code launched from Warp so notification clicks stay on the editor instead of stealing focus back to Warp ([#175](https://github.com/777genius/agent-notifications/pull/175)).
+- Drop the garbage `[unknown .]` prefix when a notification has no usable session name or folder ([#172](https://github.com/777genius/agent-notifications/pull/172)).
+- Self-heal a marketplace still declared under the retired GitHub repo name so bootstrap and updates work after the rename to `agent-notifications` ([#174](https://github.com/777genius/agent-notifications/pull/174)).
+- Clarify the bootstrap version gate and silence the shared-config baseline traceback ([#171](https://github.com/777genius/agent-notifications/pull/171)).
+- Prefix landing flag image paths with the app base URL so they load on GitHub Pages ([#173](https://github.com/777genius/agent-notifications/pull/173)).
 
 ## [1.42.0] - 2026-09-11
 

--- a/internal/config/runtime.go
+++ b/internal/config/runtime.go
@@ -9,7 +9,7 @@ import (
 
 // ConsumerVersion identifies the template compiled into this binary. The CLI
 // reports this same build value; a bundle with another version has no baseline.
-var ConsumerVersion = "1.42.0"
+var ConsumerVersion = "1.43.0"
 
 // ConsumerContext keeps resource discovery separate from canonical selection.
 // A bundle is historical evidence, never a runtime fallback. Without verified


### PR DESCRIPTION
## Summary
- Bump plugin/binary version to **1.43.0** (assets will be published from this SHA before `main` is fast-forwarded).
- Changelog for Warp pane click-to-focus, webhook agent identity, marketplace self-heal, and related fixes since v1.42.0.

## Test plan
- [x] Version sources agree (`ConsumerVersion` + four manifest fields)
- [x] `make lint` / `make test-race` locally
- [ ] Ubuntu / macOS / Windows CI green
- [ ] Draft `v1.43.0` tagged from this SHA after CI
- [ ] Downloaded draft canary: `version` + synthetic Claude/Codex Stop to a local recording sink


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated the plugin and marketplace version to 1.43.0.
  * Added changelog entries covering focus behavior, webhook identity, landing-page images, naming updates, messaging, notification prefixes, and image-path fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->