### PR TITLE
fix(install): align P2 test fixtures with kernel cleanup and managed-writer contracts

### DIFF
--- a/bin/install_e2e_test.sh
+++ b/bin/install_e2e_test.sh
@@ -994,6 +994,40 @@ if [ "$1" = "windows-hooks" ]; then
     printf '{\n  "hooks": {\n    "Stop": [\n      {\n        "hooks": [\n          {\n            "type": "command",\n            "command": "%s",\n            "args": ["handle-hook", "Stop"],\n            "timeout": 30\n          }\n        ]\n      }\n    ]\n  }\n}\n' "$exe"
     exit 0
 fi
+if [ "$1" = "internal-install-runtime" ]; then
+    shift
+    target=""
+    entry=""
+    while [ "$#" -gt 0 ]; do
+        if [ "$1" = "--stage" ]; then
+            shift
+        elif [ "$1" = "--target" ]; then
+            shift
+            target="$1"
+        elif [ "$1" = "--entry" ]; then
+            shift
+            entry="$1"
+        fi
+        shift
+    done
+    if [ -z "$target" ] || [ -z "$entry" ]; then
+        exit 1
+    fi
+    for launcher in claude-notifications agent-notifications; do
+        cat > "$target/${launcher}.bat" <<EOF
+@echo off
+REM ${launcher} Windows wrapper
+REM Automatically runs the platform-specific binary
+
+setlocal
+set SCRIPT_DIR=%~dp0
+set AGENT_NOTIFICATIONS_LAUNCHER=${launcher}
+"%SCRIPT_DIR%${entry}" %*
+EOF
+        [ -f "$target/${launcher}.bat" ] || exit 1
+    done
+    exit 0
+fi
 exit 0
 FAKE_EXE_EOF
     chmod +x "$bin_dir/claude-notifications-windows-amd64.exe"

--- a/cmd/claude-notifications/install_runtime_skill_test.go
+++ b/cmd/claude-notifications/install_runtime_skill_test.go
@@ -109,8 +109,11 @@ func TestEmbeddedSkillLifecycleProjection(t *testing.T) {
 		if e := f.run("--remove"); e != nil {
 			t.Fatal(e)
 		}
-		if !bytes.Equal(embeddedRead(t, f.skill), skills.AgentNotify()) {
-			t.Fatal("independent removal deleted shared skill")
+		// This branch runs before clientsetup adds a second consumer, so
+		// removing the only consumer must delete the owned canonical skill.
+		embeddedAbsent(t, f.skill)
+		if len(f.snapshot(t).Ledger.Consumers) != 0 {
+			t.Fatal("last consumer not released")
 		}
 		return
 	}

--- a/internal/agentnotify/mcp/lifecycle_test.go
+++ b/internal/agentnotify/mcp/lifecycle_test.go
@@ -10,6 +10,7 @@ import (
 	"runtime"
 	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/777genius/agent-notifications/internal/agentnotify"
@@ -145,34 +146,39 @@ func TestSDKSaturationCancellationFloodAndDrain(t *testing.T) {
 	}
 }
 func TestSDKOriginalDeadlineExpiredBeforeHandler(t *testing.T) {
-	var now atomic.Int64
-	now.Store(100)
-	var calls atomic.Int32
-	// Frame capture obtains 100, then injected continuous clock advances before
-	// middleware starts. A handler-created fresh budget would wrongly call backend.
-	clock := agentnotify.ClockFunc(func() notification.Deadline {
-		return notification.Deadline{BootID: "test", NotAfter: float64(now.Swap(200))}
+	synctest.Test(t, func(t *testing.T) {
+		var now atomic.Int64
+		now.Store(100)
+		var calls atomic.Int32
+		// Frame capture obtains 100, then injected continuous clock advances before
+		// middleware starts. A handler-created fresh budget would wrongly call backend.
+		clock := agentnotify.ClockFunc(func() notification.Deadline {
+			return notification.Deadline{BootID: "test", NotAfter: float64(now.Swap(200))}
+		})
+		f := rawFixture(t, backendFunc(func(context.Context, agentnotify.Payload, origin.Context, notification.Deadline) agentnotify.Receipt {
+			calls.Add(1)
+			return agentnotify.Receipt{Status: "submitted"}
+		}), clock, nil)
+		// Wait until initialize/initialized (and the deadline watcher) are blocked
+		// so this reset is sampled by tools/call, not by the handshake frame.
+		synctest.Wait()
+		now.Store(100)
+		f.send(t, callFrame(1))
+		r := f.receive(t)
+		var result struct {
+			IsError bool `json:"isError"`
+		}
+		json.Unmarshal(r["result"], &result)
+		if !result.IsError || calls.Load() != 0 {
+			t.Fatal("original deadline was reset")
+		}
+		f.cancel()
+		select {
+		case <-f.done:
+		case <-time.After(3 * time.Second):
+			t.Fatal("shutdown failed")
+		}
 	})
-	f := rawFixture(t, backendFunc(func(context.Context, agentnotify.Payload, origin.Context, notification.Deadline) agentnotify.Receipt {
-		calls.Add(1)
-		return agentnotify.Receipt{Status: "submitted"}
-	}), clock, nil)
-	now.Store(100)
-	f.send(t, callFrame(1))
-	r := f.receive(t)
-	var result struct {
-		IsError bool `json:"isError"`
-	}
-	json.Unmarshal(r["result"], &result)
-	if !result.IsError || calls.Load() != 0 {
-		t.Fatal("original deadline was reset")
-	}
-	f.cancel()
-	select {
-	case <-f.done:
-	case <-time.After(3 * time.Second):
-		t.Fatal("shutdown failed")
-	}
 }
 func TestSDKIdlePartialAndOutputClose(t *testing.T) {
 	for _, mode := range []string{"idle", "partial", "write"} {

--- a/internal/config/setup_prepare_test.go
+++ b/internal/config/setup_prepare_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -26,6 +27,24 @@ func putPrep(t *testing.T, p, s string) {
 	}
 	if e := os.WriteFile(p, []byte(s), 0640); e != nil {
 		t.Fatal(e)
+	}
+}
+
+// Windows Go reports writable regular files as 0666 (installruntime identityMode).
+func assertPreparedPerm(t *testing.T, info os.FileInfo, want os.FileMode) {
+	t.Helper()
+	if info == nil || !info.Mode().IsRegular() {
+		t.Fatal(info)
+	}
+	got := info.Mode().Perm()
+	if runtime.GOOS == "windows" {
+		if got != 0666 {
+			t.Fatal(info.Mode())
+		}
+		return
+	}
+	if got != want {
+		t.Fatal(info.Mode())
 	}
 }
 func TestPreparePrecedence(t *testing.T) {
@@ -56,9 +75,7 @@ func TestPreparePrecedence(t *testing.T) {
 			}
 			if source != "canonical" {
 				i, _ := os.Stat(c)
-				if i.Mode().Perm() != 0600 {
-					t.Fatal(i.Mode())
-				}
+				assertPreparedPerm(t, i, 0600)
 			}
 		})
 	}
@@ -76,9 +93,7 @@ func TestPreparePartial(t *testing.T) {
 		t.Fatal(string(b), e)
 	}
 	i, _ := os.Stat(c)
-	if i.Mode().Perm() != 0640 {
-		t.Fatal(i.Mode())
-	}
+	assertPreparedPerm(t, i, 0640)
 }
 func TestPrepareInvalidUnchanged(t *testing.T) {
 	for _, bad := range []string{`broken`, `null`, `{"notifications":null}`, `{"notifications":{"desktop":null}}`, `{"notifications":{"desktop":{"sound":null}}}`, `{"a":1,"a":2}`, `{"notifications":{"desktop":{"enabled":1}}}`, `{"x":"` + strings.Repeat("x", 65536) + `"}`, `{"x":` + strings.Repeat("[", 17) + `0` + strings.Repeat("]", 17) + `}`, `{"x":[` + strings.Repeat("0,", 1024) + `0]}`} {

--- a/internal/installruntime/setup_policy_test.go
+++ b/internal/installruntime/setup_policy_test.go
@@ -2,10 +2,14 @@ package installruntime
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
+	"syscall"
 	"testing"
+	"time"
 )
 
 func TestSetupPolicyAtomicFields(t *testing.T) {
@@ -177,11 +181,18 @@ func TestSetupSnapshotPreimageIsBoundToParsedBytes(t *testing.T) {
 				value = versions[`"b"`]
 			}
 			temp := path + ".manual"
-			if err := os.WriteFile(temp, []byte(value), 0600); err != nil {
-				done <- err
-				return
+			var err error
+			for attempt := 0; attempt < 25; attempt++ {
+				err = os.WriteFile(temp, []byte(value), 0600)
+				if err == nil {
+					err = os.Rename(temp, path)
+				}
+				if err == nil || !windowsSharingRefusal(err) {
+					break
+				}
+				time.Sleep(2 * time.Millisecond)
 			}
-			if err := os.Rename(temp, path); err != nil {
+			if err != nil {
 				done <- err
 				return
 			}
@@ -211,4 +222,16 @@ func TestSetupSnapshotPreimageIsBoundToParsedBytes(t *testing.T) {
 	if s.Preimage != identity([]byte(versions[string(s.Fields["foreign"])]), 0600) {
 		t.Fatal("final preimage mismatch")
 	}
+}
+
+func windowsSharingRefusal(err error) bool {
+	if err == nil || runtime.GOOS != "windows" {
+		return false
+	}
+	var errno syscall.Errno
+	if errors.As(err, &errno) && (errno == 32 || errno == 5) {
+		return true
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "Access is denied") || strings.Contains(msg, "used by another process")
 }

--- a/scripts/config_e2e_test.py
+++ b/scripts/config_e2e_test.py
@@ -66,11 +66,21 @@ class Suite:
         put(self.bundle / '.claude-plugin/plugin.json', json.dumps({'name': 'claude-notifications-go', 'version': TAG[1:]}))
         for name in ('success', 'error', 'question', 'warning', 'complete'):
             put(self.bundle / ('sounds/' + name + '.mp3'), b'fixture audio')
-        self.installer = '''#!/bin/bash
-set -eu
-mkdir -p "$INSTALL_TARGET_DIR"
-cp "$INSTALL_STAGED_ASSETS"/claude-notifications-* "$INSTALL_TARGET_DIR/claude-notifications"
-chmod +x "$INSTALL_TARGET_DIR/claude-notifications"
+        production = (ROOT / 'bin/install.sh').read_text()
+        stripped = production.strip()
+        if not stripped.endswith('main "$@"'):
+            raise AssertionError('production installer entrypoint changed')
+        # Production publication through the kernel, with isolated acquisition
+        # seams: staged/local assets only, no network, no desktop integrations.
+        self.installer = stripped[:-len('main "$@"')] + '''
+download_utilities() { :; }
+configure_windows_native_hooks() { :; }
+create_claude_notifications_app() { :; }
+setup_iterm2_venv() { :; }
+install_linux_notification_desktop_entry() { :; }
+install_gnome_activate_window_extension() { :; }
+check_github_availability() { return 0; }
+main "$@"
 '''
         put(self.bundle / 'bin/install.sh', self.installer, 0o755)
         self.asset = 'claude-notifications-' + platform.system().lower() + '-' + ('arm64' if platform.machine() in ('arm64', 'aarch64') else 'amd64')


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes all 6 P2 findings from [PR 177 review](https://github.com/777genius/agent-notifications/pull/177#pullrequestreview-5189611640) on `d5f13af`. These are test/fixture defects only; production admission, `service.go`, writer protocol floor, and product-identity-as-destination are unchanged.

- **Windows skill cleanup:** last-consumer `--remove` now asserts the owned skill is absent and consumers are empty (Unix shared-retention half unchanged).
- **Prepare permissions:** keep exact POSIX 0600/0640 checks on Unix; on Windows assert writable regular file `0666` (identityMode).
- **Managed-writer E2E fake:** `internal-install-runtime --refresh` publishes both BAT launcher aliases with production `WindowsLauncherScript` bytes; refresh still fails if launchers are missing.
- **Config E2E installer:** replace the copy-only script with production `bin/install.sh` plus isolated seams (staged/local assets, no network, no desktop integrations) so setup-codex commits a protocol-compliant writer.
- **MCP deadline clock:** arm `now.Store(100)` only after `synctest.Wait()` so initialize/initialized and the deadline watcher cannot consume the capture budget.
- **Concurrent snapshot writer:** bounded retry on Windows `ERROR_SHARING_VIOLATION` / Access is denied for the fixture WriteFile+Rename only.

## Test plan

- [x] `go test ./internal/config/ -count=1 -run TestPrepare`
- [x] `go test ./internal/installruntime/ -count=1 -run TestSetupSnapshotPreimageIsBoundToParsedBytes`
- [x] `go test ./internal/agentnotify/mcp/ -count=1 -run TestSDKOriginalDeadlineExpiredBeforeHandler`
- [x] `go test ./cmd/claude-notifications/ -count=1 -run TestEmbeddedSkillLifecycleProjection`
- [x] `test_windows_native_hooks_configured_existing_binary` from `bin/install_e2e_test.sh`
- [x] `scripts/config_e2e_test.py` 16/16 with isolated helper binary
- [ ] CI on the PR against `feat/agent-notify-e2e` (Windows 1.25/1.26, Ubuntu, macOS E2E)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-28027a61-48c1-4874-8d6f-9e7a8feedee7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-28027a61-48c1-4874-8d6f-9e7a8feedee7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

